### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-10
+
 ### Fixed
 
 - Recovered posters, summaries, genres, years, movie Rotten Tomatoes ratings,

--- a/scripts/validate-repository.ps1
+++ b/scripts/validate-repository.ps1
@@ -103,7 +103,10 @@ $contributorContract = @(
     'https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.2',
     'https://github.com/sparkmoxie/TautWeekly/issues/38',
     'https://github.com/sparkmoxie/TautWeekly/pull/39',
-    'https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.3'
+    'https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.3',
+    'https://github.com/sparkmoxie/TautWeekly/issues/41',
+    'https://github.com/sparkmoxie/TautWeekly/pull/42',
+    'https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.7.0'
 )
 foreach ($expected in $contributorContract) {
     if (-not $contributors.Contains($expected)) {


### PR DESCRIPTION
## Summary

- move the issue #41 deleted-history recovery notes from Unreleased into v0.7.0
- extend repository validation to require the reporter, fix PR #42, and v0.7.0 attribution links

## Release evidence

- fix PR #42 merged as `51a8b5e`
- merged-main CI, Pages, and multi-arch Container workflows passed
- all nine v0.7.0 archives plus `SHA256SUMS.txt` built and validated locally
- every archive contains `RELEASE-FILES.txt` and no live config, state, logs, or generated output
- movie Rotten Tomatoes and TV IMDb deleted-item recovery passed PreviewAll and SendTest regressions

The annotated `v0.7.0` tag will be created from merged `main` only after this PR is green and merged.
