### PR TITLE
fix: tolerate missing Tautulli rating metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   movie/TV releases, both anonymous Binge Champion treatments, onboarding and
   warmup variants, and the production quiet-week latest-release fallback.
 
+### Fixed
+
+- Treat Tautulli episode `rating_image` and `rating` fields as optional when
+  building personal statistics, preventing `preview-all` from failing under
+  strict PowerShell property handling when either field is omitted.
+
 ## [0.5.0] - 2026-08-04
 
 ### Added

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -126,6 +126,24 @@ function Safe-Int {
     return 0
 }
 
+function Get-OptionalStringProperty {
+    param(
+        [AllowNull()][object]$InputObject,
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject -or [string]::IsNullOrWhiteSpace($Name)) {
+        return ""
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        return ""
+    }
+
+    return [string]$property.Value
+}
+
 function Safe-Int64 {
     param([AllowNull()][object]$Value)
     if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) { return [int64]0 }
@@ -670,10 +688,11 @@ function New-ReleaseData {
 
                 $episodeTitle = [string]$item.title
                 if (-not [string]::IsNullOrWhiteSpace($episodeTitle)) {
-                    $ratingImage = [string]$item.rating_image
+                    $ratingImage = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $item -Name "rating"
                     $nativeImdbRating = ""
-                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace([string]$item.rating)) {
-                        $nativeImdbRating = [string]$item.rating
+                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $nativeImdbRating = $ratingValue
                     }
 
                     $entry.Episodes.Add([PSCustomObject]@{
@@ -951,11 +970,12 @@ function Get-TvEpisodeSnapshotFromTautulli {
         if ($shownSeen.ContainsKey($dedupeKey)) { continue }
         $shownSeen[$dedupeKey] = $true
 
-        $ratingImage = [string]$episode.rating_image
+        $ratingImage = Get-OptionalStringProperty -InputObject $episode -Name "rating_image"
+        $ratingValue = Get-OptionalStringProperty -InputObject $episode -Name "rating"
         $nativeImdbRating = ""
         if ($ratingImage -match '(?i)^imdb://' -and
-            -not [string]::IsNullOrWhiteSpace([string]$episode.rating)) {
-            $nativeImdbRating = [string]$episode.rating
+            -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+            $nativeImdbRating = $ratingValue
         }
 
         $result.Add([PSCustomObject]@{
@@ -1077,7 +1097,8 @@ function Enrich-TvEpisodeMetadata {
                 $episode.Season = $seasonIndex
             }
 
-            $ratingImage = [string]$meta.rating_image
+            $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+            $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             if (-not [string]::IsNullOrWhiteSpace($ratingImage)) {
                 $episode.RatingImage = $ratingImage
             }
@@ -1087,7 +1108,6 @@ function Enrich-TvEpisodeMetadata {
             # Fast path: Tautulli explicitly identifies IMDb as the selected
             # episode rating provider.
             if ($ratingImage -match '(?i)^imdb://') {
-                $ratingValue = [string]$meta.rating
                 if (-not [string]::IsNullOrWhiteSpace($ratingValue)) {
                     $episode.ImdbRating = $ratingValue
                 }
@@ -1264,9 +1284,11 @@ function Get-UserStats {
                     $episodeSeen[$dedupeKey] = $true
 
                     $nativeImdb = ""
-                    if ([string]$row.rating_image -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace([string]$row.rating)) {
-                        $nativeImdb = [string]$row.rating
+                    $ratingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $row -Name "rating"
+                    if ($ratingImage -match '(?i)^imdb://' -and
+                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $nativeImdb = $ratingValue
                     }
 
                     $episodeItems.Add([PSCustomObject]@{
@@ -1354,9 +1376,11 @@ function Add-UserStatsMediaMetadata {
                         rating_key = [string]$episode.RatingKey
                     }
 
-                    if ([string]$meta.rating_image -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace([string]$meta.rating)) {
-                        $episode.ImdbRating = [string]$meta.rating
+                    $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+                    if ($ratingImage -match '(?i)^imdb://' -and
+                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $episode.ImdbRating = $ratingValue
                     }
                 }
 
@@ -3224,8 +3248,10 @@ function Add-DesignRatingMetadata {
                 rating_key = $ratingKey
             }
 
-            $ratingImage = [string]$meta.rating_image
-            $audienceImage = [string]$meta.audience_rating_image
+            $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+            $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+            $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+            $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
 
             if ([string]$item.Type -eq "movie") {
                 if ($null -ne $meta.PSObject.Properties["genres"]) {
@@ -3237,12 +3263,12 @@ function Add-DesignRatingMetadata {
             }
 
             if ($ratingImage -like 'rottentomatoes://image.rating.*') {
-                $critic = Convert-DesignRatingPercent $meta.rating
+                $critic = Convert-DesignRatingPercent $ratingValue
                 $criticImage = $ratingImage
             }
 
             if ($audienceImage -like 'rottentomatoes://image.rating.*') {
-                $audience = Convert-DesignRatingPercent $meta.audience_rating
+                $audience = Convert-DesignRatingPercent $audienceRatingValue
                 $audienceImageState = $audienceImage
             }
         }

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -126,6 +126,24 @@ function Safe-Int {
     return 0
 }
 
+function Get-OptionalStringProperty {
+    param(
+        [AllowNull()][object]$InputObject,
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject -or [string]::IsNullOrWhiteSpace($Name)) {
+        return ""
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        return ""
+    }
+
+    return [string]$property.Value
+}
+
 function Safe-Int64 {
     param([AllowNull()][object]$Value)
     if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) { return [int64]0 }
@@ -670,10 +688,11 @@ function New-ReleaseData {
 
                 $episodeTitle = [string]$item.title
                 if (-not [string]::IsNullOrWhiteSpace($episodeTitle)) {
-                    $ratingImage = [string]$item.rating_image
+                    $ratingImage = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $item -Name "rating"
                     $nativeImdbRating = ""
-                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace([string]$item.rating)) {
-                        $nativeImdbRating = [string]$item.rating
+                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $nativeImdbRating = $ratingValue
                     }
 
                     $entry.Episodes.Add([PSCustomObject]@{
@@ -951,11 +970,12 @@ function Get-TvEpisodeSnapshotFromTautulli {
         if ($shownSeen.ContainsKey($dedupeKey)) { continue }
         $shownSeen[$dedupeKey] = $true
 
-        $ratingImage = [string]$episode.rating_image
+        $ratingImage = Get-OptionalStringProperty -InputObject $episode -Name "rating_image"
+        $ratingValue = Get-OptionalStringProperty -InputObject $episode -Name "rating"
         $nativeImdbRating = ""
         if ($ratingImage -match '(?i)^imdb://' -and
-            -not [string]::IsNullOrWhiteSpace([string]$episode.rating)) {
-            $nativeImdbRating = [string]$episode.rating
+            -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+            $nativeImdbRating = $ratingValue
         }
 
         $result.Add([PSCustomObject]@{
@@ -1077,7 +1097,8 @@ function Enrich-TvEpisodeMetadata {
                 $episode.Season = $seasonIndex
             }
 
-            $ratingImage = [string]$meta.rating_image
+            $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+            $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             if (-not [string]::IsNullOrWhiteSpace($ratingImage)) {
                 $episode.RatingImage = $ratingImage
             }
@@ -1087,7 +1108,6 @@ function Enrich-TvEpisodeMetadata {
             # Fast path: Tautulli explicitly identifies IMDb as the selected
             # episode rating provider.
             if ($ratingImage -match '(?i)^imdb://') {
-                $ratingValue = [string]$meta.rating
                 if (-not [string]::IsNullOrWhiteSpace($ratingValue)) {
                     $episode.ImdbRating = $ratingValue
                 }
@@ -1264,9 +1284,11 @@ function Get-UserStats {
                     $episodeSeen[$dedupeKey] = $true
 
                     $nativeImdb = ""
-                    if ([string]$row.rating_image -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace([string]$row.rating)) {
-                        $nativeImdb = [string]$row.rating
+                    $ratingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $row -Name "rating"
+                    if ($ratingImage -match '(?i)^imdb://' -and
+                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $nativeImdb = $ratingValue
                     }
 
                     $episodeItems.Add([PSCustomObject]@{
@@ -1354,9 +1376,11 @@ function Add-UserStatsMediaMetadata {
                         rating_key = [string]$episode.RatingKey
                     }
 
-                    if ([string]$meta.rating_image -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace([string]$meta.rating)) {
-                        $episode.ImdbRating = [string]$meta.rating
+                    $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+                    if ($ratingImage -match '(?i)^imdb://' -and
+                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $episode.ImdbRating = $ratingValue
                     }
                 }
 
@@ -3224,8 +3248,10 @@ function Add-DesignRatingMetadata {
                 rating_key = $ratingKey
             }
 
-            $ratingImage = [string]$meta.rating_image
-            $audienceImage = [string]$meta.audience_rating_image
+            $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+            $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+            $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+            $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
 
             if ([string]$item.Type -eq "movie") {
                 if ($null -ne $meta.PSObject.Properties["genres"]) {
@@ -3237,12 +3263,12 @@ function Add-DesignRatingMetadata {
             }
 
             if ($ratingImage -like 'rottentomatoes://image.rating.*') {
-                $critic = Convert-DesignRatingPercent $meta.rating
+                $critic = Convert-DesignRatingPercent $ratingValue
                 $criticImage = $ratingImage
             }
 
             if ($audienceImage -like 'rottentomatoes://image.rating.*') {
-                $audience = Convert-DesignRatingPercent $meta.audience_rating
+                $audience = Convert-DesignRatingPercent $audienceRatingValue
                 $audienceImageState = $audienceImage
             }
         }

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -79,6 +79,24 @@ function Safe-Int {
     return 0
 }
 
+function Get-OptionalStringProperty {
+    param(
+        [AllowNull()][object]$InputObject,
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject -or [string]::IsNullOrWhiteSpace($Name)) {
+        return ""
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        return ""
+    }
+
+    return [string]$property.Value
+}
+
 function Safe-Int64 {
     param([AllowNull()][object]$Value)
     if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) { return [int64]0 }
@@ -623,10 +641,11 @@ function New-ReleaseData {
 
                 $episodeTitle = [string]$item.title
                 if (-not [string]::IsNullOrWhiteSpace($episodeTitle)) {
-                    $ratingImage = [string]$item.rating_image
+                    $ratingImage = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $item -Name "rating"
                     $nativeImdbRating = ""
-                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace([string]$item.rating)) {
-                        $nativeImdbRating = [string]$item.rating
+                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $nativeImdbRating = $ratingValue
                     }
 
                     $entry.Episodes.Add([PSCustomObject]@{
@@ -904,11 +923,12 @@ function Get-TvEpisodeSnapshotFromTautulli {
         if ($shownSeen.ContainsKey($dedupeKey)) { continue }
         $shownSeen[$dedupeKey] = $true
 
-        $ratingImage = [string]$episode.rating_image
+        $ratingImage = Get-OptionalStringProperty -InputObject $episode -Name "rating_image"
+        $ratingValue = Get-OptionalStringProperty -InputObject $episode -Name "rating"
         $nativeImdbRating = ""
         if ($ratingImage -match '(?i)^imdb://' -and
-            -not [string]::IsNullOrWhiteSpace([string]$episode.rating)) {
-            $nativeImdbRating = [string]$episode.rating
+            -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+            $nativeImdbRating = $ratingValue
         }
 
         $result.Add([PSCustomObject]@{
@@ -1030,7 +1050,8 @@ function Enrich-TvEpisodeMetadata {
                 $episode.Season = $seasonIndex
             }
 
-            $ratingImage = [string]$meta.rating_image
+            $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+            $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             if (-not [string]::IsNullOrWhiteSpace($ratingImage)) {
                 $episode.RatingImage = $ratingImage
             }
@@ -1040,7 +1061,6 @@ function Enrich-TvEpisodeMetadata {
             # Fast path: Tautulli explicitly identifies IMDb as the selected
             # episode rating provider.
             if ($ratingImage -match '(?i)^imdb://') {
-                $ratingValue = [string]$meta.rating
                 if (-not [string]::IsNullOrWhiteSpace($ratingValue)) {
                     $episode.ImdbRating = $ratingValue
                 }
@@ -1217,9 +1237,11 @@ function Get-UserStats {
                     $episodeSeen[$dedupeKey] = $true
 
                     $nativeImdb = ""
-                    if ([string]$row.rating_image -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace([string]$row.rating)) {
-                        $nativeImdb = [string]$row.rating
+                    $ratingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $row -Name "rating"
+                    if ($ratingImage -match '(?i)^imdb://' -and
+                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $nativeImdb = $ratingValue
                     }
 
                     $episodeItems.Add([PSCustomObject]@{
@@ -1307,9 +1329,11 @@ function Add-UserStatsMediaMetadata {
                         rating_key = [string]$episode.RatingKey
                     }
 
-                    if ([string]$meta.rating_image -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace([string]$meta.rating)) {
-                        $episode.ImdbRating = [string]$meta.rating
+                    $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+                    $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+                    if ($ratingImage -match '(?i)^imdb://' -and
+                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
+                        $episode.ImdbRating = $ratingValue
                     }
                 }
 
@@ -3239,8 +3263,10 @@ function Add-DesignRatingMetadata {
                 rating_key = $ratingKey
             }
 
-            $ratingImage = [string]$meta.rating_image
-            $audienceImage = [string]$meta.audience_rating_image
+            $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+            $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+            $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+            $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
 
             if ([string]$item.Type -eq "movie") {
                 if ($null -ne $meta.PSObject.Properties["genres"]) {
@@ -3252,12 +3278,12 @@ function Add-DesignRatingMetadata {
             }
 
             if ($ratingImage -like 'rottentomatoes://image.rating.*') {
-                $critic = Convert-DesignRatingPercent $meta.rating
+                $critic = Convert-DesignRatingPercent $ratingValue
                 $criticImage = $ratingImage
             }
 
             if ($audienceImage -like 'rottentomatoes://image.rating.*') {
-                $audience = Convert-DesignRatingPercent $meta.audience_rating
+                $audience = Convert-DesignRatingPercent $audienceRatingValue
                 $audienceImageState = $audienceImage
             }
         }

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -18,7 +18,10 @@ $rendererPaths = @(
 )
 
 $requiredFunctions = @(
+    'Get-OptionalStringProperty',
     'Safe-Int',
+    'Safe-Int64',
+    'New-ReleaseData',
     'Get-HistoryRowPlayCount',
     'Format-WatchTime',
     'Get-UserStats'
@@ -102,6 +105,31 @@ foreach ($relativePath in $rendererPaths) {
     Assert-True ($oneEpisode.EpisodeItems -is [object[]]) "$relativePath collapsed one episode into a scalar"
     Assert-True ($oneEpisode.EpisodeItems.Count -eq 1) "$relativePath lost the one-episode item"
     Assert-True ($oneEpisode.MovieItems.Count -eq 0) "$relativePath created an unexpected movie"
+    Assert-True ($oneEpisode.EpisodeItems[0].ImdbRating -eq '8.5') "$relativePath lost an available episode IMDb rating"
+
+    $episodeWithoutRatingMetadata = [PSCustomObject]@{
+        media_type             = 'episode'
+        play_duration          = 1800
+        watched_status         = 0
+        percent_complete       = 50
+        rating_key             = 'episode-without-rating'
+        grandparent_rating_key = 'show-without-rating'
+        grandparent_title      = 'Show Without Rating'
+        parent_title           = 'Season 1'
+        title                  = 'Unrated Episode'
+        year                   = '2026'
+        added_at               = 1785800000
+        parent_media_index     = 1
+        media_index            = 2
+    }
+    $missingRating = Get-UserStats -History @($episodeWithoutRatingMetadata)
+    Assert-True ($missingRating.EpisodeItems.Count -eq 1) "$relativePath rejected an episode without rating metadata"
+    Assert-True ([string]::IsNullOrWhiteSpace([string]$missingRating.EpisodeItems[0].ImdbRating)) "$relativePath invented an IMDb rating for missing metadata"
+
+    $missingReleaseRating = New-ReleaseData -RecentItems @($episodeWithoutRatingMetadata)
+    Assert-True ($missingReleaseRating.TV.Count -eq 1) "$relativePath rejected a TV release without rating metadata"
+    Assert-True ($missingReleaseRating.TV[0].Episodes.Count -eq 1) "$relativePath lost an unrated TV release episode"
+    Assert-True ([string]::IsNullOrWhiteSpace([string]$missingReleaseRating.TV[0].Episodes[0].ImdbRating)) "$relativePath invented a release IMDb rating for missing metadata"
 
     $empty = Get-UserStats -History @()
     Assert-True ($empty.MovieItems -is [object[]]) "$relativePath lost the empty movie array"


### PR DESCRIPTION
## What

- treats Tautulli `rating_image`, `rating`, and paired audience-rating fields as optional metadata
- applies the guard consistently to Windows, NAS/Docker, and macOS renderers
- preserves valid IMDb ratings while allowing missing values to continue through existing metadata fallbacks
- adds regression coverage for unrated history rows and recent TV-release rows
- records the fix in the changelog

## Root cause

The renderers run under `Set-StrictMode -Version Latest`. Tautulli may omit `rating_image` and `rating` entirely for an episode, but several `preview-all` paths accessed those properties directly. A missing property therefore raised `ParentContainsErrorRecordException` instead of being treated as unavailable metadata.

## Impact

`preview-all` now completes when Tautulli omits rating metadata. The affected TV entry renders without a rating unless the existing Plex/IMDb fallback resolves one; no synthetic or incorrect score is introduced.

## Validation

- `scripts/test-renderer-collections.ps1` on all three renderers, including missing-property regression cases
- `scripts/validate-powershell.ps1`
- `scripts/validate-repository.ps1`
- `scripts/validate-unraid-template.ps1`
- `scripts/validate-platforms.ps1`
- `scripts/check-links.ps1`
- `scripts/validate-docs.ps1`
- `scripts/test-user-exclusions.ps1`
- `scripts/test-binge-champion.ps1`
- reproducible release-archive build with SHA-256 manifest

Fixes #7