### PR TITLE
fix: accept scoped recently added rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Accepted section-scoped Tautulli recently-added rows when Plex omits the
+  redundant library identifier, while continuing to reject explicit library
+  mismatches and unscoped rows.
 - Made inbox preview and body counts describe unique TV titles/shows rather
   than episode rows when multiple series are added or watched.
 

--- a/platforms/freebsd-podman/CHANGELOG.txt
+++ b/platforms/freebsd-podman/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex FreeBSD Podman platform changelog
 
 Unreleased
+- Accepts selected-library recently-added rows when Plex omits the redundant section ID.
 - Limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists.
 - Lists up to four most-watched movies and TV shows, omitting an empty TV card.
 - Inherits the supplied movie/TV stat GIFs through the maintained container payload.

--- a/platforms/linux/CHANGELOG.txt
+++ b/platforms/linux/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex native Linux platform changelog
 
 Unreleased
+- Accepts selected-library recently-added rows when Plex omits the redundant section ID.
 - Limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists.
 - Lists up to four most-watched movies and TV shows, omitting an empty TV card.
 - Inherits the supplied movie/TV stat GIFs through the maintained container payload.

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- accepts selected-library recently-added rows when Plex omits the redundant section ID
 - limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists
 - lists up to four most-watched movies and TV shows, omitting an empty TV card
 - replaces the packaged movie/TV stat GIFs while retaining CID asset behavior

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -436,9 +436,24 @@ function Test-IncludedLibraryRow {
     )
 
     if (-not $script:LibraryFilterEnabled) { return $true }
+
     $sectionId = (Get-OptionalStringProperty -InputObject $Row -Name "section_id").Trim()
-    if ([string]::IsNullOrWhiteSpace($sectionId) -or -not $script:IncludedLibraryIdSet.Contains($sectionId)) { return $false }
-    return ([string]::IsNullOrWhiteSpace($ExpectedSectionId) -or $sectionId -eq $ExpectedSectionId)
+    $expectedSectionId = ([string]$ExpectedSectionId).Trim()
+
+    if (-not [string]::IsNullOrWhiteSpace($expectedSectionId)) {
+        if (-not $script:IncludedLibraryIdSet.Contains($expectedSectionId)) { return $false }
+
+        # Tautulli uses Plex's library-specific recentlyAdded endpoint when a
+        # section_id is supplied. Plex can omit the redundant librarySectionID
+        # attribute from those already-scoped rows. Trust the selected query
+        # scope only when the row omits the field; explicit mismatches still
+        # fail closed.
+        if ([string]::IsNullOrWhiteSpace($sectionId)) { return $true }
+        return ($sectionId -eq $expectedSectionId)
+    }
+
+    if ([string]::IsNullOrWhiteSpace($sectionId)) { return $false }
+    return $script:IncludedLibraryIdSet.Contains($sectionId)
 }
 
 function Get-IncludedLibraryQueryScopes {

--- a/platforms/nas-docker/CHANGELOG.txt
+++ b/platforms/nas-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX NAS PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- accepts selected-library recently-added rows when Plex omits the redundant section ID
 - limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists
 - lists up to four most-watched movies and TV shows, omitting an empty TV card
 - replaces the packaged movie/TV stat GIFs while retaining CID asset behavior

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -436,11 +436,24 @@ function Test-IncludedLibraryRow {
     )
 
     if (-not $script:LibraryFilterEnabled) { return $true }
+
     $sectionId = (Get-OptionalStringProperty -InputObject $Row -Name "section_id").Trim()
-    if ([string]::IsNullOrWhiteSpace($sectionId) -or -not $script:IncludedLibraryIdSet.Contains($sectionId)) {
-        return $false
+    $expectedSectionId = ([string]$ExpectedSectionId).Trim()
+
+    if (-not [string]::IsNullOrWhiteSpace($expectedSectionId)) {
+        if (-not $script:IncludedLibraryIdSet.Contains($expectedSectionId)) { return $false }
+
+        # Tautulli uses Plex's library-specific recentlyAdded endpoint when a
+        # section_id is supplied. Plex can omit the redundant librarySectionID
+        # attribute from those already-scoped rows. Trust the selected query
+        # scope only when the row omits the field; explicit mismatches still
+        # fail closed.
+        if ([string]::IsNullOrWhiteSpace($sectionId)) { return $true }
+        return ($sectionId -eq $expectedSectionId)
     }
-    return ([string]::IsNullOrWhiteSpace($ExpectedSectionId) -or $sectionId -eq $ExpectedSectionId)
+
+    if ([string]::IsNullOrWhiteSpace($sectionId)) { return $false }
+    return $script:IncludedLibraryIdSet.Contains($sectionId)
 }
 
 function Get-IncludedLibraryQueryScopes {

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- accepts selected-library recently-added rows when Plex omits the redundant section ID
 - limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists
 - lists up to four most-watched movies and TV shows, omitting an empty TV card
 - replaces the packaged movie/TV stat GIFs while retaining CID asset behavior

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -369,14 +369,24 @@ function Test-IncludedLibraryRow {
     )
 
     if (-not $script:LibraryFilterEnabled) { return $true }
+
     $sectionId = (Get-OptionalStringProperty -InputObject $Row -Name "section_id").Trim()
-    if ([string]::IsNullOrWhiteSpace($sectionId) -or -not $script:IncludedLibraryIdSet.Contains($sectionId)) {
-        return $false
+    $expectedSectionId = ([string]$ExpectedSectionId).Trim()
+
+    if (-not [string]::IsNullOrWhiteSpace($expectedSectionId)) {
+        if (-not $script:IncludedLibraryIdSet.Contains($expectedSectionId)) { return $false }
+
+        # Tautulli uses Plex's library-specific recentlyAdded endpoint when a
+        # section_id is supplied. Plex can omit the redundant librarySectionID
+        # attribute from those already-scoped rows. Trust the selected query
+        # scope only when the row omits the field; explicit mismatches still
+        # fail closed.
+        if ([string]::IsNullOrWhiteSpace($sectionId)) { return $true }
+        return ($sectionId -eq $expectedSectionId)
     }
-    return (
-        [string]::IsNullOrWhiteSpace($ExpectedSectionId) -or
-        $sectionId -eq $ExpectedSectionId
-    )
+
+    if ([string]::IsNullOrWhiteSpace($sectionId)) { return $false }
+    return $script:IncludedLibraryIdSet.Contains($sectionId)
 }
 
 function Get-IncludedLibraryQueryScopes {

--- a/scripts/test-library-selection.ps1
+++ b/scripts/test-library-selection.ps1
@@ -122,6 +122,18 @@ foreach ($relative in @(
         -Actual (Test-IncludedLibraryRow -Row ([PSCustomObject]@{ section_id = '99' })) -Expected $false
     Assert-Equal -Name "$relative excludes an unscoped row at runtime" `
         -Actual (Test-IncludedLibraryRow -Row ([PSCustomObject]@{ title = 'No section metadata' })) -Expected $false
+    Assert-Equal -Name "$relative trusts missing row metadata from a selected scoped query" `
+        -Actual (Test-IncludedLibraryRow `
+            -Row ([PSCustomObject]@{ title = 'Scoped without section metadata' }) `
+            -ExpectedSectionId '10') -Expected $true
+    Assert-Equal -Name "$relative rejects an explicit mismatch from a selected scoped query" `
+        -Actual (Test-IncludedLibraryRow `
+            -Row ([PSCustomObject]@{ section_id = '20' }) `
+            -ExpectedSectionId '10') -Expected $false
+    Assert-Equal -Name "$relative rejects a missing row section for an unselected scoped query" `
+        -Actual (Test-IncludedLibraryRow `
+            -Row ([PSCustomObject]@{ title = 'Unselected scope' }) `
+            -ExpectedSectionId '99') -Expected $false
 
     $nowEpoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
     $selectedMovie = [PSCustomObject]@{
@@ -171,7 +183,7 @@ foreach ($relative in @(
                 $firstPage = New-Object System.Collections.Generic.List[object]
                 for ($index = 1; $index -le 99; $index++) {
                     $firstPage.Add([PSCustomObject]@{
-                        section_id = '20'; media_type = 'episode'; rating_key = "selected-episode-$index"
+                        media_type = 'episode'; rating_key = "selected-episode-$index"
                         grandparent_rating_key = 'selected-show'; grandparent_title = 'Selected Show'
                         title = "Selected Episode $index"; year = '2026'; added_at = $nowEpoch - $index
                         parent_media_index = 1; media_index = $index; play_duration = 1800
@@ -184,7 +196,7 @@ foreach ($relative in @(
                 $secondPage = @()
                 foreach ($showNumber in 2..4) {
                     $secondPage += [PSCustomObject]@{
-                        section_id = '20'; media_type = 'episode'; rating_key = "selected-show-$showNumber-episode"
+                        media_type = 'episode'; rating_key = "selected-show-$showNumber-episode"
                         grandparent_rating_key = "selected-show-$showNumber"; grandparent_title = "Selected Show $showNumber"
                         title = 'Premiere'; year = '2026'; added_at = $nowEpoch - (100 + $showNumber)
                         parent_media_index = 1; media_index = 1; play_duration = 1800
@@ -203,13 +215,29 @@ foreach ($relative in @(
         }
 
         $selected = if ($scope -eq '10') { $selectedMovie } else { $selectedEpisode }
+        $selectedRecent = if ($scope -eq '10') {
+            [PSCustomObject]@{
+                media_type = 'movie'; rating_key = 'selected-movie'
+                title = 'Selected Movie'; year = '2026'; added_at = $nowEpoch
+                audience_rating = '91'; rating = '8.2'; summary = 'A selected-library release.'
+            }
+        } else {
+            [PSCustomObject]@{
+                media_type = 'episode'; rating_key = 'selected-episode'
+                grandparent_rating_key = 'selected-show'; grandparent_title = 'Selected Show'
+                title = 'Selected Episode'; year = '2026'; added_at = $nowEpoch
+                parent_media_index = 1; media_index = 1
+            }
+        }
         # Include a leaked private row to prove the client still fails closed
         # if a Tautulli version ignores or mishandles section_id.
         if ($Command -eq 'get_history') {
             return [PSCustomObject]@{ data = @($selected, $privateMovie); recordsFiltered = 2 }
         }
         if ($Command -eq 'get_recently_added') {
-            return [PSCustomObject]@{ recently_added = @($selected, $privateMovie) }
+            # Tautulli's section-scoped recentlyAdded response can omit the
+            # redundant librarySectionID/section_id field on valid rows.
+            return [PSCustomObject]@{ recently_added = @($selectedRecent, $privateMovie) }
         }
         throw "Unexpected simulated command: $Command"
     }

--- a/scripts/test-release-artifacts.ps1
+++ b/scripts/test-release-artifacts.ps1
@@ -162,6 +162,8 @@ foreach ($archiveName in $expected.Keys) {
         finally { $reader.Dispose() }
         Assert-True ($renderer.Contains('Get-OptionalStringProperty -InputObject $Row -Name "section_id"')) "$archiveName lacks the executable library predicate fix."
         Assert-True ($renderer.Contains('$params.section_id = $sectionId')) "$archiveName lacks server-side selected-library scoping."
+        Assert-True ($renderer.Contains('$expectedSectionId = ([string]$ExpectedSectionId).Trim()')) "$archiveName lacks scoped recently-added row handling."
+        Assert-True ($renderer.Contains('if ([string]::IsNullOrWhiteSpace($sectionId)) { return $true }')) "$archiveName rejects selected-library rows that omit redundant section metadata."
         Assert-True ($renderer.Contains('Smtp-Transport.ps1')) "$archiveName does not load the explicit SMTP authentication transport."
         Assert-True ($renderer.Contains('Send-TautWeeklySmtpMessage')) "$archiveName does not route mail through the explicit SMTP transport."
         Assert-True ($renderer.Contains('function Get-StatsTvShowRowsHtml')) "$archiveName lacks grouped TV-show personal statistics."


### PR DESCRIPTION
## Summary

- accept Tautulli recently-added rows that omit redundant section metadata when the request was already scoped to a configured library
- continue rejecting explicit library mismatches, unselected scopes, and unscoped rows without section metadata
- add cross-platform regressions for normal-window and Latest Releases pagination paths
- verify the behavior is present in every release archive

## Root cause

TautWeekly queries `get_recently_added` once per selected `section_id`. Tautulli forwards that request to Plex's library-specific `recentlyAdded` endpoint, where Plex can omit the redundant `librarySectionID` attribute. TautWeekly treated the resulting blank response-level `section_id` as untrusted and discarded every otherwise-valid item.

## Validation

- repository, platform, documentation, link, PowerShell parsing, renderer, exclusions, Binge Champion, and update-check suites
- library-selection regressions on Windows, NAS/Linux/FreeBSD, and macOS renderers
- Windows active, quiet, and TV-only newsletter integration scenarios
- all Windows/NAS/macOS/Linux/FreeBSD release artifacts, manifests, and SHA-256 checks

Addresses #31
