### PR TITLE
chore: prepare v0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-08-09
+
 ### Fixed
 
 - Made root-started Docker and Podman console newsletter commands drop to the

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,7 +14,7 @@ proposal.
 | [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#11: container onboarding and preview reliability](https://github.com/sparkmoxie/TautWeekly/issues/11) | [PR #14](https://github.com/sparkmoxie/TautWeekly/pull/14) · [v0.5.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.1) |
 | [@Joloxx9](https://github.com/Joloxx9) | 🐛 `bug` | [#15: Tautulli user-roster compatibility](https://github.com/sparkmoxie/TautWeekly/issues/15) | [PR #16](https://github.com/sparkmoxie/TautWeekly/pull/16) · [v0.5.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.2) |
 | [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#31: selected-library and sparse-metadata renderer fixes](https://github.com/sparkmoxie/TautWeekly/issues/31) | [PR #33](https://github.com/sparkmoxie/TautWeekly/pull/33) · [v0.6.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.1)<br>[PR #36](https://github.com/sparkmoxie/TautWeekly/pull/36) · [v0.6.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.2) |
-| [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#38: container exec PUID/PGID ownership](https://github.com/sparkmoxie/TautWeekly/issues/38) | [PR #39](https://github.com/sparkmoxie/TautWeekly/pull/39) |
+| [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#38: container exec PUID/PGID ownership](https://github.com/sparkmoxie/TautWeekly/issues/38) | [PR #39](https://github.com/sparkmoxie/TautWeekly/pull/39) · [v0.6.3](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.3) |
 
 Only public GitHub handles and links are recorded. Bug credit requires an
 evidence-backed correction in the repository; enhancement credit requires an

--- a/scripts/validate-repository.ps1
+++ b/scripts/validate-repository.ps1
@@ -102,7 +102,8 @@ $contributorContract = @(
     'https://github.com/sparkmoxie/TautWeekly/pull/36',
     'https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.2',
     'https://github.com/sparkmoxie/TautWeekly/issues/38',
-    'https://github.com/sparkmoxie/TautWeekly/pull/39'
+    'https://github.com/sparkmoxie/TautWeekly/pull/39',
+    'https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.3'
 )
 foreach ($expected in $contributorContract) {
     if (-not $contributors.Contains($expected)) {


### PR DESCRIPTION
## Summary

- date the issue #38 container ownership fix as v0.6.3 in the repository changelog
- link the reporter's existing attribution to the v0.6.3 stable release
- require the v0.6.3 release link in repository attribution validation

## Release scope

v0.6.3 is a patch release of the PUID/PGID correction merged in [PR #39](https://github.com/sparkmoxie/TautWeekly/pull/39). Root-started Docker and Podman newsletter commands now drop to the configured runtime identity before writing persistent files.

## Validation

- repository, attribution, privacy, and JSON validation
- platform parity and Unraid template validation
- documentation and relative-link validation
- PowerShell syntax validation
- local v0.6.3 build of nine archives plus `SHA256SUMS.txt`
- packaged runtime contracts and SHA-256 checksums

After this PR passes CI and merges, the exact merge commit will receive a new annotated `v0.6.3` tag. Existing tags will not be moved.
