### PR TITLE
fix: make deleted-history poster recovery portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Test scheduler timezone behavior
         shell: pwsh
         run: ./scripts/test-scheduler-timezone.ps1
+      - name: Test renderer collection and poster-probe behavior on Unix
+        shell: pwsh
+        run: ./scripts/test-renderer-collections.ps1
       - name: Test SMTP authentication protocol on PowerShell 7
         run: python3 scripts/test-smtp-transport.py --helper platforms/nas-docker/app/Smtp-Transport.ps1
       - name: Validate NAS Compose configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Made the generic-poster fingerprint probe portable to Unix so deleted Plex
+  history artwork can proceed to the exact-GUID hosted recovery added in
+  v0.7.0. Follow-up reported by
+  [@gianfelicevincenzo](https://github.com/gianfelicevincenzo)
+  in [#41](https://github.com/sparkmoxie/TautWeekly/issues/41).
+
 ## [0.7.0] - 2026-08-10
 
 ### Fixed

--- a/platforms/freebsd-podman/CHANGELOG.txt
+++ b/platforms/freebsd-podman/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex FreeBSD Podman platform changelog
 
 Unreleased
+- Fixes deleted-history poster recovery on Unix by using a portable generic-poster probe.
 - Recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID.
 - Honors PUID/PGID for newsletter commands started from a root Podman exec session.
 - Treats sparse Tautulli hero metadata as optional during previews and test sends.

--- a/platforms/linux/CHANGELOG.txt
+++ b/platforms/linux/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex native Linux platform changelog
 
 Unreleased
+- Fixes deleted-history poster recovery on Unix by using a portable generic-poster probe.
 - Recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID.
 - Treats sparse Tautulli hero metadata as optional during previews and test sends.
 - Accepts selected-library recently-added rows when Plex omits the redundant section ID.

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- fixes deleted-history poster recovery on Unix by using a portable generic-poster probe
 - recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID
 - honors PUID/PGID for newsletter commands started from a root container Console or exec session
 - treats sparse Tautulli hero metadata as optional during previews and test sends

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -4310,21 +4310,21 @@ function Get-TautulliDefaultPosterHash {
         return $script:TautulliDefaultPosterHash
     }
 
-    $probePath = Join-Path $PosterDir (".tautulli-default-poster-" + [Guid]::NewGuid().ToString("N"))
+    $probePath = Join-Path $PosterDir ("tautulli-default-poster-" + [Guid]::NewGuid().ToString("N") + ".png")
     try {
         $uri = Build-TautulliUri -Command "pms_image_proxy" -Parameters @{
             fallback = "poster"
         }
         Invoke-WebRequest -Uri $uri -OutFile $probePath -TimeoutSec 60 | Out-Null
-        if ((Test-Path $probePath) -and (Get-Item $probePath).Length -gt 0) {
-            $script:TautulliDefaultPosterHash = (Get-FileHash -Path $probePath -Algorithm SHA256).Hash
+        if ((Test-Path -LiteralPath $probePath) -and (Get-Item -LiteralPath $probePath).Length -gt 0) {
+            $script:TautulliDefaultPosterHash = (Get-FileHash -LiteralPath $probePath -Algorithm SHA256).Hash
         }
     }
     catch {
         Write-Log "Could not fingerprint Tautulli's generic poster fallback: $($_.Exception.Message)" "WARN"
     }
     finally {
-        Remove-Item $probePath -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $probePath -Force -ErrorAction SilentlyContinue
     }
 
     return $script:TautulliDefaultPosterHash

--- a/platforms/nas-docker/CHANGELOG.txt
+++ b/platforms/nas-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX NAS PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- fixes deleted-history poster recovery on Unix by using a portable generic-poster probe
 - recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID
 - honors PUID/PGID for newsletter commands started from a root container Console or exec session
 - treats sparse Tautulli hero metadata as optional during previews and test sends

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -4311,21 +4311,21 @@ function Get-TautulliDefaultPosterHash {
         return $script:TautulliDefaultPosterHash
     }
 
-    $probePath = Join-Path $PosterDir (".tautulli-default-poster-" + [Guid]::NewGuid().ToString("N"))
+    $probePath = Join-Path $PosterDir ("tautulli-default-poster-" + [Guid]::NewGuid().ToString("N") + ".png")
     try {
         $uri = Build-TautulliUri -Command "pms_image_proxy" -Parameters @{
             fallback = "poster"
         }
         Invoke-WebRequest -Uri $uri -OutFile $probePath -TimeoutSec 60 | Out-Null
-        if ((Test-Path $probePath) -and (Get-Item $probePath).Length -gt 0) {
-            $script:TautulliDefaultPosterHash = (Get-FileHash -Path $probePath -Algorithm SHA256).Hash
+        if ((Test-Path -LiteralPath $probePath) -and (Get-Item -LiteralPath $probePath).Length -gt 0) {
+            $script:TautulliDefaultPosterHash = (Get-FileHash -LiteralPath $probePath -Algorithm SHA256).Hash
         }
     }
     catch {
         Write-Log "Could not fingerprint Tautulli's generic poster fallback: $($_.Exception.Message)" "WARN"
     }
     finally {
-        Remove-Item $probePath -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $probePath -Force -ErrorAction SilentlyContinue
     }
 
     return $script:TautulliDefaultPosterHash

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- fixes deleted-history poster recovery on Unix-compatible packages by using a portable generic-poster probe
 - recovers deleted Plex history posters and metadata from Tautulli's retained exact GUID
 - treats sparse Tautulli hero metadata as optional during previews and test sends
 - accepts selected-library recently-added rows when Plex omits the redundant section ID

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -4348,21 +4348,21 @@ function Get-TautulliDefaultPosterHash {
         return $script:TautulliDefaultPosterHash
     }
 
-    $probePath = Join-Path $PosterDir (".tautulli-default-poster-" + [Guid]::NewGuid().ToString("N"))
+    $probePath = Join-Path $PosterDir ("tautulli-default-poster-" + [Guid]::NewGuid().ToString("N") + ".png")
     try {
         $uri = Build-TautulliUri -Command "pms_image_proxy" -Parameters @{
             fallback = "poster"
         }
         Invoke-WebRequest -Uri $uri -OutFile $probePath -TimeoutSec 60 | Out-Null
-        if ((Test-Path $probePath) -and (Get-Item $probePath).Length -gt 0) {
-            $script:TautulliDefaultPosterHash = (Get-FileHash -Path $probePath -Algorithm SHA256).Hash
+        if ((Test-Path -LiteralPath $probePath) -and (Get-Item -LiteralPath $probePath).Length -gt 0) {
+            $script:TautulliDefaultPosterHash = (Get-FileHash -LiteralPath $probePath -Algorithm SHA256).Hash
         }
     }
     catch {
         Write-Log "Could not fingerprint Tautulli's generic poster fallback: $($_.Exception.Message)" "WARN"
     }
     finally {
-        Remove-Item $probePath -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $probePath -Force -ErrorAction SilentlyContinue
     }
 
     return $script:TautulliDefaultPosterHash

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -85,6 +85,12 @@ foreach ($relativePath in $rendererPaths) {
         $script:PosterDir = $posterProbeRoot
         $script:TautulliDefaultPosterHash = ''
         $script:posterProbeOutFile = ''
+        $script:posterProbeWarnings = New-Object System.Collections.Generic.List[string]
+
+        function Write-Log {
+            param([string]$Message, [string]$Level = 'INFO')
+            if ($Level -eq 'WARN') { $script:posterProbeWarnings.Add($Message) }
+        }
 
         function Build-TautulliUri {
             param([string]$Command, [hashtable]$Parameters = @{})
@@ -105,7 +111,8 @@ foreach ($relativePath in $rendererPaths) {
         }
 
         $posterHash = Get-TautulliDefaultPosterHash
-        Assert-True (-not [string]::IsNullOrWhiteSpace($posterHash)) "$relativePath could not fingerprint Tautulli's generic poster on this platform"
+        $probeWarningText = $script:posterProbeWarnings -join '; '
+        Assert-True (-not [string]::IsNullOrWhiteSpace($posterHash)) "$relativePath could not fingerprint Tautulli's generic poster on this platform: $probeWarningText"
         Assert-True (-not (Test-Path -LiteralPath $script:posterProbeOutFile)) "$relativePath did not clean up the generic-poster probe"
     }
     finally {

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -23,6 +23,7 @@ $requiredFunctions = @(
     'ConvertTo-DesignGenreList',
     'Add-DesignRatingMetadata',
     'Get-PlexHostedMetadataLookupPath',
+    'Get-TautulliDefaultPosterHash',
     'Get-TautulliUser',
     'Get-TautulliUsers',
     'Safe-Int',
@@ -76,6 +77,39 @@ foreach ($relativePath in $rendererPaths) {
         }
 
         Invoke-Expression $definition.Extent.Text
+    }
+
+    $posterProbeRoot = Join-Path ([IO.Path]::GetTempPath()) ('tautweekly-poster-probe-' + [Guid]::NewGuid().ToString('N'))
+    try {
+        New-Item -ItemType Directory -Force -Path $posterProbeRoot | Out-Null
+        $script:PosterDir = $posterProbeRoot
+        $script:TautulliDefaultPosterHash = ''
+        $script:posterProbeOutFile = ''
+
+        function Build-TautulliUri {
+            param([string]$Command, [hashtable]$Parameters = @{})
+            Assert-True ($Command -eq 'pms_image_proxy') "$relativePath used the wrong command for the generic-poster probe"
+            Assert-True ([string]$Parameters.fallback -eq 'poster') "$relativePath did not request Tautulli's poster fallback"
+            return 'https://tautulli.invalid/api/v2'
+        }
+
+        function Invoke-WebRequest {
+            param(
+                [string]$Uri,
+                [string]$OutFile,
+                [int]$TimeoutSec
+            )
+
+            $script:posterProbeOutFile = $OutFile
+            [IO.File]::WriteAllBytes($OutFile, [Text.Encoding]::UTF8.GetBytes(('GENERIC-POSTER' * 64)))
+        }
+
+        $posterHash = Get-TautulliDefaultPosterHash
+        Assert-True (-not [string]::IsNullOrWhiteSpace($posterHash)) "$relativePath could not fingerprint Tautulli's generic poster on this platform"
+        Assert-True (-not (Test-Path -LiteralPath $script:posterProbeOutFile)) "$relativePath did not clean up the generic-poster probe"
+    }
+    finally {
+        Remove-Item -LiteralPath $posterProbeRoot -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     $script:Config = [PSCustomObject]@{

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -85,6 +85,7 @@ foreach ($relativePath in $rendererPaths) {
         $script:PosterDir = $posterProbeRoot
         $script:TautulliDefaultPosterHash = ''
         $script:posterProbeOutFile = ''
+        $script:posterProbeRequestCount = 0
         $script:posterProbeWarnings = New-Object System.Collections.Generic.List[string]
 
         function Write-Log {
@@ -107,12 +108,17 @@ foreach ($relativePath in $rendererPaths) {
             )
 
             $script:posterProbeOutFile = $OutFile
+            $script:posterProbeRequestCount++
             [IO.File]::WriteAllBytes($OutFile, [Text.Encoding]::UTF8.GetBytes(('GENERIC-POSTER' * 64)))
         }
 
         $posterHash = Get-TautulliDefaultPosterHash
+        $cachedPosterHash = Get-TautulliDefaultPosterHash
         $probeWarningText = $script:posterProbeWarnings -join '; '
         Assert-True (-not [string]::IsNullOrWhiteSpace($posterHash)) "$relativePath could not fingerprint Tautulli's generic poster on this platform: $probeWarningText"
+        Assert-True ($cachedPosterHash -eq $posterHash -and $script:posterProbeRequestCount -eq 1) "$relativePath did not cache Tautulli's generic-poster fingerprint"
+        Assert-True ($script:posterProbeWarnings.Count -eq 0) "$relativePath logged an unexpected generic-poster probe warning: $probeWarningText"
+        Assert-True (-not ([IO.Path]::GetFileName($script:posterProbeOutFile)).StartsWith('.')) "$relativePath used a Unix-hidden generic-poster probe"
         Assert-True (-not (Test-Path -LiteralPath $script:posterProbeOutFile)) "$relativePath did not clean up the generic-poster probe"
     }
     finally {


### PR DESCRIPTION
## Summary

- reproduce and fix the issue #41 generic-poster fingerprint failure under PowerShell on Unix
- use a normal unique `.png` probe and literal-path file operations in all maintained renderers
- run the focused poster-probe regression on Ubuntu in addition to the existing Windows renderer/integration suite
- preserve exact-GUID hosted metadata recovery, token isolation, and useful local Plex 404 warnings
- credit @gianfelicevincenzo for the follow-up report

## Root cause

The v0.7.0 fingerprint probe downloaded Tautulli's generic fallback to a dot-prefixed temporary file. PowerShell on Unix treated that path as hidden, and `Get-FileHash` failed with the reporter's exact `Could not find item .../.tautulli-default-poster-*` warning. With no fingerprint cached, TautWeekly accepted the generic poster instead of proceeding to the retained-GUID hosted artwork fallback. The direct Plex 404s are the expected deleted-item condition and remain nonfatal.

The pre-fix Ubuntu regression failed with the reporter's exact error in [Actions run 31397057169](https://github.com/sparkmoxie/TautWeekly/actions/runs/31397057169).

## Validation

- focused renderer collection/poster-probe test on Windows
- focused renderer collection/poster-probe test on Ubuntu/PowerShell 7
- cached one-request fingerprint and temporary-file cleanup assertions
- sanitized deleted movie/show PreviewAll and SendTest integration
- PowerShell parse validation
- repository privacy/hygiene, docs/links, platform contracts, Unraid template
- exclusions, Binge Champion privacy, library scoping, scheduler timezone, and updater behavior

Reopens and addresses #41. The issue will remain open until the merged fix is published and verified in a new release.
