### PR TITLE
fix: recover deleted Plex history metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Recovered posters, summaries, genres, years, and available Rotten Tomatoes
-  ratings for deleted Plex items by resolving the exact metadata GUID retained
-  in Tautulli history, and rejected Tautulli's generic poster placeholder as
-  usable artwork. Reported by [@gianfelicevincenzo](https://github.com/gianfelicevincenzo)
+- Recovered posters, summaries, genres, years, movie Rotten Tomatoes ratings,
+  and TV IMDb ratings for deleted Plex items by resolving the exact metadata
+  GUID retained in Tautulli history, and rejected Tautulli's generic poster
+  placeholder as usable artwork. Reported by
+  [@gianfelicevincenzo](https://github.com/gianfelicevincenzo)
   in [#41](https://github.com/sparkmoxie/TautWeekly/issues/41).
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Recovered posters, summaries, genres, years, and available Rotten Tomatoes
+  ratings for deleted Plex items by resolving the exact metadata GUID retained
+  in Tautulli history, and rejected Tautulli's generic poster placeholder as
+  usable artwork. Reported by [@gianfelicevincenzo](https://github.com/gianfelicevincenzo)
+  in [#41](https://github.com/sparkmoxie/TautWeekly/issues/41).
+
+### Security
+
+- Limited deleted-item recovery to Plex's hosted metadata service using the
+  existing administrator Plex token and exact retained GUID. No title search,
+  recipient identity, or watch-history payload is sent, and the token is not
+  forwarded to external artwork hosts returned by Plex.
+
 ## [0.6.3] - 2026-08-09
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ proposal.
 | [@Joloxx9](https://github.com/Joloxx9) | 🐛 `bug` | [#15: Tautulli user-roster compatibility](https://github.com/sparkmoxie/TautWeekly/issues/15) | [PR #16](https://github.com/sparkmoxie/TautWeekly/pull/16) · [v0.5.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.2) |
 | [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#31: selected-library and sparse-metadata renderer fixes](https://github.com/sparkmoxie/TautWeekly/issues/31) | [PR #33](https://github.com/sparkmoxie/TautWeekly/pull/33) · [v0.6.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.1)<br>[PR #36](https://github.com/sparkmoxie/TautWeekly/pull/36) · [v0.6.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.2) |
 | [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#38: container exec PUID/PGID ownership](https://github.com/sparkmoxie/TautWeekly/issues/38) | [PR #39](https://github.com/sparkmoxie/TautWeekly/pull/39) · [v0.6.3](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.3) |
+| [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#41: deleted Plex item history metadata](https://github.com/sparkmoxie/TautWeekly/issues/41) | [PR #42](https://github.com/sparkmoxie/TautWeekly/pull/42) · [v0.7.0](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.7.0) |
 
 Only public GitHub handles and links are recorded. Bug credit requires an
 evidence-backed correction in the repository; enhancement credit requires an

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ and TestEmail delivery before trusting the next production send.
 flowchart LR
     T["Tautulli API"] --> E["TautWeekly for Plex PowerShell engine"]
     P["Plex Media Server\noptional metadata"] -.-> E
+    H["Plex hosted metadata\nexact-GUID deleted-item fallback"] -.-> E
     E --> R["HTML + plain-text renderer"]
     R --> V["Local preview"]
     R --> M["SMTP test and delivery"]
@@ -327,6 +328,10 @@ flowchart LR
 
 Tautulli supplies users, activity, history, and recently added metadata. Direct
 Plex access is optional and improves selected artwork and metadata fallbacks.
+If a Plex item has been deleted but Tautulli retains its exact media GUID, the
+configured administrator Plex token can resolve that identifier through Plex's
+hosted metadata service. TautWeekly does not search by title or send recipient
+or watch-history data, and it never forwards the token to external artwork hosts.
 The renderer produces browser previews and multipart email, while local state
 guards first-run behavior, welcomes, and repeat schedule attempts.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,10 +14,15 @@ setup is preferred.
 | `ApiKey` | Yes | Tautulli API key; treat as a secret |
 | `PlexWebUrl` | Yes | Destination for “Open Plex” links; defaults to the Plex web app |
 | `PlexServerUrl` | No | Direct Plex base URL for richer metadata and artwork |
-| `PlexToken` | No | Direct Plex token; treat as a secret |
+| `PlexToken` | No | Administrator/server Plex token for direct Plex access and exact-GUID deleted-item recovery; treat as a secret |
 
 TautWeekly for Plex's core activity flow uses Tautulli. Direct Plex access is optional
-and improves selected metadata and artwork paths.
+and improves selected metadata and artwork paths. When Plex has deleted an item
+but Tautulli still retains its history GUID, TautWeekly can use `PlexToken` to
+resolve that exact identifier through `https://metadata.provider.plex.tv` and
+cache available hosted artwork and metadata. It does not search by title or send
+recipient identity or watch-history values. If Plex returns an absolute artwork
+URL on another host, that host receives no Plex token.
 
 ## Branding and mail
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -20,6 +20,13 @@ storage, and define a retention period.
 - If LAN binding is required, restrict inbound access with the host firewall.
 - Use HTTPS for remote Tautulli/Plex endpoints when your environment provides a
   trusted TLS reverse proxy.
+- Deleted-item recovery sends only Tautulli's retained exact media GUID and the
+  configured administrator/server Plex token to
+  `https://metadata.provider.plex.tv`. It sends no recipient identity, email,
+  or watch-history values and does not perform title searches.
+- Hosted artwork returned on a different origin is fetched without the Plex
+  token. The token is attached only to Plex server and Plex metadata-provider
+  requests.
 - Use SMTP STARTTLS and provider-specific application credentials.
 
 ## Delivery safeguards

--- a/platforms/freebsd-podman/CHANGELOG.txt
+++ b/platforms/freebsd-podman/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex FreeBSD Podman platform changelog
 
 Unreleased
+- Recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID.
 - Honors PUID/PGID for newsletter commands started from a root Podman exec session.
 - Treats sparse Tautulli hero metadata as optional during previews and test sends.
 - Accepts selected-library recently-added rows when Plex omits the redundant section ID.

--- a/platforms/linux/CHANGELOG.txt
+++ b/platforms/linux/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex native Linux platform changelog
 
 Unreleased
+- Recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID.
 - Treats sparse Tautulli hero metadata as optional during previews and test sends.
 - Accepts selected-library recently-added rows when Plex omits the redundant section ID.
 - Limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists.

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID
 - honors PUID/PGID for newsletter commands started from a root container Console or exec session
 - treats sparse Tautulli hero metadata as optional during previews and test sends
 - accepts selected-library recently-added rows when Plex omits the redundant section ID

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -3400,14 +3400,15 @@ function Add-DesignRatingMetadata {
     foreach ($item in $all) {
         $critic = ""
         $audience = ""
+        $imdb = ""
         $criticImage = ""
         $audienceImageState = ""
         $genres = @()
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
-        # Primary source for the newsletter: Tautulli already exposes the
-        # selected Plex critic and audience scores plus their provider IDs.
+        # Primary source for the newsletter: Tautulli already exposes selected
+        # movie RT and TV IMDb scores plus their provider IDs.
         try {
             $meta = Invoke-TautulliApi -Command "get_metadata" -Parameters @{
                 rating_key = $ratingKey
@@ -3431,38 +3432,44 @@ function Add-DesignRatingMetadata {
                 }
             }
 
-            if ([string]$item.Type -eq "movie") {
-                if ($null -ne $meta.PSObject.Properties["genres"]) {
-                    $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
-                }
-                elseif ($null -ne $meta.PSObject.Properties["genre"]) {
-                    $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
-                }
+            if ($null -ne $meta.PSObject.Properties["genres"]) {
+                $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+            }
+            elseif ($null -ne $meta.PSObject.Properties["genre"]) {
+                $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
             }
 
-            if ($ratingImage -like 'rottentomatoes://image.rating.*') {
-                $critic = Convert-DesignRatingPercent $ratingValue
-                $criticImage = $ratingImage
+            if ($mediaType -eq "movie") {
+                if ($ratingImage -like 'rottentomatoes://image.rating.*') {
+                    $critic = Convert-DesignRatingPercent $ratingValue
+                    $criticImage = $ratingImage
+                }
+                if ($audienceImage -like 'rottentomatoes://image.rating.*') {
+                    $audience = Convert-DesignRatingPercent $audienceRatingValue
+                    $audienceImageState = $audienceImage
+                }
             }
-
-            if ($audienceImage -like 'rottentomatoes://image.rating.*') {
-                $audience = Convert-DesignRatingPercent $audienceRatingValue
-                $audienceImageState = $audienceImage
+            elseif ($ratingImage -like 'imdb://image.rating*') {
+                $imdb = $ratingValue
             }
         }
         catch {
-            Write-Log "TautWeekly for Plex Tautulli RT lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
+            Write-Log "TautWeekly for Plex Tautulli rating/metadata lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
         }
 
         # Optional secondary source: Plex's full Rating[] if direct access
         # happens to be available on this install.
-        if ([string]::IsNullOrWhiteSpace($critic) -or
-            [string]::IsNullOrWhiteSpace($audience)) {
+        $needsDirectRatings = if ($mediaType -eq "movie") {
+            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+        }
+        else {
+            [string]::IsNullOrWhiteSpace($imdb)
+        }
+        if ($needsDirectRatings) {
             try {
                 $plexMeta = Get-DesignPlexMetadata -RatingKey $ratingKey
 
                 if ($null -ne $plexMeta -and
-                    [string]$item.Type -eq "movie" -and
                     $genres.Count -eq 0 -and
                     $null -ne $plexMeta.PSObject.Properties["Genre"]) {
                     $genres = @(ConvertTo-DesignGenreList -Value $plexMeta.Genre)
@@ -3486,14 +3493,22 @@ function Add-DesignRatingMetadata {
                             $value = $ratingEntry.value
                         }
 
-                        if ([string]::IsNullOrWhiteSpace($critic) -and
+                        if ($mediaType -eq "show" -and
+                            [string]::IsNullOrWhiteSpace($imdb) -and
+                            $image -like "imdb://image.rating*") {
+                            $imdb = [string]$value
+                        }
+
+                        if ($mediaType -eq "movie" -and
+                            [string]::IsNullOrWhiteSpace($critic) -and
                             $image -like "rottentomatoes://image.rating.*" -and
                             $type -eq "critic") {
                             $critic = Convert-DesignRatingPercent $value
                             $criticImage = $image
                         }
 
-                        if ([string]::IsNullOrWhiteSpace($audience) -and
+                        if ($mediaType -eq "movie" -and
+                            [string]::IsNullOrWhiteSpace($audience) -and
                             $image -like "rottentomatoes://image.rating.*" -and
                             $type -eq "audience") {
                             $audience = Convert-DesignRatingPercent $value
@@ -3512,11 +3527,16 @@ function Add-DesignRatingMetadata {
         # administrator-authorized Plex token, resolve only that identifier
         # against Plex's hosted metadata service; never search by title.
         $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $needsHostedRating = if ($mediaType -eq "movie") {
+            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+        }
+        else {
+            [string]::IsNullOrWhiteSpace($imdb)
+        }
         $needsHostedMetadata = (
             -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
             ($genres.Count -eq 0 -or
-             [string]::IsNullOrWhiteSpace($critic) -or
-             [string]::IsNullOrWhiteSpace($audience) -or
+             $needsHostedRating -or
              [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary")) -or
              [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year")))
         )
@@ -3561,15 +3581,22 @@ function Add-DesignRatingMetadata {
                         $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating"
                     }
 
-                    if ([string]::IsNullOrWhiteSpace($critic) -and
+                    if ($mediaType -eq "movie" -and
+                        [string]::IsNullOrWhiteSpace($critic) -and
                         $hostedRatingImage -like 'rottentomatoes://image.rating.*') {
                         $critic = Convert-DesignRatingPercent $hostedRating
                         $criticImage = $hostedRatingImage
                     }
-                    if ([string]::IsNullOrWhiteSpace($audience) -and
+                    if ($mediaType -eq "movie" -and
+                        [string]::IsNullOrWhiteSpace($audience) -and
                         $hostedAudienceImage -like 'rottentomatoes://image.rating.*') {
                         $audience = Convert-DesignRatingPercent $hostedAudience
                         $audienceImageState = $hostedAudienceImage
+                    }
+                    if ($mediaType -eq "show" -and
+                        [string]::IsNullOrWhiteSpace($imdb) -and
+                        $hostedRatingImage -like 'imdb://image.rating*') {
+                        $imdb = $hostedRating
                     }
 
                     if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
@@ -3578,13 +3605,20 @@ function Add-DesignRatingMetadata {
                             $type = Get-OptionalStringProperty -InputObject $ratingEntry -Name "type"
                             $value = Get-OptionalStringProperty -InputObject $ratingEntry -Name "value"
 
-                            if ([string]::IsNullOrWhiteSpace($critic) -and
+                            if ($mediaType -eq "show" -and
+                                [string]::IsNullOrWhiteSpace($imdb) -and
+                                $image -like 'imdb://image.rating*') {
+                                $imdb = $value
+                            }
+                            if ($mediaType -eq "movie" -and
+                                [string]::IsNullOrWhiteSpace($critic) -and
                                 $image -like 'rottentomatoes://image.rating.*' -and
                                 $type -eq "critic") {
                                 $critic = Convert-DesignRatingPercent $value
                                 $criticImage = $image
                             }
-                            if ([string]::IsNullOrWhiteSpace($audience) -and
+                            if ($mediaType -eq "movie" -and
+                                [string]::IsNullOrWhiteSpace($audience) -and
                                 $image -like 'rottentomatoes://image.rating.*' -and
                                 $type -eq "audience") {
                                 $audience = Convert-DesignRatingPercent $value
@@ -3599,9 +3633,8 @@ function Add-DesignRatingMetadata {
             }
         }
 
-        # Last resort: rich exporter for movies only. TV cards use episode
-        # IMDb enrichment instead; show/season RT exporter requests are noisy
-        # and are not needed for the approved email design.
+        # Last resort: rich exporter for movies only. TV shows and episodes use
+        # IMDb values directly; show/season RT exporter requests are not needed.
         if ([string]$item.Type -eq "movie" -and
             ([string]::IsNullOrWhiteSpace($critic) -or
              [string]::IsNullOrWhiteSpace($audience))) {
@@ -3619,14 +3652,20 @@ function Add-DesignRatingMetadata {
             }
         }
 
-        Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
-            $item.Title,
-            $(if ($critic) { $critic + "%" } else { "n/a" }),
-            $(if ($audience) { $audience } else { "n/a" })
-        )
+        if ($mediaType -eq "show") {
+            Write-Log ("Design ratings: {0} -> IMDb {1}" -f $item.Title, $(if ($imdb) { $imdb } else { "n/a" }))
+        }
+        else {
+            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
+                $item.Title,
+                $(if ($critic) { $critic + "%" } else { "n/a" }),
+                $(if ($audience) { $audience } else { "n/a" })
+            )
+        }
 
         $item | Add-Member -NotePropertyName "DesignRtCritic" -NotePropertyValue $critic -Force
         $item | Add-Member -NotePropertyName "DesignRtAudience" -NotePropertyValue $audience -Force
+        $item | Add-Member -NotePropertyName "DesignImdbRating" -NotePropertyValue $imdb -Force
         $item | Add-Member -NotePropertyName "DesignRtCriticImage" -NotePropertyValue $criticImage -Force
         $item | Add-Member -NotePropertyName "DesignRtAudienceImage" -NotePropertyValue $audienceImageState -Force
         $item | Add-Member -NotePropertyName "DesignGenres" -NotePropertyValue @($genres) -Force
@@ -3693,6 +3732,18 @@ function Get-DesignRatingLine {
         $pieces.Add(
             '<span class="design-rating-year">' +
             (HtmlEncode ([string]$Item.Year)) +
+            '</span>'
+        )
+    }
+
+    $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
+    if ([string]$Item.Type -eq "show" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+        $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
+        $pieces.Add(
+            '<span class="design-rating-item">' +
+            '<img src="' + (HtmlEncode $imdbIcon) + '" alt="IMDb" ' +
+            'width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
+            (HtmlEncode $imdb) +
             '</span>'
         )
     }

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -93,6 +93,8 @@ $LogFile = Join-Path $LogDir ("tautweekly_{0}.log" -f (Get-TautWeeklyRunNow).ToS
 # them inside Get-DesignPlexContext / Get-DesignPlexMetadata.
 $script:DesignPlexContext = $null
 $script:DesignPlexMetadataCache = @{}
+$script:PlexHostedMetadataCache = @{}
+$script:TautulliDefaultPosterHash = ""
 
 function Write-Log {
     param(
@@ -688,18 +690,24 @@ function New-ReleaseData {
     $tvMap = @{}
 
     foreach ($item in $RecentItems) {
-        $type = ([string]$item.media_type).ToLowerInvariant()
+        $type = (Get-OptionalStringProperty -InputObject $item -Name "media_type").ToLowerInvariant()
 
         if ($type -eq "movie") {
+            $ratingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+            $rating = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+            if ([string]::IsNullOrWhiteSpace($rating)) {
+                $rating = Get-OptionalStringProperty -InputObject $item -Name "rating"
+            }
             $movieList.Add([PSCustomObject]@{
                 Type            = "movie"
-                ReleaseKey      = "movie:" + [string]$item.rating_key
-                RatingKey       = [string]$item.rating_key
-                PosterRatingKey = [string]$item.rating_key
-                Title           = [string]$item.title
-                Year            = [string]$item.year
-                Rating          = if ([string]$item.audience_rating) { [string]$item.audience_rating } else { [string]$item.rating }
-                Summary         = [string]$item.summary
+                ReleaseKey      = "movie:" + $ratingKey
+                RatingKey       = $ratingKey
+                PosterRatingKey = $ratingKey
+                MetadataGuid    = Get-OptionalStringProperty -InputObject $item -Name "guid"
+                Title           = Get-OptionalStringProperty -InputObject $item -Name "title"
+                Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
+                Rating          = $rating
+                Summary         = Get-OptionalStringProperty -InputObject $item -Name "summary"
                 AddedAt         = Safe-Int64 $item.added_at
                 EpisodeCount    = 0
                 SeasonCount     = 0
@@ -715,20 +723,20 @@ function New-ReleaseData {
             $posterRatingKey = ""
 
             if ($type -eq "show") {
-                $showRatingKey = [string]$item.rating_key
-                $showTitle = [string]$item.title
-                $posterRatingKey = [string]$item.rating_key
+                $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+                $showTitle = Get-OptionalStringProperty -InputObject $item -Name "title"
+                $posterRatingKey = $showRatingKey
             }
             else {
-                $showRatingKey = [string]$item.grandparent_rating_key
-                $showTitle = [string]$item.grandparent_title
-                $posterRatingKey = [string]$item.grandparent_rating_key
+                $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "grandparent_rating_key"
+                $showTitle = Get-OptionalStringProperty -InputObject $item -Name "grandparent_title"
+                $posterRatingKey = $showRatingKey
                 if ([string]::IsNullOrWhiteSpace($showTitle)) {
-                    $showTitle = [string]$item.title
+                    $showTitle = Get-OptionalStringProperty -InputObject $item -Name "title"
                 }
                 if ([string]::IsNullOrWhiteSpace($showRatingKey)) {
-                    $showRatingKey = [string]$item.rating_key
-                    $posterRatingKey = [string]$item.rating_key
+                    $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+                    $posterRatingKey = $showRatingKey
                 }
             }
 
@@ -744,8 +752,9 @@ function New-ReleaseData {
                     ReleaseKey      = $mapKey
                     RatingKey       = $showRatingKey
                     PosterRatingKey = $posterRatingKey
+                    MetadataGuid    = Get-OptionalStringProperty -InputObject $item -Name "guid"
                     Title           = $showTitle
-                    Year            = [string]$item.year
+                    Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
                     Rating          = ""
                     Summary         = ""
                     AddedAt         = Safe-Int64 $item.added_at
@@ -757,6 +766,9 @@ function New-ReleaseData {
             }
 
             $entry = $tvMap[$mapKey]
+            if ([string]::IsNullOrWhiteSpace([string]$entry.MetadataGuid)) {
+                $entry.MetadataGuid = Get-OptionalStringProperty -InputObject $item -Name "guid"
+            }
             if ((Safe-Int64 $item.added_at) -gt $entry.AddedAt) {
                 $entry.AddedAt = Safe-Int64 $item.added_at
             }
@@ -1315,11 +1327,16 @@ function Get-UserStats {
                         Type            = "movie"
                         RatingKey       = $ratingKey
                         PosterRatingKey = $ratingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         Title           = $title
-                        Year            = [string]$row.year
+                        Summary         = ""
+                        Year            = Get-OptionalStringProperty -InputObject $row -Name "year"
                         Plays           = 0
                         Seconds         = [int64]0
                     }
+                }
+                if ([string]::IsNullOrWhiteSpace([string]$movieItemTotals[$dedupeKey].MetadataGuid)) {
+                    $movieItemTotals[$dedupeKey].MetadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
                 }
                 $movieItemTotals[$dedupeKey].Plays += (Get-HistoryRowPlayCount -Row $row)
                 $movieItemTotals[$dedupeKey].Seconds += $seconds
@@ -1362,12 +1379,18 @@ function Get-UserStats {
                         Type            = "show"
                         RatingKey       = $showRatingKey
                         PosterRatingKey = $showRatingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         Title           = $showTitle
                         ShowTitle       = $showTitle
+                        Summary         = ""
+                        Year            = Get-OptionalStringProperty -InputObject $row -Name "year"
                         Plays           = 0
                         Seconds         = [int64]0
                         TotalTimeText   = ""
                     }
+                }
+                if ([string]::IsNullOrWhiteSpace([string]$tvShowTotals[$showDedupeKey].MetadataGuid)) {
+                    $tvShowTotals[$showDedupeKey].MetadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
                 }
                 $tvShowTotals[$showDedupeKey].Plays += (Get-HistoryRowPlayCount -Row $row)
                 $tvShowTotals[$showDedupeKey].Seconds += $seconds
@@ -1395,6 +1418,7 @@ function Get-UserStats {
                         Type            = "episode"
                         RatingKey       = $ratingKey
                         PosterRatingKey = $showRatingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         ShowTitle       = $showTitle
                         EpisodeTitle    = $episodeTitle
                         Season          = Safe-Int $row.parent_media_index
@@ -1558,6 +1582,7 @@ function Get-GlobalTitleTotals {
         $key = ""
         $ratingKey = ""
         $titleType = ""
+        $metadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
 
         if ($type -eq "movie") {
             $title = [string]$row.title
@@ -1586,9 +1611,15 @@ function Get-GlobalTitleTotals {
                 Title     = $title
                 Type      = $titleType
                 RatingKey = $ratingKey
+                MetadataGuid = $metadataGuid
                 Seconds   = [int64]0
                 Plays     = 0
             }
+        }
+
+        if ([string]::IsNullOrWhiteSpace([string]$totals[$key].MetadataGuid) -and
+            -not [string]::IsNullOrWhiteSpace($metadataGuid)) {
+            $totals[$key].MetadataGuid = $metadataGuid
         }
 
         $totals[$key].Seconds += $seconds
@@ -1659,6 +1690,7 @@ function New-HeroItemFromGlobalStat {
         ReleaseKey      = [string]$Stat.Key
         RatingKey       = [string]$Stat.RatingKey
         PosterRatingKey = $posterRatingKey
+        MetadataGuid    = Get-OptionalStringProperty -InputObject $Stat -Name "MetadataGuid"
         Title           = $title
         Year            = $year
         Rating          = ""
@@ -3372,6 +3404,7 @@ function Add-DesignRatingMetadata {
         $audienceImageState = ""
         $genres = @()
         $ratingKey = [string]$item.RatingKey
+        $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
         # Primary source for the newsletter: Tautulli already exposes the
         # selected Plex critic and audience scores plus their provider IDs.
@@ -3384,6 +3417,19 @@ function Add-DesignRatingMetadata {
             $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+
+            if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
+                $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+                if (-not [string]::IsNullOrWhiteSpace($summary)) {
+                    $item | Add-Member -NotePropertyName "Summary" -NotePropertyValue $summary -Force
+                }
+            }
+            if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year"))) {
+                $year = Get-OptionalStringProperty -InputObject $meta -Name "year"
+                if (-not [string]::IsNullOrWhiteSpace($year)) {
+                    $item | Add-Member -NotePropertyName "Year" -NotePropertyValue $year -Force
+                }
+            }
 
             if ([string]$item.Type -eq "movie") {
                 if ($null -ne $meta.PSObject.Properties["genres"]) {
@@ -3458,6 +3504,98 @@ function Add-DesignRatingMetadata {
             }
             catch {
                 Write-Log "TautWeekly for Plex optional direct Plex rating lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
+            }
+        }
+
+        # A deleted library item can no longer be expanded by the local PMS,
+        # but Tautulli history retains its exact Plex metadata GUID. With the
+        # administrator-authorized Plex token, resolve only that identifier
+        # against Plex's hosted metadata service; never search by title.
+        $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $needsHostedMetadata = (
+            -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
+            ($genres.Count -eq 0 -or
+             [string]::IsNullOrWhiteSpace($critic) -or
+             [string]::IsNullOrWhiteSpace($audience) -or
+             [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary")) -or
+             [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year")))
+        )
+
+        if ($needsHostedMetadata) {
+            try {
+                $hostedMeta = Get-PlexHostedMetadata -MetadataGuid $metadataGuid -MediaType $mediaType
+                if ($null -ne $hostedMeta) {
+                    if ($genres.Count -eq 0) {
+                        if ($null -ne $hostedMeta.PSObject.Properties["Genre"]) {
+                            $genres = @(ConvertTo-DesignGenreList -Value $hostedMeta.Genre)
+                        }
+                        elseif ($null -ne $hostedMeta.PSObject.Properties["genres"]) {
+                            $genres = @(ConvertTo-DesignGenreList -Value $hostedMeta.genres)
+                        }
+                    }
+
+                    if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
+                        $summary = Get-OptionalStringProperty -InputObject $hostedMeta -Name "summary"
+                        if (-not [string]::IsNullOrWhiteSpace($summary)) {
+                            $item | Add-Member -NotePropertyName "Summary" -NotePropertyValue $summary -Force
+                        }
+                    }
+                    if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year"))) {
+                        $year = Get-OptionalStringProperty -InputObject $hostedMeta -Name "year"
+                        if (-not [string]::IsNullOrWhiteSpace($year)) {
+                            $item | Add-Member -NotePropertyName "Year" -NotePropertyValue $year -Force
+                        }
+                    }
+
+                    $hostedRatingImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "ratingImage"
+                    if ([string]::IsNullOrWhiteSpace($hostedRatingImage)) {
+                        $hostedRatingImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "rating_image"
+                    }
+                    $hostedAudienceImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audienceRatingImage"
+                    if ([string]::IsNullOrWhiteSpace($hostedAudienceImage)) {
+                        $hostedAudienceImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating_image"
+                    }
+                    $hostedRating = Get-OptionalStringProperty -InputObject $hostedMeta -Name "rating"
+                    $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audienceRating"
+                    if ([string]::IsNullOrWhiteSpace($hostedAudience)) {
+                        $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating"
+                    }
+
+                    if ([string]::IsNullOrWhiteSpace($critic) -and
+                        $hostedRatingImage -like 'rottentomatoes://image.rating.*') {
+                        $critic = Convert-DesignRatingPercent $hostedRating
+                        $criticImage = $hostedRatingImage
+                    }
+                    if ([string]::IsNullOrWhiteSpace($audience) -and
+                        $hostedAudienceImage -like 'rottentomatoes://image.rating.*') {
+                        $audience = Convert-DesignRatingPercent $hostedAudience
+                        $audienceImageState = $hostedAudienceImage
+                    }
+
+                    if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
+                        foreach ($ratingEntry in @($hostedMeta.Rating)) {
+                            $image = Get-OptionalStringProperty -InputObject $ratingEntry -Name "image"
+                            $type = Get-OptionalStringProperty -InputObject $ratingEntry -Name "type"
+                            $value = Get-OptionalStringProperty -InputObject $ratingEntry -Name "value"
+
+                            if ([string]::IsNullOrWhiteSpace($critic) -and
+                                $image -like 'rottentomatoes://image.rating.*' -and
+                                $type -eq "critic") {
+                                $critic = Convert-DesignRatingPercent $value
+                                $criticImage = $image
+                            }
+                            if ([string]::IsNullOrWhiteSpace($audience) -and
+                                $image -like 'rottentomatoes://image.rating.*' -and
+                                $type -eq "audience") {
+                                $audience = Convert-DesignRatingPercent $value
+                                $audienceImageState = $image
+                            }
+                        }
+                    }
+                }
+            }
+            catch {
+                Write-Log "Plex hosted enrichment failed for deleted $mediaType history metadata: $($_.Exception.Message)" "WARN"
             }
         }
 
@@ -3918,8 +4056,247 @@ function Get-DesignHeroAssets {
     return $result
 }
 
+function Get-PlexMetadataProviderBaseUrl {
+    $defaultUrl = "https://metadata.provider.plex.tv"
+    $testUrl = [string]$env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL
+    if ([string]::IsNullOrWhiteSpace($testUrl)) { return $defaultUrl }
+
+    try {
+        $uri = [Uri]$testUrl
+        if ($uri.IsLoopback -and $uri.Scheme -in @("http", "https")) {
+            return $testUrl.TrimEnd("/")
+        }
+    }
+    catch { }
+
+    return $defaultUrl
+}
+
+function Get-PlexHostedMetadataLookupPath {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType
+    )
+
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return "" }
+
+    $guid = $MetadataGuid.Trim()
+    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9]+)(?:\?.*)?$') {
+        return "/library/metadata/" + [Uri]::EscapeDataString([string]$Matches.id)
+    }
+
+    $externalGuid = ""
+    if ($guid -match '(?i)^(?:tmdb|imdb)://[^/?]+(?:\?.*)?$') {
+        $externalGuid = $guid -replace '\?.*$', ''
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.themoviedb://(?<id>[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "tmdb://" + [string]$Matches.id
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "imdb://" + [string]$Matches.id
+    }
+
+    if ([string]::IsNullOrWhiteSpace($externalGuid)) { return "" }
+
+    $providerType = if ($MediaType -eq "movie") { 1 } else { 2 }
+    return "/library/metadata/matches?guid=" +
+        [Uri]::EscapeDataString($externalGuid) +
+        "&type=" + $providerType
+}
+
+function Get-PlexHostedMetadata {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType
+    )
+
+    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ([string]::IsNullOrWhiteSpace($lookupPath)) { return $null }
+
+    $cacheKey = $MediaType + ":" + $MetadataGuid
+    if ($script:PlexHostedMetadataCache.ContainsKey($cacheKey)) {
+        return $script:PlexHostedMetadataCache[$cacheKey]
+    }
+
+    $ctx = Get-DesignPlexContext
+    $token = Get-OptionalStringProperty -InputObject $ctx -Name "Token"
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        $script:PlexHostedMetadataCache[$cacheKey] = $null
+        return $null
+    }
+
+    $headers = @{
+        "Accept"                   = "application/json"
+        "X-Plex-Token"             = $token
+        "X-Plex-Product"           = "TautWeekly for Plex"
+        "X-Plex-Version"           = "0.7.0"
+        "X-Plex-Client-Identifier" = "tautweekly-history-artwork"
+    }
+
+    $metadata = $null
+    try {
+        $raw = Invoke-RestMethod `
+            -Uri ((Get-PlexMetadataProviderBaseUrl) + $lookupPath) `
+            -Headers $headers `
+            -Method Get `
+            -TimeoutSec 60
+
+        if ($null -ne $raw -and $null -ne $raw.PSObject.Properties["MediaContainer"]) {
+            $container = $raw.MediaContainer
+            if ($null -ne $container.PSObject.Properties["Metadata"]) {
+                $rows = @($container.Metadata)
+                if ($rows.Count -gt 0) { $metadata = $rows[0] }
+            }
+        }
+    }
+    catch {
+        Write-Log "Plex hosted metadata fallback failed for deleted $MediaType history metadata: $($_.Exception.Message)" "WARN"
+    }
+
+    if ($null -ne $metadata -and $MediaType -eq "show") {
+        $resolvedType = Get-OptionalStringProperty -InputObject $metadata -Name "type"
+        if ($resolvedType -ne "show") {
+            $showGuid = if ($resolvedType -eq "season") {
+                Get-OptionalStringProperty -InputObject $metadata -Name "parentGuid"
+            }
+            else {
+                Get-OptionalStringProperty -InputObject $metadata -Name "grandparentGuid"
+            }
+            if ([string]::IsNullOrWhiteSpace($showGuid)) {
+                $showGuid = if ($resolvedType -eq "season") {
+                    Get-OptionalStringProperty -InputObject $metadata -Name "parent_guid"
+                }
+                else {
+                    Get-OptionalStringProperty -InputObject $metadata -Name "grandparent_guid"
+                }
+            }
+            if (-not [string]::IsNullOrWhiteSpace($showGuid) -and $showGuid -ne $MetadataGuid) {
+                $showMetadata = Get-PlexHostedMetadata -MetadataGuid $showGuid -MediaType "show"
+                if ($null -ne $showMetadata) { $metadata = $showMetadata }
+            }
+        }
+    }
+
+    $script:PlexHostedMetadataCache[$cacheKey] = $metadata
+    return $metadata
+}
+
+function Get-PlexHostedPosterPath {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType,
+        [string]$DestinationPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid) -or
+        [string]::IsNullOrWhiteSpace($DestinationPath)) {
+        return ""
+    }
+
+    $metadata = Get-PlexHostedMetadata -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ($null -eq $metadata) { return "" }
+
+    $fieldNames = if ($MediaType -eq "show") {
+        @("thumb", "grandparentThumb", "grandparent_thumb", "parentThumb", "parent_thumb")
+    }
+    else {
+        @("thumb")
+    }
+
+    $posterUrl = ""
+    foreach ($fieldName in $fieldNames) {
+        $posterUrl = Get-OptionalStringProperty -InputObject $metadata -Name $fieldName
+        if (-not [string]::IsNullOrWhiteSpace($posterUrl)) { break }
+    }
+    if ([string]::IsNullOrWhiteSpace($posterUrl)) { return "" }
+
+    $providerBaseUrl = Get-PlexMetadataProviderBaseUrl
+    $assetUrl = $posterUrl
+    $headers = @{}
+
+    try {
+        if ($posterUrl.StartsWith("/")) {
+            $assetUrl = $providerBaseUrl + $posterUrl
+            $headers["X-Plex-Token"] = [string](Get-DesignPlexContext).Token
+        }
+        else {
+            $assetUri = [Uri]$posterUrl
+            if ($assetUri.Scheme -notin @("http", "https")) { return "" }
+
+            $providerUri = [Uri]$providerBaseUrl
+            if ($assetUri.Scheme -ieq $providerUri.Scheme -and
+                $assetUri.Host -ieq $providerUri.Host -and
+                $assetUri.Port -eq $providerUri.Port) {
+                $headers["X-Plex-Token"] = [string](Get-DesignPlexContext).Token
+            }
+        }
+
+        if ($headers.Count -gt 0) {
+            Invoke-WebRequest -Uri $assetUrl -Headers $headers -OutFile $DestinationPath -TimeoutSec 60 | Out-Null
+        }
+        else {
+            Invoke-WebRequest -Uri $assetUrl -OutFile $DestinationPath -TimeoutSec 60 | Out-Null
+        }
+
+        if ((Test-Path $DestinationPath) -and (Get-Item $DestinationPath).Length -gt 512) {
+            Write-Log "Recovered deleted Plex $MediaType history artwork from its retained metadata GUID."
+            return $DestinationPath
+        }
+    }
+    catch {
+        Write-Log "Plex hosted poster download failed for deleted $MediaType history artwork: $($_.Exception.Message)" "WARN"
+    }
+
+    Remove-Item $DestinationPath -Force -ErrorAction SilentlyContinue
+    return ""
+}
+
+function Get-TautulliDefaultPosterHash {
+    if (-not [string]::IsNullOrWhiteSpace($script:TautulliDefaultPosterHash)) {
+        return $script:TautulliDefaultPosterHash
+    }
+
+    $probePath = Join-Path $PosterDir (".tautulli-default-poster-" + [Guid]::NewGuid().ToString("N"))
+    try {
+        $uri = Build-TautulliUri -Command "pms_image_proxy" -Parameters @{
+            fallback = "poster"
+        }
+        Invoke-WebRequest -Uri $uri -OutFile $probePath -TimeoutSec 60 | Out-Null
+        if ((Test-Path $probePath) -and (Get-Item $probePath).Length -gt 0) {
+            $script:TautulliDefaultPosterHash = (Get-FileHash -Path $probePath -Algorithm SHA256).Hash
+        }
+    }
+    catch {
+        Write-Log "Could not fingerprint Tautulli's generic poster fallback: $($_.Exception.Message)" "WARN"
+    }
+    finally {
+        Remove-Item $probePath -Force -ErrorAction SilentlyContinue
+    }
+
+    return $script:TautulliDefaultPosterHash
+}
+
+function Test-IsTautulliDefaultPoster {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path $Path)) { return $false }
+
+    $defaultHash = Get-TautulliDefaultPosterHash
+    if ([string]::IsNullOrWhiteSpace($defaultHash)) { return $false }
+
+    return ((Get-FileHash -Path $Path -Algorithm SHA256).Hash -eq $defaultHash)
+}
+
 function Get-PosterPath {
-    param([string]$RatingKey)
+    param(
+        [string]$RatingKey,
+        [string]$MetadataGuid = "",
+        [ValidateSet("movie", "show")]
+        [string]$MediaType = "movie"
+    )
 
     if ([string]::IsNullOrWhiteSpace($RatingKey)) { return "" }
 
@@ -3927,7 +4304,13 @@ function Get-PosterPath {
     $path = Join-Path $PosterDir ($cid + ".jpg")
 
     if (Test-Path $path) {
-        if ((Get-Item $path).Length -gt 512) { return $path }
+        if ((Get-Item $path).Length -gt 512) {
+            $isCachedGenericFallback = (
+                -not [string]::IsNullOrWhiteSpace($MetadataGuid) -and
+                (Test-IsTautulliDefaultPoster -Path $path)
+            )
+            if (-not $isCachedGenericFallback) { return $path }
+        }
         Remove-Item $path -Force -ErrorAction SilentlyContinue
     }
 
@@ -3942,7 +4325,13 @@ function Get-PosterPath {
     try {
         Invoke-WebRequest -Uri $uri -OutFile $path -TimeoutSec 60 | Out-Null
         if ((Test-Path $path) -and (Get-Item $path).Length -gt 512) {
-            return $path
+            $isGenericFallback = (
+                -not [string]::IsNullOrWhiteSpace($MetadataGuid) -and
+                (Test-IsTautulliDefaultPoster -Path $path)
+            )
+            if (-not $isGenericFallback) { return $path }
+
+            Write-Log "Tautulli returned its generic poster for deleted Plex $MediaType history; trying the retained metadata GUID."
         }
     }
     catch {
@@ -3950,6 +4339,12 @@ function Get-PosterPath {
     }
 
     Remove-Item $path -Force -ErrorAction SilentlyContinue
+    $hostedPath = Get-PlexHostedPosterPath `
+        -MetadataGuid $MetadataGuid `
+        -MediaType $MediaType `
+        -DestinationPath $path
+    if (-not [string]::IsNullOrWhiteSpace($hostedPath)) { return $hostedPath }
+
     return ""
 }
 
@@ -3967,7 +4362,7 @@ function Prepare-PosterAssets {
 
     if (-not [string]::IsNullOrWhiteSpace($FeaturedRatingKey)) {
         $featured = @(
-            @($ReleaseData.Movies) + @($ReleaseData.TV) |
+            @($ReleaseData.Movies) + @($ReleaseData.TV) + @($AdditionalItems) |
             Where-Object { [string]$_.PosterRatingKey -eq $FeaturedRatingKey } |
             Select-Object -First 1
         )
@@ -4004,7 +4399,14 @@ function Prepare-PosterAssets {
         if ([string]::IsNullOrWhiteSpace($rk) -or $seen.ContainsKey($rk)) { continue }
 
         $seen[$rk] = $true
-        $path = Get-PosterPath -RatingKey $rk
+        $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $mediaType = Get-OptionalStringProperty -InputObject $item -Name "Type"
+        if ($mediaType -ne "show") { $mediaType = "movie" }
+
+        $path = Get-PosterPath `
+            -RatingKey $rk `
+            -MetadataGuid $metadataGuid `
+            -MediaType $mediaType
         if (-not [string]::IsNullOrWhiteSpace($path)) {
             $assets.Add([PSCustomObject]@{
                 RatingKey = $rk
@@ -6203,6 +6605,8 @@ if ($null -ne $script:GlobalTrendingStat -and
     -not [string]::IsNullOrWhiteSpace([string]$script:GlobalTrendingStat.RatingKey)) {
     $trendingPosterItem = [PSCustomObject]@{
         PosterRatingKey = [string]$script:GlobalTrendingStat.RatingKey
+        MetadataGuid    = Get-OptionalStringProperty -InputObject $script:GlobalTrendingStat -Name "MetadataGuid"
+        Type            = [string]$script:GlobalTrendingStat.Type
     }
 }
 

--- a/platforms/nas-docker/CHANGELOG.txt
+++ b/platforms/nas-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX NAS PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID
 - honors PUID/PGID for newsletter commands started from a root container Console or exec session
 - treats sparse Tautulli hero metadata as optional during previews and test sends
 - accepts selected-library recently-added rows when Plex omits the redundant section ID

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -3401,14 +3401,15 @@ function Add-DesignRatingMetadata {
     foreach ($item in $all) {
         $critic = ""
         $audience = ""
+        $imdb = ""
         $criticImage = ""
         $audienceImageState = ""
         $genres = @()
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
-        # Primary source for the newsletter: Tautulli already exposes the
-        # selected Plex critic and audience scores plus their provider IDs.
+        # Primary source for the newsletter: Tautulli already exposes selected
+        # movie RT and TV IMDb scores plus their provider IDs.
         try {
             $meta = Invoke-TautulliApi -Command "get_metadata" -Parameters @{
                 rating_key = $ratingKey
@@ -3432,38 +3433,44 @@ function Add-DesignRatingMetadata {
                 }
             }
 
-            if ([string]$item.Type -eq "movie") {
-                if ($null -ne $meta.PSObject.Properties["genres"]) {
-                    $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
-                }
-                elseif ($null -ne $meta.PSObject.Properties["genre"]) {
-                    $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
-                }
+            if ($null -ne $meta.PSObject.Properties["genres"]) {
+                $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+            }
+            elseif ($null -ne $meta.PSObject.Properties["genre"]) {
+                $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
             }
 
-            if ($ratingImage -like 'rottentomatoes://image.rating.*') {
-                $critic = Convert-DesignRatingPercent $ratingValue
-                $criticImage = $ratingImage
+            if ($mediaType -eq "movie") {
+                if ($ratingImage -like 'rottentomatoes://image.rating.*') {
+                    $critic = Convert-DesignRatingPercent $ratingValue
+                    $criticImage = $ratingImage
+                }
+                if ($audienceImage -like 'rottentomatoes://image.rating.*') {
+                    $audience = Convert-DesignRatingPercent $audienceRatingValue
+                    $audienceImageState = $audienceImage
+                }
             }
-
-            if ($audienceImage -like 'rottentomatoes://image.rating.*') {
-                $audience = Convert-DesignRatingPercent $audienceRatingValue
-                $audienceImageState = $audienceImage
+            elseif ($ratingImage -like 'imdb://image.rating*') {
+                $imdb = $ratingValue
             }
         }
         catch {
-            Write-Log "TautWeekly for Plex Tautulli RT lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
+            Write-Log "TautWeekly for Plex Tautulli rating/metadata lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
         }
 
         # Optional secondary source: Plex's full Rating[] if direct access
         # happens to be available on this install.
-        if ([string]::IsNullOrWhiteSpace($critic) -or
-            [string]::IsNullOrWhiteSpace($audience)) {
+        $needsDirectRatings = if ($mediaType -eq "movie") {
+            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+        }
+        else {
+            [string]::IsNullOrWhiteSpace($imdb)
+        }
+        if ($needsDirectRatings) {
             try {
                 $plexMeta = Get-DesignPlexMetadata -RatingKey $ratingKey
 
                 if ($null -ne $plexMeta -and
-                    [string]$item.Type -eq "movie" -and
                     $genres.Count -eq 0 -and
                     $null -ne $plexMeta.PSObject.Properties["Genre"]) {
                     $genres = @(ConvertTo-DesignGenreList -Value $plexMeta.Genre)
@@ -3487,14 +3494,22 @@ function Add-DesignRatingMetadata {
                             $value = $ratingEntry.value
                         }
 
-                        if ([string]::IsNullOrWhiteSpace($critic) -and
+                        if ($mediaType -eq "show" -and
+                            [string]::IsNullOrWhiteSpace($imdb) -and
+                            $image -like "imdb://image.rating*") {
+                            $imdb = [string]$value
+                        }
+
+                        if ($mediaType -eq "movie" -and
+                            [string]::IsNullOrWhiteSpace($critic) -and
                             $image -like "rottentomatoes://image.rating.*" -and
                             $type -eq "critic") {
                             $critic = Convert-DesignRatingPercent $value
                             $criticImage = $image
                         }
 
-                        if ([string]::IsNullOrWhiteSpace($audience) -and
+                        if ($mediaType -eq "movie" -and
+                            [string]::IsNullOrWhiteSpace($audience) -and
                             $image -like "rottentomatoes://image.rating.*" -and
                             $type -eq "audience") {
                             $audience = Convert-DesignRatingPercent $value
@@ -3513,11 +3528,16 @@ function Add-DesignRatingMetadata {
         # administrator-authorized Plex token, resolve only that identifier
         # against Plex's hosted metadata service; never search by title.
         $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $needsHostedRating = if ($mediaType -eq "movie") {
+            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+        }
+        else {
+            [string]::IsNullOrWhiteSpace($imdb)
+        }
         $needsHostedMetadata = (
             -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
             ($genres.Count -eq 0 -or
-             [string]::IsNullOrWhiteSpace($critic) -or
-             [string]::IsNullOrWhiteSpace($audience) -or
+             $needsHostedRating -or
              [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary")) -or
              [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year")))
         )
@@ -3562,15 +3582,22 @@ function Add-DesignRatingMetadata {
                         $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating"
                     }
 
-                    if ([string]::IsNullOrWhiteSpace($critic) -and
+                    if ($mediaType -eq "movie" -and
+                        [string]::IsNullOrWhiteSpace($critic) -and
                         $hostedRatingImage -like 'rottentomatoes://image.rating.*') {
                         $critic = Convert-DesignRatingPercent $hostedRating
                         $criticImage = $hostedRatingImage
                     }
-                    if ([string]::IsNullOrWhiteSpace($audience) -and
+                    if ($mediaType -eq "movie" -and
+                        [string]::IsNullOrWhiteSpace($audience) -and
                         $hostedAudienceImage -like 'rottentomatoes://image.rating.*') {
                         $audience = Convert-DesignRatingPercent $hostedAudience
                         $audienceImageState = $hostedAudienceImage
+                    }
+                    if ($mediaType -eq "show" -and
+                        [string]::IsNullOrWhiteSpace($imdb) -and
+                        $hostedRatingImage -like 'imdb://image.rating*') {
+                        $imdb = $hostedRating
                     }
 
                     if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
@@ -3579,13 +3606,20 @@ function Add-DesignRatingMetadata {
                             $type = Get-OptionalStringProperty -InputObject $ratingEntry -Name "type"
                             $value = Get-OptionalStringProperty -InputObject $ratingEntry -Name "value"
 
-                            if ([string]::IsNullOrWhiteSpace($critic) -and
+                            if ($mediaType -eq "show" -and
+                                [string]::IsNullOrWhiteSpace($imdb) -and
+                                $image -like 'imdb://image.rating*') {
+                                $imdb = $value
+                            }
+                            if ($mediaType -eq "movie" -and
+                                [string]::IsNullOrWhiteSpace($critic) -and
                                 $image -like 'rottentomatoes://image.rating.*' -and
                                 $type -eq "critic") {
                                 $critic = Convert-DesignRatingPercent $value
                                 $criticImage = $image
                             }
-                            if ([string]::IsNullOrWhiteSpace($audience) -and
+                            if ($mediaType -eq "movie" -and
+                                [string]::IsNullOrWhiteSpace($audience) -and
                                 $image -like 'rottentomatoes://image.rating.*' -and
                                 $type -eq "audience") {
                                 $audience = Convert-DesignRatingPercent $value
@@ -3600,9 +3634,8 @@ function Add-DesignRatingMetadata {
             }
         }
 
-        # Last resort: rich exporter for movies only. TV cards use episode
-        # IMDb enrichment instead; show/season RT exporter requests are noisy
-        # and are not needed for the approved email design.
+        # Last resort: rich exporter for movies only. TV shows and episodes use
+        # IMDb values directly; show/season RT exporter requests are not needed.
         if ([string]$item.Type -eq "movie" -and
             ([string]::IsNullOrWhiteSpace($critic) -or
              [string]::IsNullOrWhiteSpace($audience))) {
@@ -3620,14 +3653,20 @@ function Add-DesignRatingMetadata {
             }
         }
 
-        Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
-            $item.Title,
-            $(if ($critic) { $critic + "%" } else { "n/a" }),
-            $(if ($audience) { $audience } else { "n/a" })
-        )
+        if ($mediaType -eq "show") {
+            Write-Log ("Design ratings: {0} -> IMDb {1}" -f $item.Title, $(if ($imdb) { $imdb } else { "n/a" }))
+        }
+        else {
+            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
+                $item.Title,
+                $(if ($critic) { $critic + "%" } else { "n/a" }),
+                $(if ($audience) { $audience } else { "n/a" })
+            )
+        }
 
         $item | Add-Member -NotePropertyName "DesignRtCritic" -NotePropertyValue $critic -Force
         $item | Add-Member -NotePropertyName "DesignRtAudience" -NotePropertyValue $audience -Force
+        $item | Add-Member -NotePropertyName "DesignImdbRating" -NotePropertyValue $imdb -Force
         $item | Add-Member -NotePropertyName "DesignRtCriticImage" -NotePropertyValue $criticImage -Force
         $item | Add-Member -NotePropertyName "DesignRtAudienceImage" -NotePropertyValue $audienceImageState -Force
         $item | Add-Member -NotePropertyName "DesignGenres" -NotePropertyValue @($genres) -Force
@@ -3694,6 +3733,18 @@ function Get-DesignRatingLine {
         $pieces.Add(
             '<span class="design-rating-year">' +
             (HtmlEncode ([string]$Item.Year)) +
+            '</span>'
+        )
+    }
+
+    $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
+    if ([string]$Item.Type -eq "show" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+        $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
+        $pieces.Add(
+            '<span class="design-rating-item">' +
+            '<img src="' + (HtmlEncode $imdbIcon) + '" alt="IMDb" ' +
+            'width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
+            (HtmlEncode $imdb) +
             '</span>'
         )
     }

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -93,6 +93,8 @@ $LogFile = Join-Path $LogDir ("tautweekly_{0}.log" -f (Get-TautWeeklyRunNow).ToS
 # them inside Get-DesignPlexContext / Get-DesignPlexMetadata.
 $script:DesignPlexContext = $null
 $script:DesignPlexMetadataCache = @{}
+$script:PlexHostedMetadataCache = @{}
+$script:TautulliDefaultPosterHash = ""
 
 function Write-Log {
     param(
@@ -689,18 +691,24 @@ function New-ReleaseData {
     $tvMap = @{}
 
     foreach ($item in $RecentItems) {
-        $type = ([string]$item.media_type).ToLowerInvariant()
+        $type = (Get-OptionalStringProperty -InputObject $item -Name "media_type").ToLowerInvariant()
 
         if ($type -eq "movie") {
+            $ratingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+            $rating = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+            if ([string]::IsNullOrWhiteSpace($rating)) {
+                $rating = Get-OptionalStringProperty -InputObject $item -Name "rating"
+            }
             $movieList.Add([PSCustomObject]@{
                 Type            = "movie"
-                ReleaseKey      = "movie:" + [string]$item.rating_key
-                RatingKey       = [string]$item.rating_key
-                PosterRatingKey = [string]$item.rating_key
-                Title           = [string]$item.title
-                Year            = [string]$item.year
-                Rating          = if ([string]$item.audience_rating) { [string]$item.audience_rating } else { [string]$item.rating }
-                Summary         = [string]$item.summary
+                ReleaseKey      = "movie:" + $ratingKey
+                RatingKey       = $ratingKey
+                PosterRatingKey = $ratingKey
+                MetadataGuid    = Get-OptionalStringProperty -InputObject $item -Name "guid"
+                Title           = Get-OptionalStringProperty -InputObject $item -Name "title"
+                Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
+                Rating          = $rating
+                Summary         = Get-OptionalStringProperty -InputObject $item -Name "summary"
                 AddedAt         = Safe-Int64 $item.added_at
                 EpisodeCount    = 0
                 SeasonCount     = 0
@@ -716,20 +724,20 @@ function New-ReleaseData {
             $posterRatingKey = ""
 
             if ($type -eq "show") {
-                $showRatingKey = [string]$item.rating_key
-                $showTitle = [string]$item.title
-                $posterRatingKey = [string]$item.rating_key
+                $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+                $showTitle = Get-OptionalStringProperty -InputObject $item -Name "title"
+                $posterRatingKey = $showRatingKey
             }
             else {
-                $showRatingKey = [string]$item.grandparent_rating_key
-                $showTitle = [string]$item.grandparent_title
-                $posterRatingKey = [string]$item.grandparent_rating_key
+                $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "grandparent_rating_key"
+                $showTitle = Get-OptionalStringProperty -InputObject $item -Name "grandparent_title"
+                $posterRatingKey = $showRatingKey
                 if ([string]::IsNullOrWhiteSpace($showTitle)) {
-                    $showTitle = [string]$item.title
+                    $showTitle = Get-OptionalStringProperty -InputObject $item -Name "title"
                 }
                 if ([string]::IsNullOrWhiteSpace($showRatingKey)) {
-                    $showRatingKey = [string]$item.rating_key
-                    $posterRatingKey = [string]$item.rating_key
+                    $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+                    $posterRatingKey = $showRatingKey
                 }
             }
 
@@ -745,8 +753,9 @@ function New-ReleaseData {
                     ReleaseKey      = $mapKey
                     RatingKey       = $showRatingKey
                     PosterRatingKey = $posterRatingKey
+                    MetadataGuid    = Get-OptionalStringProperty -InputObject $item -Name "guid"
                     Title           = $showTitle
-                    Year            = [string]$item.year
+                    Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
                     Rating          = ""
                     Summary         = ""
                     AddedAt         = Safe-Int64 $item.added_at
@@ -758,6 +767,9 @@ function New-ReleaseData {
             }
 
             $entry = $tvMap[$mapKey]
+            if ([string]::IsNullOrWhiteSpace([string]$entry.MetadataGuid)) {
+                $entry.MetadataGuid = Get-OptionalStringProperty -InputObject $item -Name "guid"
+            }
             if ((Safe-Int64 $item.added_at) -gt $entry.AddedAt) {
                 $entry.AddedAt = Safe-Int64 $item.added_at
             }
@@ -1316,11 +1328,16 @@ function Get-UserStats {
                         Type            = "movie"
                         RatingKey       = $ratingKey
                         PosterRatingKey = $ratingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         Title           = $title
-                        Year            = [string]$row.year
+                        Summary         = ""
+                        Year            = Get-OptionalStringProperty -InputObject $row -Name "year"
                         Plays           = 0
                         Seconds         = [int64]0
                     }
+                }
+                if ([string]::IsNullOrWhiteSpace([string]$movieItemTotals[$dedupeKey].MetadataGuid)) {
+                    $movieItemTotals[$dedupeKey].MetadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
                 }
                 $movieItemTotals[$dedupeKey].Plays += (Get-HistoryRowPlayCount -Row $row)
                 $movieItemTotals[$dedupeKey].Seconds += $seconds
@@ -1363,12 +1380,18 @@ function Get-UserStats {
                         Type            = "show"
                         RatingKey       = $showRatingKey
                         PosterRatingKey = $showRatingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         Title           = $showTitle
                         ShowTitle       = $showTitle
+                        Summary         = ""
+                        Year            = Get-OptionalStringProperty -InputObject $row -Name "year"
                         Plays           = 0
                         Seconds         = [int64]0
                         TotalTimeText   = ""
                     }
+                }
+                if ([string]::IsNullOrWhiteSpace([string]$tvShowTotals[$showDedupeKey].MetadataGuid)) {
+                    $tvShowTotals[$showDedupeKey].MetadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
                 }
                 $tvShowTotals[$showDedupeKey].Plays += (Get-HistoryRowPlayCount -Row $row)
                 $tvShowTotals[$showDedupeKey].Seconds += $seconds
@@ -1396,6 +1419,7 @@ function Get-UserStats {
                         Type            = "episode"
                         RatingKey       = $ratingKey
                         PosterRatingKey = $showRatingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         ShowTitle       = $showTitle
                         EpisodeTitle    = $episodeTitle
                         Season          = Safe-Int $row.parent_media_index
@@ -1559,6 +1583,7 @@ function Get-GlobalTitleTotals {
         $key = ""
         $ratingKey = ""
         $titleType = ""
+        $metadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
 
         if ($type -eq "movie") {
             $title = [string]$row.title
@@ -1587,9 +1612,15 @@ function Get-GlobalTitleTotals {
                 Title     = $title
                 Type      = $titleType
                 RatingKey = $ratingKey
+                MetadataGuid = $metadataGuid
                 Seconds   = [int64]0
                 Plays     = 0
             }
+        }
+
+        if ([string]::IsNullOrWhiteSpace([string]$totals[$key].MetadataGuid) -and
+            -not [string]::IsNullOrWhiteSpace($metadataGuid)) {
+            $totals[$key].MetadataGuid = $metadataGuid
         }
 
         $totals[$key].Seconds += $seconds
@@ -1660,6 +1691,7 @@ function New-HeroItemFromGlobalStat {
         ReleaseKey      = [string]$Stat.Key
         RatingKey       = [string]$Stat.RatingKey
         PosterRatingKey = $posterRatingKey
+        MetadataGuid    = Get-OptionalStringProperty -InputObject $Stat -Name "MetadataGuid"
         Title           = $title
         Year            = $year
         Rating          = ""
@@ -3373,6 +3405,7 @@ function Add-DesignRatingMetadata {
         $audienceImageState = ""
         $genres = @()
         $ratingKey = [string]$item.RatingKey
+        $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
         # Primary source for the newsletter: Tautulli already exposes the
         # selected Plex critic and audience scores plus their provider IDs.
@@ -3385,6 +3418,19 @@ function Add-DesignRatingMetadata {
             $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+
+            if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
+                $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+                if (-not [string]::IsNullOrWhiteSpace($summary)) {
+                    $item | Add-Member -NotePropertyName "Summary" -NotePropertyValue $summary -Force
+                }
+            }
+            if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year"))) {
+                $year = Get-OptionalStringProperty -InputObject $meta -Name "year"
+                if (-not [string]::IsNullOrWhiteSpace($year)) {
+                    $item | Add-Member -NotePropertyName "Year" -NotePropertyValue $year -Force
+                }
+            }
 
             if ([string]$item.Type -eq "movie") {
                 if ($null -ne $meta.PSObject.Properties["genres"]) {
@@ -3459,6 +3505,98 @@ function Add-DesignRatingMetadata {
             }
             catch {
                 Write-Log "TautWeekly for Plex optional direct Plex rating lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
+            }
+        }
+
+        # A deleted library item can no longer be expanded by the local PMS,
+        # but Tautulli history retains its exact Plex metadata GUID. With the
+        # administrator-authorized Plex token, resolve only that identifier
+        # against Plex's hosted metadata service; never search by title.
+        $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $needsHostedMetadata = (
+            -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
+            ($genres.Count -eq 0 -or
+             [string]::IsNullOrWhiteSpace($critic) -or
+             [string]::IsNullOrWhiteSpace($audience) -or
+             [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary")) -or
+             [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year")))
+        )
+
+        if ($needsHostedMetadata) {
+            try {
+                $hostedMeta = Get-PlexHostedMetadata -MetadataGuid $metadataGuid -MediaType $mediaType
+                if ($null -ne $hostedMeta) {
+                    if ($genres.Count -eq 0) {
+                        if ($null -ne $hostedMeta.PSObject.Properties["Genre"]) {
+                            $genres = @(ConvertTo-DesignGenreList -Value $hostedMeta.Genre)
+                        }
+                        elseif ($null -ne $hostedMeta.PSObject.Properties["genres"]) {
+                            $genres = @(ConvertTo-DesignGenreList -Value $hostedMeta.genres)
+                        }
+                    }
+
+                    if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
+                        $summary = Get-OptionalStringProperty -InputObject $hostedMeta -Name "summary"
+                        if (-not [string]::IsNullOrWhiteSpace($summary)) {
+                            $item | Add-Member -NotePropertyName "Summary" -NotePropertyValue $summary -Force
+                        }
+                    }
+                    if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year"))) {
+                        $year = Get-OptionalStringProperty -InputObject $hostedMeta -Name "year"
+                        if (-not [string]::IsNullOrWhiteSpace($year)) {
+                            $item | Add-Member -NotePropertyName "Year" -NotePropertyValue $year -Force
+                        }
+                    }
+
+                    $hostedRatingImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "ratingImage"
+                    if ([string]::IsNullOrWhiteSpace($hostedRatingImage)) {
+                        $hostedRatingImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "rating_image"
+                    }
+                    $hostedAudienceImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audienceRatingImage"
+                    if ([string]::IsNullOrWhiteSpace($hostedAudienceImage)) {
+                        $hostedAudienceImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating_image"
+                    }
+                    $hostedRating = Get-OptionalStringProperty -InputObject $hostedMeta -Name "rating"
+                    $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audienceRating"
+                    if ([string]::IsNullOrWhiteSpace($hostedAudience)) {
+                        $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating"
+                    }
+
+                    if ([string]::IsNullOrWhiteSpace($critic) -and
+                        $hostedRatingImage -like 'rottentomatoes://image.rating.*') {
+                        $critic = Convert-DesignRatingPercent $hostedRating
+                        $criticImage = $hostedRatingImage
+                    }
+                    if ([string]::IsNullOrWhiteSpace($audience) -and
+                        $hostedAudienceImage -like 'rottentomatoes://image.rating.*') {
+                        $audience = Convert-DesignRatingPercent $hostedAudience
+                        $audienceImageState = $hostedAudienceImage
+                    }
+
+                    if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
+                        foreach ($ratingEntry in @($hostedMeta.Rating)) {
+                            $image = Get-OptionalStringProperty -InputObject $ratingEntry -Name "image"
+                            $type = Get-OptionalStringProperty -InputObject $ratingEntry -Name "type"
+                            $value = Get-OptionalStringProperty -InputObject $ratingEntry -Name "value"
+
+                            if ([string]::IsNullOrWhiteSpace($critic) -and
+                                $image -like 'rottentomatoes://image.rating.*' -and
+                                $type -eq "critic") {
+                                $critic = Convert-DesignRatingPercent $value
+                                $criticImage = $image
+                            }
+                            if ([string]::IsNullOrWhiteSpace($audience) -and
+                                $image -like 'rottentomatoes://image.rating.*' -and
+                                $type -eq "audience") {
+                                $audience = Convert-DesignRatingPercent $value
+                                $audienceImageState = $image
+                            }
+                        }
+                    }
+                }
+            }
+            catch {
+                Write-Log "Plex hosted enrichment failed for deleted $mediaType history metadata: $($_.Exception.Message)" "WARN"
             }
         }
 
@@ -3919,8 +4057,247 @@ function Get-DesignHeroAssets {
     return $result
 }
 
+function Get-PlexMetadataProviderBaseUrl {
+    $defaultUrl = "https://metadata.provider.plex.tv"
+    $testUrl = [string]$env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL
+    if ([string]::IsNullOrWhiteSpace($testUrl)) { return $defaultUrl }
+
+    try {
+        $uri = [Uri]$testUrl
+        if ($uri.IsLoopback -and $uri.Scheme -in @("http", "https")) {
+            return $testUrl.TrimEnd("/")
+        }
+    }
+    catch { }
+
+    return $defaultUrl
+}
+
+function Get-PlexHostedMetadataLookupPath {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType
+    )
+
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return "" }
+
+    $guid = $MetadataGuid.Trim()
+    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9]+)(?:\?.*)?$') {
+        return "/library/metadata/" + [Uri]::EscapeDataString([string]$Matches.id)
+    }
+
+    $externalGuid = ""
+    if ($guid -match '(?i)^(?:tmdb|imdb)://[^/?]+(?:\?.*)?$') {
+        $externalGuid = $guid -replace '\?.*$', ''
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.themoviedb://(?<id>[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "tmdb://" + [string]$Matches.id
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "imdb://" + [string]$Matches.id
+    }
+
+    if ([string]::IsNullOrWhiteSpace($externalGuid)) { return "" }
+
+    $providerType = if ($MediaType -eq "movie") { 1 } else { 2 }
+    return "/library/metadata/matches?guid=" +
+        [Uri]::EscapeDataString($externalGuid) +
+        "&type=" + $providerType
+}
+
+function Get-PlexHostedMetadata {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType
+    )
+
+    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ([string]::IsNullOrWhiteSpace($lookupPath)) { return $null }
+
+    $cacheKey = $MediaType + ":" + $MetadataGuid
+    if ($script:PlexHostedMetadataCache.ContainsKey($cacheKey)) {
+        return $script:PlexHostedMetadataCache[$cacheKey]
+    }
+
+    $ctx = Get-DesignPlexContext
+    $token = Get-OptionalStringProperty -InputObject $ctx -Name "Token"
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        $script:PlexHostedMetadataCache[$cacheKey] = $null
+        return $null
+    }
+
+    $headers = @{
+        "Accept"                   = "application/json"
+        "X-Plex-Token"             = $token
+        "X-Plex-Product"           = "TautWeekly for Plex"
+        "X-Plex-Version"           = "0.7.0"
+        "X-Plex-Client-Identifier" = "tautweekly-history-artwork"
+    }
+
+    $metadata = $null
+    try {
+        $raw = Invoke-RestMethod `
+            -Uri ((Get-PlexMetadataProviderBaseUrl) + $lookupPath) `
+            -Headers $headers `
+            -Method Get `
+            -TimeoutSec 60
+
+        if ($null -ne $raw -and $null -ne $raw.PSObject.Properties["MediaContainer"]) {
+            $container = $raw.MediaContainer
+            if ($null -ne $container.PSObject.Properties["Metadata"]) {
+                $rows = @($container.Metadata)
+                if ($rows.Count -gt 0) { $metadata = $rows[0] }
+            }
+        }
+    }
+    catch {
+        Write-Log "Plex hosted metadata fallback failed for deleted $MediaType history metadata: $($_.Exception.Message)" "WARN"
+    }
+
+    if ($null -ne $metadata -and $MediaType -eq "show") {
+        $resolvedType = Get-OptionalStringProperty -InputObject $metadata -Name "type"
+        if ($resolvedType -ne "show") {
+            $showGuid = if ($resolvedType -eq "season") {
+                Get-OptionalStringProperty -InputObject $metadata -Name "parentGuid"
+            }
+            else {
+                Get-OptionalStringProperty -InputObject $metadata -Name "grandparentGuid"
+            }
+            if ([string]::IsNullOrWhiteSpace($showGuid)) {
+                $showGuid = if ($resolvedType -eq "season") {
+                    Get-OptionalStringProperty -InputObject $metadata -Name "parent_guid"
+                }
+                else {
+                    Get-OptionalStringProperty -InputObject $metadata -Name "grandparent_guid"
+                }
+            }
+            if (-not [string]::IsNullOrWhiteSpace($showGuid) -and $showGuid -ne $MetadataGuid) {
+                $showMetadata = Get-PlexHostedMetadata -MetadataGuid $showGuid -MediaType "show"
+                if ($null -ne $showMetadata) { $metadata = $showMetadata }
+            }
+        }
+    }
+
+    $script:PlexHostedMetadataCache[$cacheKey] = $metadata
+    return $metadata
+}
+
+function Get-PlexHostedPosterPath {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType,
+        [string]$DestinationPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid) -or
+        [string]::IsNullOrWhiteSpace($DestinationPath)) {
+        return ""
+    }
+
+    $metadata = Get-PlexHostedMetadata -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ($null -eq $metadata) { return "" }
+
+    $fieldNames = if ($MediaType -eq "show") {
+        @("thumb", "grandparentThumb", "grandparent_thumb", "parentThumb", "parent_thumb")
+    }
+    else {
+        @("thumb")
+    }
+
+    $posterUrl = ""
+    foreach ($fieldName in $fieldNames) {
+        $posterUrl = Get-OptionalStringProperty -InputObject $metadata -Name $fieldName
+        if (-not [string]::IsNullOrWhiteSpace($posterUrl)) { break }
+    }
+    if ([string]::IsNullOrWhiteSpace($posterUrl)) { return "" }
+
+    $providerBaseUrl = Get-PlexMetadataProviderBaseUrl
+    $assetUrl = $posterUrl
+    $headers = @{}
+
+    try {
+        if ($posterUrl.StartsWith("/")) {
+            $assetUrl = $providerBaseUrl + $posterUrl
+            $headers["X-Plex-Token"] = [string](Get-DesignPlexContext).Token
+        }
+        else {
+            $assetUri = [Uri]$posterUrl
+            if ($assetUri.Scheme -notin @("http", "https")) { return "" }
+
+            $providerUri = [Uri]$providerBaseUrl
+            if ($assetUri.Scheme -ieq $providerUri.Scheme -and
+                $assetUri.Host -ieq $providerUri.Host -and
+                $assetUri.Port -eq $providerUri.Port) {
+                $headers["X-Plex-Token"] = [string](Get-DesignPlexContext).Token
+            }
+        }
+
+        if ($headers.Count -gt 0) {
+            Invoke-WebRequest -Uri $assetUrl -Headers $headers -OutFile $DestinationPath -TimeoutSec 60 | Out-Null
+        }
+        else {
+            Invoke-WebRequest -Uri $assetUrl -OutFile $DestinationPath -TimeoutSec 60 | Out-Null
+        }
+
+        if ((Test-Path $DestinationPath) -and (Get-Item $DestinationPath).Length -gt 512) {
+            Write-Log "Recovered deleted Plex $MediaType history artwork from its retained metadata GUID."
+            return $DestinationPath
+        }
+    }
+    catch {
+        Write-Log "Plex hosted poster download failed for deleted $MediaType history artwork: $($_.Exception.Message)" "WARN"
+    }
+
+    Remove-Item $DestinationPath -Force -ErrorAction SilentlyContinue
+    return ""
+}
+
+function Get-TautulliDefaultPosterHash {
+    if (-not [string]::IsNullOrWhiteSpace($script:TautulliDefaultPosterHash)) {
+        return $script:TautulliDefaultPosterHash
+    }
+
+    $probePath = Join-Path $PosterDir (".tautulli-default-poster-" + [Guid]::NewGuid().ToString("N"))
+    try {
+        $uri = Build-TautulliUri -Command "pms_image_proxy" -Parameters @{
+            fallback = "poster"
+        }
+        Invoke-WebRequest -Uri $uri -OutFile $probePath -TimeoutSec 60 | Out-Null
+        if ((Test-Path $probePath) -and (Get-Item $probePath).Length -gt 0) {
+            $script:TautulliDefaultPosterHash = (Get-FileHash -Path $probePath -Algorithm SHA256).Hash
+        }
+    }
+    catch {
+        Write-Log "Could not fingerprint Tautulli's generic poster fallback: $($_.Exception.Message)" "WARN"
+    }
+    finally {
+        Remove-Item $probePath -Force -ErrorAction SilentlyContinue
+    }
+
+    return $script:TautulliDefaultPosterHash
+}
+
+function Test-IsTautulliDefaultPoster {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path $Path)) { return $false }
+
+    $defaultHash = Get-TautulliDefaultPosterHash
+    if ([string]::IsNullOrWhiteSpace($defaultHash)) { return $false }
+
+    return ((Get-FileHash -Path $Path -Algorithm SHA256).Hash -eq $defaultHash)
+}
+
 function Get-PosterPath {
-    param([string]$RatingKey)
+    param(
+        [string]$RatingKey,
+        [string]$MetadataGuid = "",
+        [ValidateSet("movie", "show")]
+        [string]$MediaType = "movie"
+    )
 
     if ([string]::IsNullOrWhiteSpace($RatingKey)) { return "" }
 
@@ -3928,7 +4305,13 @@ function Get-PosterPath {
     $path = Join-Path $PosterDir ($cid + ".jpg")
 
     if (Test-Path $path) {
-        if ((Get-Item $path).Length -gt 512) { return $path }
+        if ((Get-Item $path).Length -gt 512) {
+            $isCachedGenericFallback = (
+                -not [string]::IsNullOrWhiteSpace($MetadataGuid) -and
+                (Test-IsTautulliDefaultPoster -Path $path)
+            )
+            if (-not $isCachedGenericFallback) { return $path }
+        }
         Remove-Item $path -Force -ErrorAction SilentlyContinue
     }
 
@@ -3943,7 +4326,13 @@ function Get-PosterPath {
     try {
         Invoke-WebRequest -Uri $uri -OutFile $path -TimeoutSec 60 | Out-Null
         if ((Test-Path $path) -and (Get-Item $path).Length -gt 512) {
-            return $path
+            $isGenericFallback = (
+                -not [string]::IsNullOrWhiteSpace($MetadataGuid) -and
+                (Test-IsTautulliDefaultPoster -Path $path)
+            )
+            if (-not $isGenericFallback) { return $path }
+
+            Write-Log "Tautulli returned its generic poster for deleted Plex $MediaType history; trying the retained metadata GUID."
         }
     }
     catch {
@@ -3951,6 +4340,12 @@ function Get-PosterPath {
     }
 
     Remove-Item $path -Force -ErrorAction SilentlyContinue
+    $hostedPath = Get-PlexHostedPosterPath `
+        -MetadataGuid $MetadataGuid `
+        -MediaType $MediaType `
+        -DestinationPath $path
+    if (-not [string]::IsNullOrWhiteSpace($hostedPath)) { return $hostedPath }
+
     return ""
 }
 
@@ -3968,7 +4363,7 @@ function Prepare-PosterAssets {
 
     if (-not [string]::IsNullOrWhiteSpace($FeaturedRatingKey)) {
         $featured = @(
-            @($ReleaseData.Movies) + @($ReleaseData.TV) |
+            @($ReleaseData.Movies) + @($ReleaseData.TV) + @($AdditionalItems) |
             Where-Object { [string]$_.PosterRatingKey -eq $FeaturedRatingKey } |
             Select-Object -First 1
         )
@@ -4005,7 +4400,14 @@ function Prepare-PosterAssets {
         if ([string]::IsNullOrWhiteSpace($rk) -or $seen.ContainsKey($rk)) { continue }
 
         $seen[$rk] = $true
-        $path = Get-PosterPath -RatingKey $rk
+        $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $mediaType = Get-OptionalStringProperty -InputObject $item -Name "Type"
+        if ($mediaType -ne "show") { $mediaType = "movie" }
+
+        $path = Get-PosterPath `
+            -RatingKey $rk `
+            -MetadataGuid $metadataGuid `
+            -MediaType $mediaType
         if (-not [string]::IsNullOrWhiteSpace($path)) {
             $assets.Add([PSCustomObject]@{
                 RatingKey = $rk
@@ -6204,6 +6606,8 @@ if ($null -ne $script:GlobalTrendingStat -and
     -not [string]::IsNullOrWhiteSpace([string]$script:GlobalTrendingStat.RatingKey)) {
     $trendingPosterItem = [PSCustomObject]@{
         PosterRatingKey = [string]$script:GlobalTrendingStat.RatingKey
+        MetadataGuid    = Get-OptionalStringProperty -InputObject $script:GlobalTrendingStat -Name "MetadataGuid"
+        Type            = [string]$script:GlobalTrendingStat.Type
     }
 }
 

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID
 - treats sparse Tautulli hero metadata as optional during previews and test sends
 - accepts selected-library recently-added rows when Plex omits the redundant section ID
 - limits HOT NEW RELEASE to movies and falls back to Trending when no new movie exists

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -3438,14 +3438,15 @@ function Add-DesignRatingMetadata {
     foreach ($item in $all) {
         $critic = ""
         $audience = ""
+        $imdb = ""
         $criticImage = ""
         $audienceImageState = ""
         $genres = @()
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
-        # Primary source for the newsletter: Tautulli already exposes the
-        # selected Plex critic and audience scores plus their provider IDs.
+        # Primary source for the newsletter: Tautulli already exposes selected
+        # movie RT and TV IMDb scores plus their provider IDs.
         try {
             $meta = Invoke-TautulliApi -Command "get_metadata" -Parameters @{
                 rating_key = $ratingKey
@@ -3469,38 +3470,44 @@ function Add-DesignRatingMetadata {
                 }
             }
 
-            if ([string]$item.Type -eq "movie") {
-                if ($null -ne $meta.PSObject.Properties["genres"]) {
-                    $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
-                }
-                elseif ($null -ne $meta.PSObject.Properties["genre"]) {
-                    $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
-                }
+            if ($null -ne $meta.PSObject.Properties["genres"]) {
+                $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+            }
+            elseif ($null -ne $meta.PSObject.Properties["genre"]) {
+                $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
             }
 
-            if ($ratingImage -like 'rottentomatoes://image.rating.*') {
-                $critic = Convert-DesignRatingPercent $ratingValue
-                $criticImage = $ratingImage
+            if ($mediaType -eq "movie") {
+                if ($ratingImage -like 'rottentomatoes://image.rating.*') {
+                    $critic = Convert-DesignRatingPercent $ratingValue
+                    $criticImage = $ratingImage
+                }
+                if ($audienceImage -like 'rottentomatoes://image.rating.*') {
+                    $audience = Convert-DesignRatingPercent $audienceRatingValue
+                    $audienceImageState = $audienceImage
+                }
             }
-
-            if ($audienceImage -like 'rottentomatoes://image.rating.*') {
-                $audience = Convert-DesignRatingPercent $audienceRatingValue
-                $audienceImageState = $audienceImage
+            elseif ($ratingImage -like 'imdb://image.rating*') {
+                $imdb = $ratingValue
             }
         }
         catch {
-            Write-Log "TautWeekly for Plex Tautulli RT lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
+            Write-Log "TautWeekly for Plex Tautulli rating/metadata lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
         }
 
         # Optional secondary source: Plex's full Rating[] if direct access
         # happens to be available on this install.
-        if ([string]::IsNullOrWhiteSpace($critic) -or
-            [string]::IsNullOrWhiteSpace($audience)) {
+        $needsDirectRatings = if ($mediaType -eq "movie") {
+            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+        }
+        else {
+            [string]::IsNullOrWhiteSpace($imdb)
+        }
+        if ($needsDirectRatings) {
             try {
                 $plexMeta = Get-DesignPlexMetadata -RatingKey $ratingKey
 
                 if ($null -ne $plexMeta -and
-                    [string]$item.Type -eq "movie" -and
                     $genres.Count -eq 0 -and
                     $null -ne $plexMeta.PSObject.Properties["Genre"]) {
                     $genres = @(ConvertTo-DesignGenreList -Value $plexMeta.Genre)
@@ -3524,14 +3531,22 @@ function Add-DesignRatingMetadata {
                             $value = $ratingEntry.value
                         }
 
-                        if ([string]::IsNullOrWhiteSpace($critic) -and
+                        if ($mediaType -eq "show" -and
+                            [string]::IsNullOrWhiteSpace($imdb) -and
+                            $image -like "imdb://image.rating*") {
+                            $imdb = [string]$value
+                        }
+
+                        if ($mediaType -eq "movie" -and
+                            [string]::IsNullOrWhiteSpace($critic) -and
                             $image -like "rottentomatoes://image.rating.*" -and
                             $type -eq "critic") {
                             $critic = Convert-DesignRatingPercent $value
                             $criticImage = $image
                         }
 
-                        if ([string]::IsNullOrWhiteSpace($audience) -and
+                        if ($mediaType -eq "movie" -and
+                            [string]::IsNullOrWhiteSpace($audience) -and
                             $image -like "rottentomatoes://image.rating.*" -and
                             $type -eq "audience") {
                             $audience = Convert-DesignRatingPercent $value
@@ -3550,11 +3565,16 @@ function Add-DesignRatingMetadata {
         # administrator-authorized Plex token, resolve only that identifier
         # against Plex's hosted metadata service; never search by title.
         $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $needsHostedRating = if ($mediaType -eq "movie") {
+            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+        }
+        else {
+            [string]::IsNullOrWhiteSpace($imdb)
+        }
         $needsHostedMetadata = (
             -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
             ($genres.Count -eq 0 -or
-             [string]::IsNullOrWhiteSpace($critic) -or
-             [string]::IsNullOrWhiteSpace($audience) -or
+             $needsHostedRating -or
              [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary")) -or
              [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year")))
         )
@@ -3599,15 +3619,22 @@ function Add-DesignRatingMetadata {
                         $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating"
                     }
 
-                    if ([string]::IsNullOrWhiteSpace($critic) -and
+                    if ($mediaType -eq "movie" -and
+                        [string]::IsNullOrWhiteSpace($critic) -and
                         $hostedRatingImage -like 'rottentomatoes://image.rating.*') {
                         $critic = Convert-DesignRatingPercent $hostedRating
                         $criticImage = $hostedRatingImage
                     }
-                    if ([string]::IsNullOrWhiteSpace($audience) -and
+                    if ($mediaType -eq "movie" -and
+                        [string]::IsNullOrWhiteSpace($audience) -and
                         $hostedAudienceImage -like 'rottentomatoes://image.rating.*') {
                         $audience = Convert-DesignRatingPercent $hostedAudience
                         $audienceImageState = $hostedAudienceImage
+                    }
+                    if ($mediaType -eq "show" -and
+                        [string]::IsNullOrWhiteSpace($imdb) -and
+                        $hostedRatingImage -like 'imdb://image.rating*') {
+                        $imdb = $hostedRating
                     }
 
                     if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
@@ -3616,13 +3643,20 @@ function Add-DesignRatingMetadata {
                             $type = Get-OptionalStringProperty -InputObject $ratingEntry -Name "type"
                             $value = Get-OptionalStringProperty -InputObject $ratingEntry -Name "value"
 
-                            if ([string]::IsNullOrWhiteSpace($critic) -and
+                            if ($mediaType -eq "show" -and
+                                [string]::IsNullOrWhiteSpace($imdb) -and
+                                $image -like 'imdb://image.rating*') {
+                                $imdb = $value
+                            }
+                            if ($mediaType -eq "movie" -and
+                                [string]::IsNullOrWhiteSpace($critic) -and
                                 $image -like 'rottentomatoes://image.rating.*' -and
                                 $type -eq "critic") {
                                 $critic = Convert-DesignRatingPercent $value
                                 $criticImage = $image
                             }
-                            if ([string]::IsNullOrWhiteSpace($audience) -and
+                            if ($mediaType -eq "movie" -and
+                                [string]::IsNullOrWhiteSpace($audience) -and
                                 $image -like 'rottentomatoes://image.rating.*' -and
                                 $type -eq "audience") {
                                 $audience = Convert-DesignRatingPercent $value
@@ -3637,9 +3671,8 @@ function Add-DesignRatingMetadata {
             }
         }
 
-        # Last resort: rich exporter for movies only. TV cards use episode
-        # IMDb enrichment instead; show/season RT exporter requests are noisy
-        # and are not needed for the approved email design.
+        # Last resort: rich exporter for movies only. TV shows and episodes use
+        # IMDb values directly; show/season RT exporter requests are not needed.
         if ([string]$item.Type -eq "movie" -and
             ([string]::IsNullOrWhiteSpace($critic) -or
              [string]::IsNullOrWhiteSpace($audience))) {
@@ -3657,14 +3690,20 @@ function Add-DesignRatingMetadata {
             }
         }
 
-        Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
-            $item.Title,
-            $(if ($critic) { $critic + "%" } else { "n/a" }),
-            $(if ($audience) { $audience } else { "n/a" })
-        )
+        if ($mediaType -eq "show") {
+            Write-Log ("Design ratings: {0} -> IMDb {1}" -f $item.Title, $(if ($imdb) { $imdb } else { "n/a" }))
+        }
+        else {
+            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
+                $item.Title,
+                $(if ($critic) { $critic + "%" } else { "n/a" }),
+                $(if ($audience) { $audience } else { "n/a" })
+            )
+        }
 
         $item | Add-Member -NotePropertyName "DesignRtCritic" -NotePropertyValue $critic -Force
         $item | Add-Member -NotePropertyName "DesignRtAudience" -NotePropertyValue $audience -Force
+        $item | Add-Member -NotePropertyName "DesignImdbRating" -NotePropertyValue $imdb -Force
         $item | Add-Member -NotePropertyName "DesignRtCriticImage" -NotePropertyValue $criticImage -Force
         $item | Add-Member -NotePropertyName "DesignRtAudienceImage" -NotePropertyValue $audienceImageState -Force
         $item | Add-Member -NotePropertyName "DesignGenres" -NotePropertyValue @($genres) -Force
@@ -3731,6 +3770,18 @@ function Get-DesignRatingLine {
         $pieces.Add(
             '<span class="design-rating-year">' +
             (HtmlEncode ([string]$Item.Year)) +
+            '</span>'
+        )
+    }
+
+    $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
+    if ([string]$Item.Type -eq "show" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+        $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
+        $pieces.Add(
+            '<span class="design-rating-item">' +
+            '<img src="' + (HtmlEncode $imdbIcon) + '" alt="IMDb" ' +
+            'width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
+            (HtmlEncode $imdb) +
             '</span>'
         )
     }

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -45,6 +45,8 @@ $LogFile = Join-Path $LogDir ("tautweekly_{0}.log" -f (Get-Date -Format "yyyyMMd
 # them inside Get-DesignPlexContext / Get-DesignPlexMetadata.
 $script:DesignPlexContext = $null
 $script:DesignPlexMetadataCache = @{}
+$script:PlexHostedMetadataCache = @{}
+$script:TautulliDefaultPosterHash = ""
 
 function Write-Log {
     param(
@@ -650,18 +652,24 @@ function New-ReleaseData {
     $tvMap = @{}
 
     foreach ($item in $RecentItems) {
-        $type = ([string]$item.media_type).ToLowerInvariant()
+        $type = (Get-OptionalStringProperty -InputObject $item -Name "media_type").ToLowerInvariant()
 
         if ($type -eq "movie") {
+            $ratingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+            $rating = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+            if ([string]::IsNullOrWhiteSpace($rating)) {
+                $rating = Get-OptionalStringProperty -InputObject $item -Name "rating"
+            }
             $movieList.Add([PSCustomObject]@{
                 Type            = "movie"
-                ReleaseKey      = "movie:" + [string]$item.rating_key
-                RatingKey       = [string]$item.rating_key
-                PosterRatingKey = [string]$item.rating_key
-                Title           = [string]$item.title
-                Year            = [string]$item.year
-                Rating          = if ([string]$item.audience_rating) { [string]$item.audience_rating } else { [string]$item.rating }
-                Summary         = [string]$item.summary
+                ReleaseKey      = "movie:" + $ratingKey
+                RatingKey       = $ratingKey
+                PosterRatingKey = $ratingKey
+                MetadataGuid    = Get-OptionalStringProperty -InputObject $item -Name "guid"
+                Title           = Get-OptionalStringProperty -InputObject $item -Name "title"
+                Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
+                Rating          = $rating
+                Summary         = Get-OptionalStringProperty -InputObject $item -Name "summary"
                 AddedAt         = Safe-Int64 $item.added_at
                 EpisodeCount    = 0
                 SeasonCount     = 0
@@ -677,20 +685,20 @@ function New-ReleaseData {
             $posterRatingKey = ""
 
             if ($type -eq "show") {
-                $showRatingKey = [string]$item.rating_key
-                $showTitle = [string]$item.title
-                $posterRatingKey = [string]$item.rating_key
+                $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+                $showTitle = Get-OptionalStringProperty -InputObject $item -Name "title"
+                $posterRatingKey = $showRatingKey
             }
             else {
-                $showRatingKey = [string]$item.grandparent_rating_key
-                $showTitle = [string]$item.grandparent_title
-                $posterRatingKey = [string]$item.grandparent_rating_key
+                $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "grandparent_rating_key"
+                $showTitle = Get-OptionalStringProperty -InputObject $item -Name "grandparent_title"
+                $posterRatingKey = $showRatingKey
                 if ([string]::IsNullOrWhiteSpace($showTitle)) {
-                    $showTitle = [string]$item.title
+                    $showTitle = Get-OptionalStringProperty -InputObject $item -Name "title"
                 }
                 if ([string]::IsNullOrWhiteSpace($showRatingKey)) {
-                    $showRatingKey = [string]$item.rating_key
-                    $posterRatingKey = [string]$item.rating_key
+                    $showRatingKey = Get-OptionalStringProperty -InputObject $item -Name "rating_key"
+                    $posterRatingKey = $showRatingKey
                 }
             }
 
@@ -706,8 +714,9 @@ function New-ReleaseData {
                     ReleaseKey      = $mapKey
                     RatingKey       = $showRatingKey
                     PosterRatingKey = $posterRatingKey
+                    MetadataGuid    = Get-OptionalStringProperty -InputObject $item -Name "guid"
                     Title           = $showTitle
-                    Year            = [string]$item.year
+                    Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
                     Rating          = ""
                     Summary         = ""
                     AddedAt         = Safe-Int64 $item.added_at
@@ -719,6 +728,9 @@ function New-ReleaseData {
             }
 
             $entry = $tvMap[$mapKey]
+            if ([string]::IsNullOrWhiteSpace([string]$entry.MetadataGuid)) {
+                $entry.MetadataGuid = Get-OptionalStringProperty -InputObject $item -Name "guid"
+            }
             if ((Safe-Int64 $item.added_at) -gt $entry.AddedAt) {
                 $entry.AddedAt = Safe-Int64 $item.added_at
             }
@@ -1291,11 +1303,16 @@ function Get-UserStats {
                         Type            = "movie"
                         RatingKey       = $ratingKey
                         PosterRatingKey = $ratingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         Title           = $title
-                        Year            = [string]$row.year
+                        Summary         = ""
+                        Year            = Get-OptionalStringProperty -InputObject $row -Name "year"
                         Plays           = 0
                         Seconds         = [int64]0
                     }
+                }
+                if ([string]::IsNullOrWhiteSpace([string]$movieItemTotals[$dedupeKey].MetadataGuid)) {
+                    $movieItemTotals[$dedupeKey].MetadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
                 }
                 $movieItemTotals[$dedupeKey].Plays += (Get-HistoryRowPlayCount -Row $row)
                 $movieItemTotals[$dedupeKey].Seconds += $seconds
@@ -1338,12 +1355,18 @@ function Get-UserStats {
                         Type            = "show"
                         RatingKey       = $showRatingKey
                         PosterRatingKey = $showRatingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         Title           = $showTitle
                         ShowTitle       = $showTitle
+                        Summary         = ""
+                        Year            = Get-OptionalStringProperty -InputObject $row -Name "year"
                         Plays           = 0
                         Seconds         = [int64]0
                         TotalTimeText   = ""
                     }
+                }
+                if ([string]::IsNullOrWhiteSpace([string]$tvShowTotals[$showDedupeKey].MetadataGuid)) {
+                    $tvShowTotals[$showDedupeKey].MetadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
                 }
                 $tvShowTotals[$showDedupeKey].Plays += (Get-HistoryRowPlayCount -Row $row)
                 $tvShowTotals[$showDedupeKey].Seconds += $seconds
@@ -1371,6 +1394,7 @@ function Get-UserStats {
                         Type            = "episode"
                         RatingKey       = $ratingKey
                         PosterRatingKey = $showRatingKey
+                        MetadataGuid    = Get-OptionalStringProperty -InputObject $row -Name "guid"
                         ShowTitle       = $showTitle
                         EpisodeTitle    = $episodeTitle
                         Season          = Safe-Int $row.parent_media_index
@@ -1534,6 +1558,7 @@ function Get-GlobalTitleTotals {
         $key = ""
         $ratingKey = ""
         $titleType = ""
+        $metadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
 
         if ($type -eq "movie") {
             $title = [string]$row.title
@@ -1562,9 +1587,15 @@ function Get-GlobalTitleTotals {
                 Title     = $title
                 Type      = $titleType
                 RatingKey = $ratingKey
+                MetadataGuid = $metadataGuid
                 Seconds   = [int64]0
                 Plays     = 0
             }
+        }
+
+        if ([string]::IsNullOrWhiteSpace([string]$totals[$key].MetadataGuid) -and
+            -not [string]::IsNullOrWhiteSpace($metadataGuid)) {
+            $totals[$key].MetadataGuid = $metadataGuid
         }
 
         $totals[$key].Seconds += $seconds
@@ -1635,6 +1666,7 @@ function New-HeroItemFromGlobalStat {
         ReleaseKey      = [string]$Stat.Key
         RatingKey       = [string]$Stat.RatingKey
         PosterRatingKey = $posterRatingKey
+        MetadataGuid    = Get-OptionalStringProperty -InputObject $Stat -Name "MetadataGuid"
         Title           = $title
         Year            = $year
         Rating          = ""
@@ -3410,6 +3442,7 @@ function Add-DesignRatingMetadata {
         $audienceImageState = ""
         $genres = @()
         $ratingKey = [string]$item.RatingKey
+        $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
         # Primary source for the newsletter: Tautulli already exposes the
         # selected Plex critic and audience scores plus their provider IDs.
@@ -3422,6 +3455,19 @@ function Add-DesignRatingMetadata {
             $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+
+            if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
+                $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+                if (-not [string]::IsNullOrWhiteSpace($summary)) {
+                    $item | Add-Member -NotePropertyName "Summary" -NotePropertyValue $summary -Force
+                }
+            }
+            if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year"))) {
+                $year = Get-OptionalStringProperty -InputObject $meta -Name "year"
+                if (-not [string]::IsNullOrWhiteSpace($year)) {
+                    $item | Add-Member -NotePropertyName "Year" -NotePropertyValue $year -Force
+                }
+            }
 
             if ([string]$item.Type -eq "movie") {
                 if ($null -ne $meta.PSObject.Properties["genres"]) {
@@ -3496,6 +3542,98 @@ function Add-DesignRatingMetadata {
             }
             catch {
                 Write-Log "TautWeekly for Plex optional direct Plex rating lookup failed for $($item.Title): $($_.Exception.Message)" "WARN"
+            }
+        }
+
+        # A deleted library item can no longer be expanded by the local PMS,
+        # but Tautulli history retains its exact Plex metadata GUID. With the
+        # administrator-authorized Plex token, resolve only that identifier
+        # against Plex's hosted metadata service; never search by title.
+        $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $needsHostedMetadata = (
+            -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
+            ($genres.Count -eq 0 -or
+             [string]::IsNullOrWhiteSpace($critic) -or
+             [string]::IsNullOrWhiteSpace($audience) -or
+             [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary")) -or
+             [string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year")))
+        )
+
+        if ($needsHostedMetadata) {
+            try {
+                $hostedMeta = Get-PlexHostedMetadata -MetadataGuid $metadataGuid -MediaType $mediaType
+                if ($null -ne $hostedMeta) {
+                    if ($genres.Count -eq 0) {
+                        if ($null -ne $hostedMeta.PSObject.Properties["Genre"]) {
+                            $genres = @(ConvertTo-DesignGenreList -Value $hostedMeta.Genre)
+                        }
+                        elseif ($null -ne $hostedMeta.PSObject.Properties["genres"]) {
+                            $genres = @(ConvertTo-DesignGenreList -Value $hostedMeta.genres)
+                        }
+                    }
+
+                    if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
+                        $summary = Get-OptionalStringProperty -InputObject $hostedMeta -Name "summary"
+                        if (-not [string]::IsNullOrWhiteSpace($summary)) {
+                            $item | Add-Member -NotePropertyName "Summary" -NotePropertyValue $summary -Force
+                        }
+                    }
+                    if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Year"))) {
+                        $year = Get-OptionalStringProperty -InputObject $hostedMeta -Name "year"
+                        if (-not [string]::IsNullOrWhiteSpace($year)) {
+                            $item | Add-Member -NotePropertyName "Year" -NotePropertyValue $year -Force
+                        }
+                    }
+
+                    $hostedRatingImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "ratingImage"
+                    if ([string]::IsNullOrWhiteSpace($hostedRatingImage)) {
+                        $hostedRatingImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "rating_image"
+                    }
+                    $hostedAudienceImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audienceRatingImage"
+                    if ([string]::IsNullOrWhiteSpace($hostedAudienceImage)) {
+                        $hostedAudienceImage = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating_image"
+                    }
+                    $hostedRating = Get-OptionalStringProperty -InputObject $hostedMeta -Name "rating"
+                    $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audienceRating"
+                    if ([string]::IsNullOrWhiteSpace($hostedAudience)) {
+                        $hostedAudience = Get-OptionalStringProperty -InputObject $hostedMeta -Name "audience_rating"
+                    }
+
+                    if ([string]::IsNullOrWhiteSpace($critic) -and
+                        $hostedRatingImage -like 'rottentomatoes://image.rating.*') {
+                        $critic = Convert-DesignRatingPercent $hostedRating
+                        $criticImage = $hostedRatingImage
+                    }
+                    if ([string]::IsNullOrWhiteSpace($audience) -and
+                        $hostedAudienceImage -like 'rottentomatoes://image.rating.*') {
+                        $audience = Convert-DesignRatingPercent $hostedAudience
+                        $audienceImageState = $hostedAudienceImage
+                    }
+
+                    if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
+                        foreach ($ratingEntry in @($hostedMeta.Rating)) {
+                            $image = Get-OptionalStringProperty -InputObject $ratingEntry -Name "image"
+                            $type = Get-OptionalStringProperty -InputObject $ratingEntry -Name "type"
+                            $value = Get-OptionalStringProperty -InputObject $ratingEntry -Name "value"
+
+                            if ([string]::IsNullOrWhiteSpace($critic) -and
+                                $image -like 'rottentomatoes://image.rating.*' -and
+                                $type -eq "critic") {
+                                $critic = Convert-DesignRatingPercent $value
+                                $criticImage = $image
+                            }
+                            if ([string]::IsNullOrWhiteSpace($audience) -and
+                                $image -like 'rottentomatoes://image.rating.*' -and
+                                $type -eq "audience") {
+                                $audience = Convert-DesignRatingPercent $value
+                                $audienceImageState = $image
+                            }
+                        }
+                    }
+                }
+            }
+            catch {
+                Write-Log "Plex hosted enrichment failed for deleted $mediaType history metadata: $($_.Exception.Message)" "WARN"
             }
         }
 
@@ -3956,8 +4094,247 @@ function Get-DesignHeroAssets {
     return $result
 }
 
+function Get-PlexMetadataProviderBaseUrl {
+    $defaultUrl = "https://metadata.provider.plex.tv"
+    $testUrl = [string]$env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL
+    if ([string]::IsNullOrWhiteSpace($testUrl)) { return $defaultUrl }
+
+    try {
+        $uri = [Uri]$testUrl
+        if ($uri.IsLoopback -and $uri.Scheme -in @("http", "https")) {
+            return $testUrl.TrimEnd("/")
+        }
+    }
+    catch { }
+
+    return $defaultUrl
+}
+
+function Get-PlexHostedMetadataLookupPath {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType
+    )
+
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return "" }
+
+    $guid = $MetadataGuid.Trim()
+    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9]+)(?:\?.*)?$') {
+        return "/library/metadata/" + [Uri]::EscapeDataString([string]$Matches.id)
+    }
+
+    $externalGuid = ""
+    if ($guid -match '(?i)^(?:tmdb|imdb)://[^/?]+(?:\?.*)?$') {
+        $externalGuid = $guid -replace '\?.*$', ''
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.themoviedb://(?<id>[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "tmdb://" + [string]$Matches.id
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "imdb://" + [string]$Matches.id
+    }
+
+    if ([string]::IsNullOrWhiteSpace($externalGuid)) { return "" }
+
+    $providerType = if ($MediaType -eq "movie") { 1 } else { 2 }
+    return "/library/metadata/matches?guid=" +
+        [Uri]::EscapeDataString($externalGuid) +
+        "&type=" + $providerType
+}
+
+function Get-PlexHostedMetadata {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType
+    )
+
+    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ([string]::IsNullOrWhiteSpace($lookupPath)) { return $null }
+
+    $cacheKey = $MediaType + ":" + $MetadataGuid
+    if ($script:PlexHostedMetadataCache.ContainsKey($cacheKey)) {
+        return $script:PlexHostedMetadataCache[$cacheKey]
+    }
+
+    $ctx = Get-DesignPlexContext
+    $token = Get-OptionalStringProperty -InputObject $ctx -Name "Token"
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        $script:PlexHostedMetadataCache[$cacheKey] = $null
+        return $null
+    }
+
+    $headers = @{
+        "Accept"                   = "application/json"
+        "X-Plex-Token"             = $token
+        "X-Plex-Product"           = "TautWeekly for Plex"
+        "X-Plex-Version"           = "0.7.0"
+        "X-Plex-Client-Identifier" = "tautweekly-history-artwork"
+    }
+
+    $metadata = $null
+    try {
+        $raw = Invoke-RestMethod `
+            -Uri ((Get-PlexMetadataProviderBaseUrl) + $lookupPath) `
+            -Headers $headers `
+            -Method Get `
+            -TimeoutSec 60
+
+        if ($null -ne $raw -and $null -ne $raw.PSObject.Properties["MediaContainer"]) {
+            $container = $raw.MediaContainer
+            if ($null -ne $container.PSObject.Properties["Metadata"]) {
+                $rows = @($container.Metadata)
+                if ($rows.Count -gt 0) { $metadata = $rows[0] }
+            }
+        }
+    }
+    catch {
+        Write-Log "Plex hosted metadata fallback failed for deleted $MediaType history metadata: $($_.Exception.Message)" "WARN"
+    }
+
+    if ($null -ne $metadata -and $MediaType -eq "show") {
+        $resolvedType = Get-OptionalStringProperty -InputObject $metadata -Name "type"
+        if ($resolvedType -ne "show") {
+            $showGuid = if ($resolvedType -eq "season") {
+                Get-OptionalStringProperty -InputObject $metadata -Name "parentGuid"
+            }
+            else {
+                Get-OptionalStringProperty -InputObject $metadata -Name "grandparentGuid"
+            }
+            if ([string]::IsNullOrWhiteSpace($showGuid)) {
+                $showGuid = if ($resolvedType -eq "season") {
+                    Get-OptionalStringProperty -InputObject $metadata -Name "parent_guid"
+                }
+                else {
+                    Get-OptionalStringProperty -InputObject $metadata -Name "grandparent_guid"
+                }
+            }
+            if (-not [string]::IsNullOrWhiteSpace($showGuid) -and $showGuid -ne $MetadataGuid) {
+                $showMetadata = Get-PlexHostedMetadata -MetadataGuid $showGuid -MediaType "show"
+                if ($null -ne $showMetadata) { $metadata = $showMetadata }
+            }
+        }
+    }
+
+    $script:PlexHostedMetadataCache[$cacheKey] = $metadata
+    return $metadata
+}
+
+function Get-PlexHostedPosterPath {
+    param(
+        [string]$MetadataGuid,
+        [ValidateSet("movie", "show")]
+        [string]$MediaType,
+        [string]$DestinationPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid) -or
+        [string]::IsNullOrWhiteSpace($DestinationPath)) {
+        return ""
+    }
+
+    $metadata = Get-PlexHostedMetadata -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ($null -eq $metadata) { return "" }
+
+    $fieldNames = if ($MediaType -eq "show") {
+        @("thumb", "grandparentThumb", "grandparent_thumb", "parentThumb", "parent_thumb")
+    }
+    else {
+        @("thumb")
+    }
+
+    $posterUrl = ""
+    foreach ($fieldName in $fieldNames) {
+        $posterUrl = Get-OptionalStringProperty -InputObject $metadata -Name $fieldName
+        if (-not [string]::IsNullOrWhiteSpace($posterUrl)) { break }
+    }
+    if ([string]::IsNullOrWhiteSpace($posterUrl)) { return "" }
+
+    $providerBaseUrl = Get-PlexMetadataProviderBaseUrl
+    $assetUrl = $posterUrl
+    $headers = @{}
+
+    try {
+        if ($posterUrl.StartsWith("/")) {
+            $assetUrl = $providerBaseUrl + $posterUrl
+            $headers["X-Plex-Token"] = [string](Get-DesignPlexContext).Token
+        }
+        else {
+            $assetUri = [Uri]$posterUrl
+            if ($assetUri.Scheme -notin @("http", "https")) { return "" }
+
+            $providerUri = [Uri]$providerBaseUrl
+            if ($assetUri.Scheme -ieq $providerUri.Scheme -and
+                $assetUri.Host -ieq $providerUri.Host -and
+                $assetUri.Port -eq $providerUri.Port) {
+                $headers["X-Plex-Token"] = [string](Get-DesignPlexContext).Token
+            }
+        }
+
+        if ($headers.Count -gt 0) {
+            Invoke-WebRequest -Uri $assetUrl -Headers $headers -OutFile $DestinationPath -TimeoutSec 60 | Out-Null
+        }
+        else {
+            Invoke-WebRequest -Uri $assetUrl -OutFile $DestinationPath -TimeoutSec 60 | Out-Null
+        }
+
+        if ((Test-Path $DestinationPath) -and (Get-Item $DestinationPath).Length -gt 512) {
+            Write-Log "Recovered deleted Plex $MediaType history artwork from its retained metadata GUID."
+            return $DestinationPath
+        }
+    }
+    catch {
+        Write-Log "Plex hosted poster download failed for deleted $MediaType history artwork: $($_.Exception.Message)" "WARN"
+    }
+
+    Remove-Item $DestinationPath -Force -ErrorAction SilentlyContinue
+    return ""
+}
+
+function Get-TautulliDefaultPosterHash {
+    if (-not [string]::IsNullOrWhiteSpace($script:TautulliDefaultPosterHash)) {
+        return $script:TautulliDefaultPosterHash
+    }
+
+    $probePath = Join-Path $PosterDir (".tautulli-default-poster-" + [Guid]::NewGuid().ToString("N"))
+    try {
+        $uri = Build-TautulliUri -Command "pms_image_proxy" -Parameters @{
+            fallback = "poster"
+        }
+        Invoke-WebRequest -Uri $uri -OutFile $probePath -TimeoutSec 60 | Out-Null
+        if ((Test-Path $probePath) -and (Get-Item $probePath).Length -gt 0) {
+            $script:TautulliDefaultPosterHash = (Get-FileHash -Path $probePath -Algorithm SHA256).Hash
+        }
+    }
+    catch {
+        Write-Log "Could not fingerprint Tautulli's generic poster fallback: $($_.Exception.Message)" "WARN"
+    }
+    finally {
+        Remove-Item $probePath -Force -ErrorAction SilentlyContinue
+    }
+
+    return $script:TautulliDefaultPosterHash
+}
+
+function Test-IsTautulliDefaultPoster {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path $Path)) { return $false }
+
+    $defaultHash = Get-TautulliDefaultPosterHash
+    if ([string]::IsNullOrWhiteSpace($defaultHash)) { return $false }
+
+    return ((Get-FileHash -Path $Path -Algorithm SHA256).Hash -eq $defaultHash)
+}
+
 function Get-PosterPath {
-    param([string]$RatingKey)
+    param(
+        [string]$RatingKey,
+        [string]$MetadataGuid = "",
+        [ValidateSet("movie", "show")]
+        [string]$MediaType = "movie"
+    )
 
     if ([string]::IsNullOrWhiteSpace($RatingKey)) { return "" }
 
@@ -3965,7 +4342,13 @@ function Get-PosterPath {
     $path = Join-Path $PosterDir ($cid + ".jpg")
 
     if (Test-Path $path) {
-        if ((Get-Item $path).Length -gt 512) { return $path }
+        if ((Get-Item $path).Length -gt 512) {
+            $isCachedGenericFallback = (
+                -not [string]::IsNullOrWhiteSpace($MetadataGuid) -and
+                (Test-IsTautulliDefaultPoster -Path $path)
+            )
+            if (-not $isCachedGenericFallback) { return $path }
+        }
         Remove-Item $path -Force -ErrorAction SilentlyContinue
     }
 
@@ -3980,7 +4363,13 @@ function Get-PosterPath {
     try {
         Invoke-WebRequest -Uri $uri -OutFile $path -TimeoutSec 60 | Out-Null
         if ((Test-Path $path) -and (Get-Item $path).Length -gt 512) {
-            return $path
+            $isGenericFallback = (
+                -not [string]::IsNullOrWhiteSpace($MetadataGuid) -and
+                (Test-IsTautulliDefaultPoster -Path $path)
+            )
+            if (-not $isGenericFallback) { return $path }
+
+            Write-Log "Tautulli returned its generic poster for deleted Plex $MediaType history; trying the retained metadata GUID."
         }
     }
     catch {
@@ -3988,6 +4377,12 @@ function Get-PosterPath {
     }
 
     Remove-Item $path -Force -ErrorAction SilentlyContinue
+    $hostedPath = Get-PlexHostedPosterPath `
+        -MetadataGuid $MetadataGuid `
+        -MediaType $MediaType `
+        -DestinationPath $path
+    if (-not [string]::IsNullOrWhiteSpace($hostedPath)) { return $hostedPath }
+
     return ""
 }
 
@@ -4005,7 +4400,7 @@ function Prepare-PosterAssets {
 
     if (-not [string]::IsNullOrWhiteSpace($FeaturedRatingKey)) {
         $featured = @(
-            @($ReleaseData.Movies) + @($ReleaseData.TV) |
+            @($ReleaseData.Movies) + @($ReleaseData.TV) + @($AdditionalItems) |
             Where-Object { [string]$_.PosterRatingKey -eq $FeaturedRatingKey } |
             Select-Object -First 1
         )
@@ -4042,7 +4437,14 @@ function Prepare-PosterAssets {
         if ([string]::IsNullOrWhiteSpace($rk) -or $seen.ContainsKey($rk)) { continue }
 
         $seen[$rk] = $true
-        $path = Get-PosterPath -RatingKey $rk
+        $metadataGuid = Get-OptionalStringProperty -InputObject $item -Name "MetadataGuid"
+        $mediaType = Get-OptionalStringProperty -InputObject $item -Name "Type"
+        if ($mediaType -ne "show") { $mediaType = "movie" }
+
+        $path = Get-PosterPath `
+            -RatingKey $rk `
+            -MetadataGuid $metadataGuid `
+            -MediaType $mediaType
         if (-not [string]::IsNullOrWhiteSpace($path)) {
             $assets.Add([PSCustomObject]@{
                 RatingKey = $rk
@@ -6241,6 +6643,8 @@ if ($null -ne $script:GlobalTrendingStat -and
     -not [string]::IsNullOrWhiteSpace([string]$script:GlobalTrendingStat.RatingKey)) {
     $trendingPosterItem = [PSCustomObject]@{
         PosterRatingKey = [string]$script:GlobalTrendingStat.RatingKey
+        MetadataGuid    = Get-OptionalStringProperty -InputObject $script:GlobalTrendingStat -Name "MetadataGuid"
+        Type            = [string]$script:GlobalTrendingStat.Type
     }
 }
 

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -40,7 +40,7 @@ foreach ($engine in $engines) {
         continue
     }
 
-    foreach ($scenario in @('active', 'quiet', 'tv-only', 'optional-hero-metadata')) {
+    foreach ($scenario in @('active', 'quiet', 'tv-only', 'optional-hero-metadata', 'deleted-history-metadata')) {
         $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ('tautweekly-integration-' + [Guid]::NewGuid().ToString('N'))
         $appRoot = Join-Path $tempRoot 'app'
         $dataRoot = Join-Path $tempRoot 'data'
@@ -81,7 +81,7 @@ foreach ($engine in $engines) {
             $baseUrl = (Get-Content $readyFile -Raw).Trim()
 
             $smtpPort = 0
-            if ($scenario -eq 'optional-hero-metadata') {
+            if ($scenario -in @('optional-hero-metadata', 'deleted-history-metadata')) {
                 $smtpPort = Get-FreeTcpPort
                 $smtpServer = Start-Process -FilePath $PythonPath -ArgumentList @(
                     '-u', $fakeSmtp, '--port', [string]$smtpPort,
@@ -111,7 +111,7 @@ foreach ($engine in $engines) {
                 MaxMovies = 4
                 MaxTv = 4
             }
-            if ($scenario -eq 'optional-hero-metadata') {
+            if ($scenario -in @('optional-hero-metadata', 'deleted-history-metadata')) {
                 $configOverrides['SmtpHost'] = '127.0.0.1'
                 $configOverrides['SmtpPort'] = $smtpPort
                 $configOverrides['SmtpEnableSsl'] = $false
@@ -139,10 +139,14 @@ foreach ($engine in $engines) {
 
             $oldDataRoot = $env:TAUTWEEKLY_DATA_DIR
             $oldConfig = $env:TAUTWEEKLY_CONFIG
+            $oldMetadataProvider = $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL
             try {
                 if ($engine.Container) {
                     $env:TAUTWEEKLY_DATA_DIR = $dataRoot
                     $env:TAUTWEEKLY_CONFIG = $configPath
+                }
+                if ($scenario -eq 'deleted-history-metadata') {
+                    $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL = $baseUrl + '/hosted'
                 }
                 $process = Start-Process -FilePath $engine.Host -ArgumentList @(
                     '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $headlessRunner,
@@ -153,6 +157,7 @@ foreach ($engine in $engines) {
             finally {
                 $env:TAUTWEEKLY_DATA_DIR = $oldDataRoot
                 $env:TAUTWEEKLY_CONFIG = $oldConfig
+                $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL = $oldMetadataProvider
             }
 
             if ($process.ExitCode -ne 0) {
@@ -165,7 +170,7 @@ foreach ($engine in $engines) {
             Assert-True ((Get-ChildItem $outputRoot -Filter 'preview-all-*.html').Count -eq 7) "$($engine.Name)/$scenario did not generate all six states plus the index."
             $indexHtml = Get-Content $indexPath -Raw -Encoding UTF8
             $normalHtml = Get-Content $normalPath -Raw -Encoding UTF8
-            $expectedMode = if ($scenario -eq 'quiet') { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
+            $expectedMode = if ($scenario -in @('quiet', 'deleted-history-metadata')) { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
             Assert-True ($indexHtml.Contains($expectedMode)) "$($engine.Name)/$scenario reported the wrong release mode."
             Assert-True ($normalHtml.Contains('Selected Movie')) "$($engine.Name)/$scenario lost the selected movie."
             Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the selected TV show."
@@ -175,13 +180,29 @@ foreach ($engine in $engines) {
             Assert-True ($normalHtml.Contains('1 TV show')) "$($engine.Name)/$scenario lost the unique TV-show breakdown."
             Assert-True (-not $normalHtml.Contains('0 movies')) "$($engine.Name)/$scenario rendered an empty Binge Champion movie category."
             Assert-True (-not $normalHtml.Contains('qualifying plays')) "$($engine.Name)/$scenario retained qualifying-play copy in Total Watched."
-            Assert-True (-not $normalHtml.Contains('TV SHOWS WATCHED')) "$($engine.Name)/$scenario rendered an empty TV stats card."
+            if ($scenario -ne 'deleted-history-metadata') {
+                Assert-True (-not $normalHtml.Contains('TV SHOWS WATCHED')) "$($engine.Name)/$scenario rendered an empty TV stats card."
+            }
 
             if ($scenario -eq 'tv-only') {
                 Assert-True ($normalHtml.Contains('0 NEW MOVIES') -and $normalHtml.Contains('1 TV TITLE')) "$($engine.Name)/$scenario reported the wrong release-title counts."
                 Assert-True ($normalHtml.Contains('TRENDING THIS WEEK')) "$($engine.Name)/$scenario did not promote Trending into the hero."
                 Assert-True (-not $normalHtml.Contains('HOT NEW RELEASE')) "$($engine.Name)/$scenario promoted a TV release as HOT NEW RELEASE."
                 Assert-True (([regex]::Matches($normalHtml, 'Selected Show')).Count -ge 2) "$($engine.Name)/$scenario removed the TV release after using Trending as the hero."
+            }
+
+            if ($scenario -eq 'deleted-history-metadata') {
+                Assert-True ($normalHtml.Contains('TV SHOWS WATCHED')) "$($engine.Name)/$scenario did not render the deleted-history TV stats card."
+                Assert-True ($normalHtml.Contains('Hosted history show summary.')) "$($engine.Name)/$scenario did not restore the deleted TV summary."
+                Assert-True ($normalHtml.Contains('History Drama, Mystery, and more')) "$($engine.Name)/$scenario did not restore deleted movie genres."
+                Assert-True ($normalHtml.Contains('87%') -and $normalHtml.Contains('93%')) "$($engine.Name)/$scenario did not restore deleted movie ratings."
+                Assert-True ($normalHtml.Contains('posters/poster_selected-movie.jpg')) "$($engine.Name)/$scenario did not render the recovered movie poster."
+                Assert-True ($normalHtml.Contains('posters/poster_selected-show.jpg')) "$($engine.Name)/$scenario did not render the recovered TV poster."
+
+                $moviePoster = Join-Path (Join-Path $outputRoot 'posters') 'poster_selected-movie.jpg'
+                $showPoster = Join-Path (Join-Path $outputRoot 'posters') 'poster_selected-show.jpg'
+                Assert-True ((Test-Path $moviePoster) -and (Get-Item $moviePoster).Length -gt 512) "$($engine.Name)/$scenario did not persist the recovered movie poster."
+                Assert-True ((Test-Path $showPoster) -and (Get-Item $showPoster).Length -gt 512) "$($engine.Name)/$scenario did not persist the recovered TV poster."
             }
 
             $calls = @(Get-Content $callLog | ForEach-Object { $_ | ConvertFrom-Json })
@@ -195,7 +216,19 @@ foreach ($engine in $engines) {
                 [string]$_.query.section_id -notin @('10', '20')
             }).Count -eq 0) "$($engine.Name)/$scenario issued an unscoped/private media query."
 
-            if ($scenario -eq 'optional-hero-metadata') {
+            if ($scenario -eq 'deleted-history-metadata') {
+                $hostedCalls = @($calls | Where-Object { [string]$_.path -like '/hosted/library/metadata/*' })
+                Assert-True (@($hostedCalls | Where-Object { -not $_.has_plex_token }).Count -eq 0) "$($engine.Name)/$scenario called hosted metadata without the administrator Plex token."
+                Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedmovieguid' }).Count -gt 0) "$($engine.Name)/$scenario did not resolve the retained movie GUID."
+                Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedepisodeguid' }).Count -gt 0) "$($engine.Name)/$scenario did not resolve the retained episode GUID."
+                Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedshowguid' }).Count -gt 0) "$($engine.Name)/$scenario did not promote the retained episode GUID to show metadata."
+                Assert-True (@($calls | Where-Object { [string]$_.path -match 'private' }).Count -eq 0) "$($engine.Name)/$scenario leaked a private-library identifier to hosted metadata."
+                $externalPosterCalls = @($calls | Where-Object { [string]$_.path -eq '/hosted/deleted-movie.jpg' })
+                Assert-True ($externalPosterCalls.Count -gt 0) "$($engine.Name)/$scenario did not fetch the external hosted movie poster."
+                Assert-True (@($externalPosterCalls | Where-Object { $_.has_plex_token }).Count -eq 0) "$($engine.Name)/$scenario forwarded the Plex token to an external poster host."
+            }
+
+            if ($scenario -in @('optional-hero-metadata', 'deleted-history-metadata')) {
                 $previewLog = Get-Content $stdout -Raw
                 Assert-True ($previewLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario did not exercise the recoverable direct Plex 404 fallback."
                 Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the global-history title fallback for sparse hero metadata."
@@ -224,10 +257,16 @@ foreach ($engine in $engines) {
 
                 $oldDataRoot = $env:TAUTWEEKLY_DATA_DIR
                 $oldConfig = $env:TAUTWEEKLY_CONFIG
+                $oldMetadataProvider = $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL
                 try {
                     if ($engine.Container) {
                         $env:TAUTWEEKLY_DATA_DIR = $dataRoot
                         $env:TAUTWEEKLY_CONFIG = $configPath
+                    }
+                    if ($scenario -eq 'deleted-history-metadata') {
+                        Remove-Item -LiteralPath (Join-Path $outputRoot 'posters') -Recurse -Force -ErrorAction SilentlyContinue
+                        New-Item -ItemType Directory -Force -Path (Join-Path $outputRoot 'posters') | Out-Null
+                        $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL = $baseUrl + '/hosted'
                     }
                     $sendProcess = Start-Process -FilePath $engine.Host -ArgumentList @(
                         '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $headlessRunner,
@@ -238,6 +277,7 @@ foreach ($engine in $engines) {
                 finally {
                     $env:TAUTWEEKLY_DATA_DIR = $oldDataRoot
                     $env:TAUTWEEKLY_CONFIG = $oldConfig
+                    $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL = $oldMetadataProvider
                 }
                 if ($sendProcess.ExitCode -ne 0) {
                     throw "$($engine.Name)/$scenario SendTest failed ($($sendProcess.ExitCode)).`nSTDOUT:`n$(Get-Content $sendStdout -Raw)`nSTDERR:`n$(Get-Content $sendStderr -Raw)"
@@ -245,6 +285,10 @@ foreach ($engine in $engines) {
                 $sendLog = Get-Content $sendStdout -Raw
                 Assert-True ($sendLog.Contains('Test email sent successfully.')) "$($engine.Name)/$scenario SendTest did not complete delivery."
                 Assert-True ($sendLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario SendTest did not preserve the direct Plex 404 warning."
+                if ($scenario -eq 'deleted-history-metadata') {
+                    Assert-True ($sendLog.Contains('Recovered deleted Plex movie history artwork')) "$($engine.Name)/$scenario SendTest did not recover deleted movie artwork."
+                    Assert-True ($sendLog.Contains('Recovered deleted Plex show history artwork')) "$($engine.Name)/$scenario SendTest did not recover deleted TV artwork."
+                }
                 $smtpCommands = @(Get-Content $smtpCallLog | ForEach-Object { ($_ | ConvertFrom-Json).command })
                 Assert-True ('DATA' -in $smtpCommands) "$($engine.Name)/$scenario SendTest did not submit an SMTP message."
             }

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -196,6 +196,7 @@ foreach ($engine in $engines) {
                 Assert-True ($normalHtml.Contains('Hosted history show summary.')) "$($engine.Name)/$scenario did not restore the deleted TV summary."
                 Assert-True ($normalHtml.Contains('History Drama, Mystery, and more')) "$($engine.Name)/$scenario did not restore deleted movie genres."
                 Assert-True ($normalHtml.Contains('87%') -and $normalHtml.Contains('93%')) "$($engine.Name)/$scenario did not restore deleted movie ratings."
+                Assert-True ($normalHtml.Contains('76%') -and $normalHtml.Contains('84%')) "$($engine.Name)/$scenario did not restore applicable deleted TV ratings."
                 Assert-True ($normalHtml.Contains('posters/poster_selected-movie.jpg')) "$($engine.Name)/$scenario did not render the recovered movie poster."
                 Assert-True ($normalHtml.Contains('posters/poster_selected-show.jpg')) "$($engine.Name)/$scenario did not render the recovered TV poster."
 

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -196,7 +196,7 @@ foreach ($engine in $engines) {
                 Assert-True ($normalHtml.Contains('Hosted history show summary.')) "$($engine.Name)/$scenario did not restore the deleted TV summary."
                 Assert-True ($normalHtml.Contains('History Drama, Mystery, and more')) "$($engine.Name)/$scenario did not restore deleted movie genres."
                 Assert-True ($normalHtml.Contains('87%') -and $normalHtml.Contains('93%')) "$($engine.Name)/$scenario did not restore deleted movie ratings."
-                Assert-True ($normalHtml.Contains('76%') -and $normalHtml.Contains('84%')) "$($engine.Name)/$scenario did not restore applicable deleted TV ratings."
+                Assert-True ($normalHtml -match 'alt="IMDb"[^>]*>8\.4') "$($engine.Name)/$scenario did not restore the deleted TV IMDb rating."
                 Assert-True ($normalHtml.Contains('posters/poster_selected-movie.jpg')) "$($engine.Name)/$scenario did not render the recovered movie poster."
                 Assert-True ($normalHtml.Contains('posters/poster_selected-show.jpg')) "$($engine.Name)/$scenario did not render the recovered TV poster."
 

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -19,6 +19,10 @@ $rendererPaths = @(
 
 $requiredFunctions = @(
     'Get-OptionalStringProperty',
+    'Convert-DesignRatingPercent',
+    'ConvertTo-DesignGenreList',
+    'Add-DesignRatingMetadata',
+    'Get-PlexHostedMetadataLookupPath',
     'Get-TautulliUser',
     'Get-TautulliUsers',
     'Safe-Int',
@@ -118,6 +122,7 @@ foreach ($relativePath in $rendererPaths) {
         watched_status  = 1
         percent_complete = 100
         rating_key      = 'movie-1'
+        guid            = 'plex://movie/movie-guid-1'
         title           = 'Movie One'
         year            = '2026'
     }
@@ -127,6 +132,7 @@ foreach ($relativePath in $rendererPaths) {
         watched_status         = 0
         percent_complete       = 50
         rating_key             = 'episode-1'
+        guid                   = 'plex://episode/episode-guid-1'
         grandparent_rating_key = 'show-1'
         grandparent_title      = 'Show One'
         parent_title           = 'Season 1'
@@ -140,6 +146,7 @@ foreach ($relativePath in $rendererPaths) {
     $oneMovie = Get-UserStats -History @($movie)
     Assert-True ($oneMovie.MovieItems -is [object[]]) "$relativePath collapsed one movie into a scalar"
     Assert-True ($oneMovie.MovieItems.Count -eq 1) "$relativePath lost the one-movie item"
+    Assert-True ($oneMovie.MovieItems[0].MetadataGuid -eq 'plex://movie/movie-guid-1') "$relativePath lost the retained movie metadata GUID"
     Assert-True ($oneMovie.EpisodeItems.Count -eq 0) "$relativePath created an unexpected episode"
     Assert-True ($oneMovie.TvShowItems.Count -eq 0) "$relativePath created an unexpected TV show"
 
@@ -148,8 +155,47 @@ foreach ($relativePath in $rendererPaths) {
     Assert-True ($oneEpisode.EpisodeItems.Count -eq 1) "$relativePath lost the one-episode item"
     Assert-True ($oneEpisode.MovieItems.Count -eq 0) "$relativePath created an unexpected movie"
     Assert-True ($oneEpisode.TvShowItems.Count -eq 1) "$relativePath did not group the episode into one TV show"
+    Assert-True ($oneEpisode.TvShowItems[0].MetadataGuid -eq 'plex://episode/episode-guid-1') "$relativePath lost the representative episode GUID for TV artwork"
     Assert-True ($oneEpisode.TvShowItems[0].ShowTitle -eq 'Show One') "$relativePath lost the grouped TV show title"
     Assert-True ($oneEpisode.EpisodeItems[0].ImdbRating -eq '8.5') "$relativePath lost an available episode IMDb rating"
+
+    Assert-True ((Get-PlexHostedMetadataLookupPath -MetadataGuid 'plex://movie/5d123abc?lang=en' -MediaType 'movie') -eq '/library/metadata/5d123abc') "$relativePath did not normalize a retained Plex GUID"
+    Assert-True ((Get-PlexHostedMetadataLookupPath -MetadataGuid 'com.plexapp.agents.themoviedb://12345?lang=en' -MediaType 'movie') -eq '/library/metadata/matches?guid=tmdb%3A%2F%2F12345&type=1') "$relativePath did not normalize a legacy TMDB movie GUID"
+    Assert-True ([string]::IsNullOrWhiteSpace((Get-PlexHostedMetadataLookupPath -MetadataGuid 'com.plexapp.agents.thetvdb://999/1/2' -MediaType 'show'))) "$relativePath guessed from an unsupported legacy TVDB GUID"
+
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') }
+    function Get-DesignPlexMetadata { param([string]$RatingKey) return $null }
+    function Get-DesignRichExport {
+        param([string]$RatingKey, [string]$MediaType, [switch]$NeedLogo)
+        return [PSCustomObject]@{ RtCritic = ''; RtAudience = '' }
+    }
+    function Get-PlexHostedMetadata {
+        param([string]$MetadataGuid, [string]$MediaType)
+        Assert-True ($MetadataGuid -eq 'plex://movie/deleted-movie-guid') "$relativePath changed the retained GUID during hosted enrichment"
+        Assert-True ($MediaType -eq 'movie') "$relativePath used the wrong hosted metadata type"
+        return [PSCustomObject]@{
+            type = 'movie'
+            summary = 'Retained exact-GUID summary.'
+            year = '2024'
+            Genre = @([PSCustomObject]@{ tag = 'Mystery' }, [PSCustomObject]@{ tag = 'Drama' })
+            rating = '8.7'
+            ratingImage = 'rottentomatoes://image.rating.ripe'
+            audienceRating = '9.3'
+            audienceRatingImage = 'rottentomatoes://image.rating.upright'
+        }
+    }
+    $deletedMovieItem = [PSCustomObject]@{
+        RatingKey = 'deleted-movie'
+        MetadataGuid = 'plex://movie/deleted-movie-guid'
+        Type = 'movie'
+        Title = 'Deleted Movie'
+    }
+    Add-DesignRatingMetadata -ReleaseData ([PSCustomObject]@{ Movies = @($deletedMovieItem); TV = @() })
+    Assert-True ($deletedMovieItem.Summary -eq 'Retained exact-GUID summary.') "$relativePath did not restore a deleted movie summary"
+    Assert-True ($deletedMovieItem.Year -eq '2024') "$relativePath did not restore a deleted movie year"
+    Assert-True (($deletedMovieItem.DesignGenres -join ',') -eq 'Mystery,Drama') "$relativePath did not restore deleted movie genres"
+    Assert-True ($deletedMovieItem.DesignRtCritic -eq '87') "$relativePath did not restore the deleted movie critic rating"
+    Assert-True ($deletedMovieItem.DesignRtAudience -eq '93') "$relativePath did not restore the deleted movie audience rating"
 
     $secondEpisode = [PSCustomObject]@{
         media_type             = 'episode'
@@ -264,6 +310,7 @@ foreach ($relativePath in $rendererPaths) {
     Assert-True ($source -match 'width="42" height="42" alt="Movies watched"') "$relativePath does not render the movie GIF at the standard stat-icon size"
     Assert-True ($source -match 'width="42" height="42" alt="TV shows watched"') "$relativePath does not render the TV GIF at the standard stat-icon size"
     Assert-True ($source -notmatch '\$qualifyingPlayCount qualifying') "$relativePath retains qualifying-play copy in Total Watched"
+    Assert-True ($source -match '\$assetUri\.Scheme -ieq \$providerUri\.Scheme') "$relativePath can forward a Plex token across an artwork scheme change"
     Assert-True ($source.Contains('The real email layout, across every state.')) "$relativePath lost the Preview All headline"
     Assert-True ($source.Contains('Go ahead, shrink my window.')) "$relativePath lost the responsive Preview All subtitle"
 

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -197,6 +197,29 @@ foreach ($relativePath in $rendererPaths) {
     Assert-True ($deletedMovieItem.DesignRtCritic -eq '87') "$relativePath did not restore the deleted movie critic rating"
     Assert-True ($deletedMovieItem.DesignRtAudience -eq '93') "$relativePath did not restore the deleted movie audience rating"
 
+    function Get-PlexHostedMetadata {
+        param([string]$MetadataGuid, [string]$MediaType)
+        Assert-True ($MetadataGuid -eq 'plex://episode/deleted-episode-guid') "$relativePath changed the retained episode GUID during hosted enrichment"
+        Assert-True ($MediaType -eq 'show') "$relativePath used the wrong hosted TV metadata type"
+        return [PSCustomObject]@{
+            type = 'show'
+            summary = 'Retained TV summary.'
+            year = '2024'
+            rating = '8.4'
+            ratingImage = 'imdb://image.rating'
+        }
+    }
+    $deletedShowItem = [PSCustomObject]@{
+        RatingKey = 'deleted-show'
+        MetadataGuid = 'plex://episode/deleted-episode-guid'
+        Type = 'show'
+        Title = 'Deleted Show'
+    }
+    Add-DesignRatingMetadata -ReleaseData ([PSCustomObject]@{ Movies = @(); TV = @($deletedShowItem) })
+    Assert-True ($deletedShowItem.DesignImdbRating -eq '8.4') "$relativePath did not restore the deleted TV IMDb rating"
+    Assert-True ([string]::IsNullOrWhiteSpace($deletedShowItem.DesignRtCritic)) "$relativePath mislabeled a TV IMDb rating as Rotten Tomatoes"
+    Assert-True ([string]::IsNullOrWhiteSpace($deletedShowItem.DesignRtAudience)) "$relativePath invented a TV Rotten Tomatoes audience rating"
+
     $secondEpisode = [PSCustomObject]@{
         media_type             = 'episode'
         play_duration          = 3600

--- a/scripts/test-support/fake-tautulli.py
+++ b/scripts/test-support/fake-tautulli.py
@@ -291,10 +291,8 @@ class Handler(BaseHTTPRequestHandler):
                                     "summary": "Hosted history show summary.",
                                     "thumb": f"{self.server.base_url}/hosted/deleted-show.jpg",  # type: ignore[attr-defined]
                                     "Genre": [{"tag": "Drama"}, {"tag": "Mystery"}],
-                                    "rating": "7.6",
-                                    "ratingImage": "rottentomatoes://image.rating.ripe",
-                                    "audienceRating": "8.4",
-                                    "audienceRatingImage": "rottentomatoes://image.rating.upright",
+                                    "rating": "8.4",
+                                    "ratingImage": "imdb://image.rating",
                                 }
                             ]
                         }

--- a/scripts/test-support/fake-tautulli.py
+++ b/scripts/test-support/fake-tautulli.py
@@ -16,7 +16,7 @@ def media_rows(scenario: str) -> dict[str, list[dict[str, object]]]:
     old = now - (30 * 86400)
     movie_added = now if scenario in ("active", "optional-hero-metadata") else old
     tv_added = now if scenario in ("active", "tv-only", "optional-hero-metadata") else old
-    return {
+    rows = {
         "10": [
             {
                 "section_id": "10",
@@ -64,6 +64,22 @@ def media_rows(scenario: str) -> dict[str, list[dict[str, object]]]:
             }
         ],
     }
+    if scenario == "deleted-history-metadata":
+        rows["10"][0]["guid"] = "plex://movie/deletedmovieguid"
+        rows["20"][0]["guid"] = "plex://episode/deletedepisodeguid"
+        for field in (
+            "year",
+            "summary",
+            "rating",
+            "rating_image",
+            "audience_rating",
+            "audience_rating_image",
+            "genres",
+        ):
+            rows["10"][0].pop(field, None)
+        for field in ("year", "summary", "rating", "rating_image"):
+            rows["20"][0].pop(field, None)
+    return rows
 
 
 USERS = {
@@ -88,9 +104,9 @@ USERS = {
 }
 
 
-def history_rows(section_id: str) -> list[dict[str, object]]:
+def history_rows(section_id: str, scenario: str) -> list[dict[str, object]]:
     if section_id == "10":
-        return [
+        rows = [
             {
                 "section_id": "10",
                 "media_type": "movie",
@@ -108,8 +124,13 @@ def history_rows(section_id: str) -> list[dict[str, object]]:
                 "group_count": 1,
             }
         ]
+        if scenario == "deleted-history-metadata":
+            rows[0]["guid"] = "plex://movie/deletedmovieguid"
+            for field in ("year", "summary", "rating", "audience_rating"):
+                rows[0].pop(field, None)
+        return rows
     if section_id == "20":
-        return [
+        rows = [
             {
                 "section_id": "20",
                 "media_type": "episode",
@@ -132,6 +153,32 @@ def history_rows(section_id: str) -> list[dict[str, object]]:
                 "rating_image": "imdb://image.rating",
             }
         ]
+        if scenario == "deleted-history-metadata":
+            rows[0]["guid"] = "plex://episode/deletedepisodeguid"
+            for field in ("year", "summary", "rating", "rating_image"):
+                rows[0].pop(field, None)
+            rows.append(
+                {
+                    "section_id": "20",
+                    "media_type": "episode",
+                    "rating_key": "viewer-deleted-episode",
+                    "grandparent_rating_key": "selected-show",
+                    "grandparent_title": "Selected Show",
+                    "parent_title": "Season 1",
+                    "title": "Viewer Deleted Episode",
+                    "year": "2026",
+                    "guid": "plex://episode/deletedepisodeguid",
+                    "user_id": "1",
+                    "friendly_name": "Virtual Viewer",
+                    "play_duration": 1800,
+                    "watched_status": 1,
+                    "percent_complete": 100,
+                    "group_count": 1,
+                    "parent_media_index": 1,
+                    "media_index": 3,
+                }
+            )
+        return rows
     return [
         {
             "section_id": "99",
@@ -169,10 +216,103 @@ class Handler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         query = {key: values[-1] for key, values in parse_qs(parsed.query).items()}
         with self.server.call_log.open("a", encoding="utf-8") as handle:  # type: ignore[attr-defined]
-            handle.write(json.dumps({"path": parsed.path, "query": query}) + "\n")
+            handle.write(
+                json.dumps(
+                    {
+                        "path": parsed.path,
+                        "query": query,
+                        "has_plex_token": bool(self.headers.get("X-Plex-Token")),
+                    }
+                )
+                + "\n"
+            )
+
+        if parsed.path.startswith("/hosted/library/metadata/"):
+            metadata_id = parsed.path.rsplit("/", 1)[-1]
+            if not self.headers.get("X-Plex-Token"):
+                self.write_json({"error": "missing virtual Plex token"}, status=401)
+                return
+
+            if metadata_id == "deletedmovieguid":
+                self.write_json(
+                    {
+                        "MediaContainer": {
+                            "Metadata": [
+                                {
+                                    "type": "movie",
+                                    "guid": "plex://movie/deletedmovieguid",
+                                    "title": "Selected Movie",
+                                    "year": "2026",
+                                    "summary": "Hosted history movie summary.",
+                                    "thumb": f"http://localhost:{self.server.server_port}/hosted/deleted-movie.jpg",  # type: ignore[attr-defined]
+                                    "Genre": [
+                                        {"tag": "History Drama"},
+                                        {"tag": "Mystery"},
+                                        {"tag": "Archive"},
+                                    ],
+                                    "rating": "8.7",
+                                    "ratingImage": "rottentomatoes://image.rating.ripe",
+                                    "audienceRating": "9.3",
+                                    "audienceRatingImage": "rottentomatoes://image.rating.upright",
+                                }
+                            ]
+                        }
+                    }
+                )
+                return
+
+            if metadata_id == "deletedepisodeguid":
+                self.write_json(
+                    {
+                        "MediaContainer": {
+                            "Metadata": [
+                                {
+                                    "type": "episode",
+                                    "guid": "plex://episode/deletedepisodeguid",
+                                    "grandparentGuid": "plex://show/deletedshowguid",
+                                    "grandparentThumb": f"{self.server.base_url}/hosted/deleted-show.jpg",  # type: ignore[attr-defined]
+                                }
+                            ]
+                        }
+                    }
+                )
+                return
+
+            if metadata_id == "deletedshowguid":
+                self.write_json(
+                    {
+                        "MediaContainer": {
+                            "Metadata": [
+                                {
+                                    "type": "show",
+                                    "guid": "plex://show/deletedshowguid",
+                                    "title": "Selected Show",
+                                    "year": "2024",
+                                    "summary": "Hosted history show summary.",
+                                    "thumb": f"{self.server.base_url}/hosted/deleted-show.jpg",  # type: ignore[attr-defined]
+                                    "Genre": [{"tag": "Drama"}, {"tag": "Mystery"}],
+                                }
+                            ]
+                        }
+                    }
+                )
+                return
+
+            self.write_json({"MediaContainer": {"Metadata": []}})
+            return
+
+        if parsed.path in ("/hosted/deleted-movie.jpg", "/hosted/deleted-show.jpg"):
+            marker = b"MOVIE" if parsed.path.endswith("deleted-movie.jpg") else b"SHOW"
+            payload = b"\xff\xd8" + (marker * 160) + b"\xff\xd9"
+            self.send_response(200)
+            self.send_header("Content-Type", "image/jpeg")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
 
         if parsed.path.startswith("/library/metadata/"):
-            if self.server.scenario == "optional-hero-metadata":  # type: ignore[attr-defined]
+            if self.server.scenario in ("optional-hero-metadata", "deleted-history-metadata"):  # type: ignore[attr-defined]
                 self.write_json({"error": "sanitized missing Plex metadata"}, status=404)
                 return
             self.write_json({"MediaContainer": {"size": 0, "Metadata": []}})
@@ -184,7 +324,8 @@ class Handler(BaseHTTPRequestHandler):
 
         command = query.get("cmd", "")
         if command == "pms_image_proxy":
-            payload = b"\xff\xd8" + (b"VIRTUAL-POSTER" * 48) + b"\xff\xd9"
+            marker = b"GENERIC-POSTER" if self.server.scenario == "deleted-history-metadata" else b"VIRTUAL-POSTER"  # type: ignore[attr-defined]
+            payload = b"\xff\xd8" + (marker * 48) + b"\xff\xd9"
             self.send_response(200)
             self.send_header("Content-Type", "image/jpeg")
             self.send_header("Content-Length", str(len(payload)))
@@ -220,7 +361,7 @@ class Handler(BaseHTTPRequestHandler):
             )
             return
         if command == "get_history":
-            rows = history_rows(query.get("section_id", ""))
+            rows = history_rows(query.get("section_id", ""), self.server.scenario)  # type: ignore[attr-defined]
             user_id = query.get("user_id", "")
             if user_id:
                 rows = [row for row in rows if str(row.get("user_id", "")) == user_id]
@@ -240,6 +381,22 @@ class Handler(BaseHTTPRequestHandler):
             return
         if command == "get_metadata":
             key = query.get("rating_key", "")
+            if self.server.scenario == "deleted-history-metadata" and key in (  # type: ignore[attr-defined]
+                "selected-movie",
+                "selected-show",
+                "champion-episode",
+                "viewer-deleted-episode",
+            ):
+                self.write_json(
+                    {
+                        "response": {
+                            "result": "error",
+                            "message": "sanitized deleted Plex metadata",
+                            "data": {},
+                        }
+                    }
+                )
+                return
             is_episode = "episode" in key
             is_show = key.startswith("selected-show") and not is_episode
             if self.server.scenario == "optional-hero-metadata" and is_show:  # type: ignore[attr-defined]
@@ -286,7 +443,7 @@ def main() -> None:
     parser.add_argument("--port", type=int, required=True)
     parser.add_argument(
         "--scenario",
-        choices=("active", "quiet", "tv-only", "optional-hero-metadata"),
+        choices=("active", "quiet", "tv-only", "optional-hero-metadata", "deleted-history-metadata"),
         required=True,
     )
     parser.add_argument("--call-log", type=Path, required=True)

--- a/scripts/test-support/fake-tautulli.py
+++ b/scripts/test-support/fake-tautulli.py
@@ -291,6 +291,10 @@ class Handler(BaseHTTPRequestHandler):
                                     "summary": "Hosted history show summary.",
                                     "thumb": f"{self.server.base_url}/hosted/deleted-show.jpg",  # type: ignore[attr-defined]
                                     "Genre": [{"tag": "Drama"}, {"tag": "Mystery"}],
+                                    "rating": "7.6",
+                                    "ratingImage": "rottentomatoes://image.rating.ripe",
+                                    "audienceRating": "8.4",
+                                    "audienceRatingImage": "rottentomatoes://image.rating.upright",
                                 }
                             ]
                         }


### PR DESCRIPTION
## Summary

- recover deleted Plex history artwork and metadata from the exact GUID retained by Tautulli
- reject Tautulli's generic poster fallback and cache the recovered hosted poster
- restore available summary, year, genres, movie Rotten Tomatoes ratings, and TV IMDb ratings across maintained renderers
- credit @gianfelicevincenzo for issue #41 in the changelog and CONTRIBUTORS ledger

## Privacy and security

- sends only the retained media GUID and existing administrator/server Plex token to `https://metadata.provider.plex.tv`
- performs no title search and sends no recipient identity, email, or watch-history values
- never forwards the Plex token to an external artwork origin returned by the metadata provider
- preserves selected-library scoping and existing recoverable direct Plex 404 warnings

## Validation

- PowerShell syntax: 59 files
- renderer collection/optional-field coverage: Windows, NAS/Linux/FreeBSD, macOS
- PreviewAll and SendTest integration: active, quiet, TV-only, optional hero, deleted-history scenarios
- explicit movie RT and TV IMDb provider-label regression coverage
- repository privacy/hygiene, docs/links, platform contracts, Unraid template
- exclusions, Binge Champion privacy, library scoping, update checks, scheduler timezone
- v0.7.0 candidate: nine archives plus SHA256SUMS; release artifact contracts passed

Addresses #41. The issue will remain open until the merged fix is published and verified in v0.7.0.
