### PR TITLE
fix: honor PUID for container exec modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Made root-started Docker and Podman console newsletter commands drop to the
+  configured PUID/PGID before writing locks, logs, posters, or diagnostics.
+
 ## [0.6.2] - 2026-08-09
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ proposal.
 | [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#11: container onboarding and preview reliability](https://github.com/sparkmoxie/TautWeekly/issues/11) | [PR #14](https://github.com/sparkmoxie/TautWeekly/pull/14) · [v0.5.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.1) |
 | [@Joloxx9](https://github.com/Joloxx9) | 🐛 `bug` | [#15: Tautulli user-roster compatibility](https://github.com/sparkmoxie/TautWeekly/issues/15) | [PR #16](https://github.com/sparkmoxie/TautWeekly/pull/16) · [v0.5.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.2) |
 | [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#31: selected-library and sparse-metadata renderer fixes](https://github.com/sparkmoxie/TautWeekly/issues/31) | [PR #33](https://github.com/sparkmoxie/TautWeekly/pull/33) · [v0.6.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.1)<br>[PR #36](https://github.com/sparkmoxie/TautWeekly/pull/36) · [v0.6.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.2) |
+| [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#38: container exec PUID/PGID ownership](https://github.com/sparkmoxie/TautWeekly/issues/38) | [PR #39](https://github.com/sparkmoxie/TautWeekly/pull/39) |
 
 Only public GitHub handles and links are recorded. Bug credit requires an
 evidence-backed correction in the repository; enhancement credit requires an

--- a/platforms/freebsd-podman/CHANGELOG.txt
+++ b/platforms/freebsd-podman/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex FreeBSD Podman platform changelog
 
 Unreleased
+- Honors PUID/PGID for newsletter commands started from a root Podman exec session.
 - Treats sparse Tautulli hero metadata as optional during previews and test sends.
 - Accepts selected-library recently-added rows when Plex omits the redundant section ID.
 - Limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists.

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- honors PUID/PGID for newsletter commands started from a root container Console or exec session
 - treats sparse Tautulli hero metadata as optional during previews and test sends
 - accepts selected-library recently-added rows when Plex omits the redundant section ID
 - limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists

--- a/platforms/mac-docker/app/bin/run-mode.sh
+++ b/platforms/mac-docker/app/bin/run-mode.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Docker and Podman exec sessions start as the image's default root user and
+# bypass entrypoint.sh. Drop privileges before creating any persistent files so
+# interactive Preview/Send commands honor the configured PUID/PGID too.
+if [[ "$(id -u)" -eq 0 ]]; then
+  runtime_uid="${PUID:-1000}"
+  runtime_gid="${PGID:-1000}"
+  if ! [[ "$runtime_uid" =~ ^[0-9]+$ && "$runtime_gid" =~ ^[0-9]+$ ]]; then
+    echo "PUID and PGID must be numeric." >&2
+    exit 64
+  fi
+  if [[ "$runtime_uid" == "0" || "$runtime_gid" == "0" ]]; then
+    echo "PUID/PGID 0 is refused. Configure a non-root numeric identity, normally 1000:1000." >&2
+    exit 64
+  fi
+  exec gosu "$runtime_uid:$runtime_gid" "$0" "$@"
+fi
+
 MODE="${1:-}"
 shift || true
 app_root="${TAUTWEEKLY_APP_DIR:-/opt/tautweekly}"

--- a/platforms/nas-docker/CHANGELOG.txt
+++ b/platforms/nas-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX NAS PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- honors PUID/PGID for newsletter commands started from a root container Console or exec session
 - treats sparse Tautulli hero metadata as optional during previews and test sends
 - accepts selected-library recently-added rows when Plex omits the redundant section ID
 - limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists

--- a/platforms/nas-docker/app/bin/run-mode.sh
+++ b/platforms/nas-docker/app/bin/run-mode.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Docker and Podman exec sessions start as the image's default root user and
+# bypass entrypoint.sh. Drop privileges before creating any persistent files so
+# interactive Preview/Send commands honor the configured PUID/PGID too.
+if [[ "$(id -u)" -eq 0 ]]; then
+  runtime_uid="${PUID:-1000}"
+  runtime_gid="${PGID:-1000}"
+  if ! [[ "$runtime_uid" =~ ^[0-9]+$ && "$runtime_gid" =~ ^[0-9]+$ ]]; then
+    echo "PUID and PGID must be numeric." >&2
+    exit 64
+  fi
+  if [[ "$runtime_uid" == "0" || "$runtime_gid" == "0" ]]; then
+    echo "PUID/PGID 0 is refused. Configure a non-root numeric identity, normally 1000:1000." >&2
+    exit 64
+  fi
+  exec gosu "$runtime_uid:$runtime_gid" "$0" "$@"
+fi
+
 MODE="${1:-}"
 shift || true
 app_root="${TAUTWEEKLY_APP_DIR:-/opt/tautweekly}"

--- a/scripts/test-container-image.sh
+++ b/scripts/test-container-image.sh
@@ -61,6 +61,20 @@ docker exec "$container_name" test -s /data/config.example.json || fail 'Persist
 docker exec "$container_name" test -s /data/output/index.html || fail 'Preview landing page was not initialized.'
 docker exec "$container_name" test -s /data/service-heartbeat.json || fail 'Service supervisor heartbeat was not initialized.'
 
+# A normal docker exec bypasses entrypoint.sh and therefore begins as root.
+# run-mode.sh must still drop to PUID/PGID before it creates any data.
+[[ "$(docker exec "$container_name" id -u)" == "0" ]] || fail 'Ownership regression precondition did not start docker exec as root.'
+ownership_probe='/data/exec-ownership-probe'
+docker exec "$container_name" rm -rf "$ownership_probe"
+docker exec \
+  -e "TAUTWEEKLY_DATA_DIR=$ownership_probe" \
+  -e "TAUTWEEKLY_CONFIG=$ownership_probe/missing-config.json" \
+  "$container_name" /opt/tautweekly/bin/run-mode.sh InvalidOwnershipProbe \
+  >/dev/null 2>&1 || true
+docker exec "$container_name" test -f "$ownership_probe/.tautweekly-operation.lock" || fail 'Root-started run-mode did not create the ownership probe lock.'
+[[ "$(docker exec "$container_name" stat -c '%u:%g' "$ownership_probe")" == "$host_uid:$host_gid" ]] || fail 'Root-started run-mode created its data directory with the wrong owner.'
+[[ "$(docker exec "$container_name" stat -c '%u:%g' "$ownership_probe/.tautweekly-operation.lock")" == "$host_uid:$host_gid" ]] || fail 'Root-started run-mode created its operation lock with the wrong owner.'
+
 set +e
 root_output="$(docker run --rm -e PUID=0 -e PGID="$host_gid" "$image" 2>&1)"
 root_status=$?

--- a/scripts/test-platform-command-routing.sh
+++ b/scripts/test-platform-command-routing.sh
@@ -137,9 +137,40 @@ if command -v flock >/dev/null 2>&1; then
       bash "$repo_root/platforms/nas-docker/app/bin/run-mode.sh" Preview one two >/dev/null 2>&1; then
     fail 'run-mode accepted two user identifiers'
   fi
+
 else
   printf '[WARN] Shared operation-lock routing skipped because flock is unavailable.\n'
 fi
+
+# Container exec starts as root and bypasses entrypoint.sh. Simulate that
+# boundary and require run-mode to re-exec under the configured PUID/PGID
+# before creating its operation lock or output directories.
+root_stub_bin="$test_root/root-bin"
+root_data="$test_root/root-data"
+mkdir -p "$root_stub_bin" "$root_data"
+cat >"$root_stub_bin/id" <<'STUB'
+#!/usr/bin/env bash
+[[ "${1:-}" == '-u' ]] || exit 64
+printf '0\n'
+STUB
+cat >"$root_stub_bin/gosu" <<'STUB'
+#!/usr/bin/env bash
+printf 'gosu %s\n' "$*" >>"$TAUTWEEKLY_TEST_CALL_LOG"
+STUB
+chmod +x "$root_stub_bin/id" "$root_stub_bin/gosu"
+reset_calls
+for runtime_wrapper in \
+    "$repo_root/platforms/nas-docker/app/bin/run-mode.sh" \
+    "$repo_root/platforms/mac-docker/app/bin/run-mode.sh"; do
+  PUID=1234 PGID=5678 \
+  PATH="$root_stub_bin:$PATH" \
+  TAUTWEEKLY_APP_DIR=/virtual/app \
+  TAUTWEEKLY_DATA_DIR="$root_data" \
+  TAUTWEEKLY_CONFIG="$root_data/config.json" \
+    bash "$runtime_wrapper" Preview 'Viewer With Spaces'
+  assert_call "gosu 1234:5678 $runtime_wrapper Preview Viewer With Spaces"
+done
+[[ ! -e "$root_data/.tautweekly-operation.lock" ]] || fail 'run-mode wrote persistent data before dropping root privileges'
 
 # Installer preflight must fail before any system mutation for invalid targets.
 set +e

--- a/scripts/validate-repository.ps1
+++ b/scripts/validate-repository.ps1
@@ -100,7 +100,9 @@ $contributorContract = @(
     'https://github.com/sparkmoxie/TautWeekly/issues/15',
     'https://github.com/sparkmoxie/TautWeekly/issues/31',
     'https://github.com/sparkmoxie/TautWeekly/pull/36',
-    'https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.2'
+    'https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.2',
+    'https://github.com/sparkmoxie/TautWeekly/issues/38',
+    'https://github.com/sparkmoxie/TautWeekly/pull/39'
 )
 foreach ($expected in $contributorContract) {
     if (-not $contributors.Contains($expected)) {


### PR DESCRIPTION
## Summary

- make root-started Docker and Podman newsletter commands drop to the configured PUID/PGID before creating locks, logs, posters, or diagnostics
- keep the NAS and macOS maintained runtime wrappers identical
- add simulated-root coverage for both wrappers and a real container-image ownership regression
- document the correction in the repository and affected platform changelogs

## Root cause

Docker and Podman exec sessions use the image's default root identity and bypass the entrypoint's `gosu` transition. `run-mode.sh` previously created persistent paths immediately, so PreviewAll and SendTest launched from a container console could write root-owned files even while the long-running scheduler correctly ran as PUID/PGID.

## Validation

- `scripts/test-platform-command-routing.sh`
- `scripts/validate-repository.ps1`
- `scripts/validate-platforms.ps1`
- `scripts/validate-unraid-template.ps1`
- `scripts/validate-powershell.ps1`
- release archive build and package/checksum contract tests
- hosted ShellCheck, Compose, and real Docker image ownership checks pending

Fixes #38
