### PR TITLE
fix: preserve dotfiles in release zip archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-08-03
+
+### Fixed
+
+- Preserved Docker dotfiles in ZIP release archives, including
+  `.dockerignore`, `.env.example`, and `data/.keep`.
+- Added a build-time ZIP payload parity check so archive creation fails if any
+  staged source file is omitted.
+
 ## [0.1.0] - 2026-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ guards first-run behavior, welcomes, and repeat schedule attempts.
 
 ## Release downloads
 
-PlexWeekly `v0.1.0` publishes five installable archives and a checksum manifest.
+PlexWeekly `v0.1.1` publishes five installable archives and a checksum manifest.
 The stable links below follow the latest published release.
 
 | Platform | Published artifact | Download |

--- a/scripts/build-releases.ps1
+++ b/scripts/build-releases.ps1
@@ -6,6 +6,8 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
 if ([string]::IsNullOrWhiteSpace($Root)) { $Root = Split-Path -Parent $PSScriptRoot }
 if ([string]::IsNullOrWhiteSpace($Version)) {
     $Version = if ($env:GITHUB_REF_NAME) { $env:GITHUB_REF_NAME -replace '^v','' } else { 'dev' }
@@ -61,7 +63,47 @@ function Copy-Platform {
 function New-Zip {
     param([string]$FolderName, [string]$ArchiveName)
     $archive = Join-Path $dist $ArchiveName
-    Compress-Archive -LiteralPath (Join-Path $staging $FolderName) -DestinationPath $archive -CompressionLevel Optimal
+    $source = Join-Path $staging $FolderName
+    $expected = @(
+        Get-ChildItem -LiteralPath $source -Force -Recurse -File | ForEach-Object {
+            $relative = $_.FullName.Substring($source.Length).TrimStart('\','/').Replace('\','/')
+            "$FolderName/$relative"
+        }
+    ) | Sort-Object -Unique
+
+    $stream = [IO.File]::Open($archive, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+    $zip = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $true)
+    try {
+        foreach ($file in (Get-ChildItem -LiteralPath $source -Force -Recurse -File)) {
+            $relative = $file.FullName.Substring($source.Length).TrimStart('\','/').Replace('\','/')
+            $entryName = "$FolderName/$relative"
+            [void][IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+                $zip,
+                $file.FullName,
+                $entryName,
+                [IO.Compression.CompressionLevel]::Optimal
+            )
+        }
+    }
+    finally {
+        $zip.Dispose()
+        $stream.Dispose()
+    }
+
+    $zip = [IO.Compression.ZipFile]::OpenRead($archive)
+    try {
+        $actual = @(
+            $zip.Entries | Where-Object { -not [string]::IsNullOrEmpty($_.Name) } |
+                ForEach-Object { $_.FullName.Replace('\','/') }
+        ) | Sort-Object -Unique
+    }
+    finally {
+        $zip.Dispose()
+    }
+    $difference = @(Compare-Object -ReferenceObject $expected -DifferenceObject $actual)
+    if ($difference.Count -gt 0) {
+        throw "ZIP payload differs from release staging for ${ArchiveName}: $($difference.InputObject -join ', ')"
+    }
     return $archive
 }
 


### PR DESCRIPTION
## Summary

- preserve Docker dotfiles in ZIP release archives
- generate portable forward-slash ZIP entry names on every host
- fail release builds when ZIP contents differ from staging
- document the corrected v0.1.1 patch release

## Validation

- repository, privacy, JSON, links, docs, and PowerShell validation
- renderer collection edge tests
- bash syntax validation (ShellCheck delegated to hosted CI)
- local v0.1.1 build and SHA-256 verification
- path traversal and portable separator audit
- NAS and macOS ZIP/TAR hash parity (49 files each)
- sanitized configuration and forbidden-runtime-file audit