### PR TITLE
docs: credit community contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,23 @@ Explain what changed, why it is safe, which platforms are affected, and which
 checks were run. Include sanitized screenshots for documentation or rendering
 changes. Small, reviewable pull requests are preferred.
 
+## Contributor attribution
+
+After a community contribution ships, update the [contributors ledger](CONTRIBUTORS.md)
+using the existing evidence hierarchy:
+
+- `🐛 bug` credits the human reporter when their report leads to an implemented
+  correction.
+- `💡 enhancement` credits the human proposer when their feature request is
+  implemented.
+- Link the public issue, merged pull request, and first release containing the
+  change so the attribution can be independently verified.
+
+Use public GitHub handles only. Do not credit duplicates that produced no
+distinct correction, invalid or unshipped reports, maintainer housekeeping, or
+the implementer in place of the original reporter or proposer. Attribution is
+not commit co-authorship; use `Co-authored-by` only for actual commit authors.
+
 By contributing, you agree that your original contribution is licensed under
 the repository's MIT license. Do not submit assets or code that you do not have
 permission to redistribute.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,20 @@
+# Contributors
+
+TautWeekly for Plex follows the [All Contributors](https://allcontributors.org/en/reference/)
+principle by recognizing community work beyond code. This compact table is
+maintained by hand so every entry can link directly from the public report or
+proposal to the shipped repository change. TautWeekly uses `🐛 bug` for a bug
+report that led to a correction and `💡 enhancement` for an implemented feature
+proposal.
+
+| Contributor | Contribution | Evidence | Shipped correction |
+|---|---|---|---|
+| [@Demonmeister](https://github.com/Demonmeister) | 💡 `enhancement` | [#6: privacy-focused Binge Champion proposal](https://github.com/sparkmoxie/TautWeekly/issues/6) | [PR #5](https://github.com/sparkmoxie/TautWeekly/pull/5) · [v0.4.0](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.4.0) |
+| [@Demonmeister](https://github.com/Demonmeister) | 🐛 `bug` | [#7: missing Tautulli rating metadata](https://github.com/sparkmoxie/TautWeekly/issues/7) | [PR #10](https://github.com/sparkmoxie/TautWeekly/pull/10) · [v0.5.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.1) |
+| [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#11: container onboarding and preview reliability](https://github.com/sparkmoxie/TautWeekly/issues/11) | [PR #14](https://github.com/sparkmoxie/TautWeekly/pull/14) · [v0.5.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.1) |
+| [@Joloxx9](https://github.com/Joloxx9) | 🐛 `bug` | [#15: Tautulli user-roster compatibility](https://github.com/sparkmoxie/TautWeekly/issues/15) | [PR #16](https://github.com/sparkmoxie/TautWeekly/pull/16) · [v0.5.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.2) |
+| [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#31: selected-library recently-added filtering](https://github.com/sparkmoxie/TautWeekly/issues/31) | [PR #33](https://github.com/sparkmoxie/TautWeekly/pull/33) · [v0.6.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.1) |
+
+Only public GitHub handles and links are recorded. Bug credit requires an
+evidence-backed correction in the repository; enhancement credit requires an
+implemented proposal. Attribution does not imply commit co-authorship.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ them locally; send controlled tests; then schedule production delivery.
 [Email States Preview](https://sparkmoxie.github.io/TautWeekly/examples/preview-all-00-INDEX.html) ·
 [Release downloads](#release-downloads) ·
 [Security](SECURITY.md) ·
-[Contributing](CONTRIBUTING.md)
+[Contributing](CONTRIBUTING.md) ·
+[Contributors](CONTRIBUTORS.md)
 
 </div>
 

--- a/scripts/validate-repository.ps1
+++ b/scripts/validate-repository.ps1
@@ -21,7 +21,7 @@ function Add-Pass {
 }
 
 $required = @(
-    'README.md', 'LICENSE', 'SECURITY.md', 'CONTRIBUTING.md', 'CHANGELOG.md',
+    'README.md', 'LICENSE', 'SECURITY.md', 'CONTRIBUTING.md', 'CONTRIBUTORS.md', 'CHANGELOG.md',
     'CODE_OF_CONDUCT.md', 'THIRD_PARTY_NOTICES.md', '.gitignore', '.gitattributes',
     'ca_profile.xml', 'templates/tautweekly.xml',
     'platforms/windows/TautWeekly.ps1',
@@ -74,6 +74,38 @@ foreach ($relative in $required) {
     }
 }
 if ($failures.Count -eq 0) { Add-Pass "Required repository structure is present." }
+
+$readme = [IO.File]::ReadAllText((Join-Path $Root 'README.md'))
+$contributing = [IO.File]::ReadAllText((Join-Path $Root 'CONTRIBUTING.md'))
+$contributors = [IO.File]::ReadAllText((Join-Path $Root 'CONTRIBUTORS.md'))
+if (-not $readme.Contains('[Contributors](CONTRIBUTORS.md)')) {
+    Add-Failure 'README.md is missing its prominent contributor-attribution link.'
+}
+if (-not $contributing.Contains('[contributors ledger](CONTRIBUTORS.md)')) {
+    Add-Failure 'CONTRIBUTING.md is missing the contributor-attribution hierarchy.'
+}
+$contributorContract = @(
+    '[All Contributors](https://allcontributors.org/en/reference/)',
+    '| Contributor | Contribution | Evidence | Shipped correction |',
+    '`bug`',
+    '`enhancement`',
+    'https://github.com/Demonmeister',
+    'https://github.com/gianfelicevincenzo',
+    'https://github.com/Joloxx9',
+    'https://github.com/sparkmoxie/TautWeekly/issues/6',
+    'https://github.com/sparkmoxie/TautWeekly/issues/7',
+    'https://github.com/sparkmoxie/TautWeekly/issues/11',
+    'https://github.com/sparkmoxie/TautWeekly/issues/15',
+    'https://github.com/sparkmoxie/TautWeekly/issues/31'
+)
+foreach ($expected in $contributorContract) {
+    if (-not $contributors.Contains($expected)) {
+        Add-Failure "Contributor attribution is missing required structure or evidence: $expected"
+    }
+}
+if (-not ($failures | Where-Object { $_ -like '*contributor*' -or $_ -like '*Contributor*' })) {
+    Add-Pass 'Contributor attribution structure and evidence links are present.'
+}
 
 $forbiddenNames = @(
     'config.json', '.env', 'state.json', 'access-state.json',


### PR DESCRIPTION
## Summary

- add a permanent, evidence-linked `CONTRIBUTORS.md` ledger
- credit shipped community bug reports as `🐛 bug` and the implemented Binge Champion proposal as `💡 enhancement`
- link every credited issue to its merged pull request and first containing release
- add a prominent README entry point and document the same hierarchy for future contributions
- validate the contributor file, README/CONTRIBUTING links, public handles, and credited issue links without adding a bot, plugin, avatar table, or `.all-contributorsrc`

## Credited evidence

| Contributor | Type | Issue | Shipped in |
|---|---|---|---|
| @Demonmeister | 💡 enhancement | #6 | #5 / v0.4.0 |
| @Demonmeister | 🐛 bug | #7 | #10 / v0.5.1 |
| @gianfelicevincenzo | 🐛 bug | #11 | #14 / v0.5.1 |
| @Joloxx9 | 🐛 bug | #15 | #16 / v0.5.2 |
| @gianfelicevincenzo | 🐛 bug | #31 | #33 / v0.6.1 |

Issue #11 was reopened for later documentation/UI follow-ups, but its original container-onboarding and preview-reliability report has a distinct shipped correction in #14. Issue #31 was initially closed, then reopened and fixed in #33; the final outcome controls.

## Excluded closed issues

- #12: duplicate missing-rating report opened after #10 had already merged; #14 delivered that existing fix to the stable channel but did not add a distinct correction for this report
- #13: feature request closed as not planned; no shipped implementation
- #17: implemented library-selection work, but the issue was opened by the maintainer and is excluded as maintainer housekeeping
- #24: feature request closed as not planned; no shipped implementation

No attribution candidate remains ambiguous.

## Impact

Community reporters and proposers receive permanent public credit without rewriting commit history or implying commit co-authorship. Future shipped reports and enhancements follow the same issue → merged PR → first release evidence hierarchy.

## Validation

- `validate-repository.ps1`: repository structure, contributor contract, privacy, secret patterns, sanitized examples
- `validate-docs.ps1`: all canonical rendered documentation features and redirects
- `check-links.ps1`: 29 Markdown/HTML files
- `git diff --check`
