### PR TITLE
fix: recover legacy deleted history metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Extended exact-GUID recovery for deleted Plex history to legacy TMDB agent
+  aliases and legacy TVDB episode/show identifiers, and made unsupported or
+  empty exact matches visible through privacy-safe warnings. Follow-up reported
+  by [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) in
+  [#41](https://github.com/sparkmoxie/TautWeekly/issues/41).
+
+### Security
+
+- Kept legacy deleted-history recovery limited to validated numeric provider
+  identifiers. It performs no title search and never writes the retained
+  identifier or Plex token to diagnostics.
+
 ## [0.8.0] - 2026-08-10
 
 ### Fixed

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -4246,19 +4246,26 @@ function Get-PlexHostedMetadataLookupPath {
     if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return "" }
 
     $guid = $MetadataGuid.Trim()
-    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9]+)(?:\?.*)?$') {
+    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9][a-z0-9_-]*)(?:\?.*)?$') {
         return "/library/metadata/" + [Uri]::EscapeDataString([string]$Matches.id)
     }
 
     $externalGuid = ""
-    if ($guid -match '(?i)^(?:tmdb|imdb)://[^/?]+(?:\?.*)?$') {
-        $externalGuid = $guid -replace '\?.*$', ''
+    if ($guid -match '(?i)^tmdb://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
+        $externalGuid = "tmdb://" + [string]$Matches.id
     }
-    elseif ($guid -match '(?i)^com\.plexapp\.agents\.themoviedb://(?<id>[0-9]+)(?:\?.*)?$') {
+    elseif ($guid -match '(?i)^imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "imdb://" + [string]$Matches.id
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.(?:themoviedb|tmdb)://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
         $externalGuid = "tmdb://" + [string]$Matches.id
     }
     elseif ($guid -match '(?i)^com\.plexapp\.agents\.imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
         $externalGuid = "imdb://" + [string]$Matches.id
+    }
+    elseif ($MediaType -eq "show" -and
+        $guid -match '(?i)^(?:tvdb|com\.plexapp\.agents\.thetvdb)://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
+        $externalGuid = "tvdb://" + [string]$Matches.id
     }
 
     if ([string]::IsNullOrWhiteSpace($externalGuid)) { return "" }
@@ -4276,17 +4283,24 @@ function Get-PlexHostedMetadata {
         [string]$MediaType
     )
 
-    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
-    if ([string]::IsNullOrWhiteSpace($lookupPath)) { return $null }
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return $null }
 
-    $cacheKey = $MediaType + ":" + $MetadataGuid
+    $cacheKey = $MediaType + ":" + $MetadataGuid.Trim()
     if ($script:PlexHostedMetadataCache.ContainsKey($cacheKey)) {
         return $script:PlexHostedMetadataCache[$cacheKey]
+    }
+
+    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ([string]::IsNullOrWhiteSpace($lookupPath)) {
+        Write-Log "Plex hosted metadata recovery skipped a retained $MediaType GUID because its exact provider format is unsupported." "WARN"
+        $script:PlexHostedMetadataCache[$cacheKey] = $null
+        return $null
     }
 
     $ctx = Get-DesignPlexContext
     $token = Get-OptionalStringProperty -InputObject $ctx -Name "Token"
     if ([string]::IsNullOrWhiteSpace($token)) {
+        Write-Log "Plex hosted metadata recovery requires the configured administrator Plex token." "WARN"
         $script:PlexHostedMetadataCache[$cacheKey] = $null
         return $null
     }
@@ -4300,12 +4314,14 @@ function Get-PlexHostedMetadata {
     }
 
     $metadata = $null
+    $requestCompleted = $false
     try {
         $raw = Invoke-RestMethod `
             -Uri ((Get-PlexMetadataProviderBaseUrl) + $lookupPath) `
             -Headers $headers `
             -Method Get `
             -TimeoutSec 60
+        $requestCompleted = $true
 
         if ($null -ne $raw -and $null -ne $raw.PSObject.Properties["MediaContainer"]) {
             $container = $raw.MediaContainer
@@ -4317,6 +4333,10 @@ function Get-PlexHostedMetadata {
     }
     catch {
         Write-Log "Plex hosted metadata fallback failed for deleted $MediaType history metadata: $($_.Exception.Message)" "WARN"
+    }
+
+    if ($requestCompleted -and $null -eq $metadata) {
+        Write-Log "Plex hosted metadata recovery returned no exact match for the retained $MediaType GUID." "WARN"
     }
 
     if ($null -ne $metadata -and $MediaType -eq "show") {

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -4247,19 +4247,26 @@ function Get-PlexHostedMetadataLookupPath {
     if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return "" }
 
     $guid = $MetadataGuid.Trim()
-    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9]+)(?:\?.*)?$') {
+    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9][a-z0-9_-]*)(?:\?.*)?$') {
         return "/library/metadata/" + [Uri]::EscapeDataString([string]$Matches.id)
     }
 
     $externalGuid = ""
-    if ($guid -match '(?i)^(?:tmdb|imdb)://[^/?]+(?:\?.*)?$') {
-        $externalGuid = $guid -replace '\?.*$', ''
+    if ($guid -match '(?i)^tmdb://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
+        $externalGuid = "tmdb://" + [string]$Matches.id
     }
-    elseif ($guid -match '(?i)^com\.plexapp\.agents\.themoviedb://(?<id>[0-9]+)(?:\?.*)?$') {
+    elseif ($guid -match '(?i)^imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "imdb://" + [string]$Matches.id
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.(?:themoviedb|tmdb)://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
         $externalGuid = "tmdb://" + [string]$Matches.id
     }
     elseif ($guid -match '(?i)^com\.plexapp\.agents\.imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
         $externalGuid = "imdb://" + [string]$Matches.id
+    }
+    elseif ($MediaType -eq "show" -and
+        $guid -match '(?i)^(?:tvdb|com\.plexapp\.agents\.thetvdb)://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
+        $externalGuid = "tvdb://" + [string]$Matches.id
     }
 
     if ([string]::IsNullOrWhiteSpace($externalGuid)) { return "" }
@@ -4277,17 +4284,24 @@ function Get-PlexHostedMetadata {
         [string]$MediaType
     )
 
-    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
-    if ([string]::IsNullOrWhiteSpace($lookupPath)) { return $null }
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return $null }
 
-    $cacheKey = $MediaType + ":" + $MetadataGuid
+    $cacheKey = $MediaType + ":" + $MetadataGuid.Trim()
     if ($script:PlexHostedMetadataCache.ContainsKey($cacheKey)) {
         return $script:PlexHostedMetadataCache[$cacheKey]
+    }
+
+    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ([string]::IsNullOrWhiteSpace($lookupPath)) {
+        Write-Log "Plex hosted metadata recovery skipped a retained $MediaType GUID because its exact provider format is unsupported." "WARN"
+        $script:PlexHostedMetadataCache[$cacheKey] = $null
+        return $null
     }
 
     $ctx = Get-DesignPlexContext
     $token = Get-OptionalStringProperty -InputObject $ctx -Name "Token"
     if ([string]::IsNullOrWhiteSpace($token)) {
+        Write-Log "Plex hosted metadata recovery requires the configured administrator Plex token." "WARN"
         $script:PlexHostedMetadataCache[$cacheKey] = $null
         return $null
     }
@@ -4301,12 +4315,14 @@ function Get-PlexHostedMetadata {
     }
 
     $metadata = $null
+    $requestCompleted = $false
     try {
         $raw = Invoke-RestMethod `
             -Uri ((Get-PlexMetadataProviderBaseUrl) + $lookupPath) `
             -Headers $headers `
             -Method Get `
             -TimeoutSec 60
+        $requestCompleted = $true
 
         if ($null -ne $raw -and $null -ne $raw.PSObject.Properties["MediaContainer"]) {
             $container = $raw.MediaContainer
@@ -4318,6 +4334,10 @@ function Get-PlexHostedMetadata {
     }
     catch {
         Write-Log "Plex hosted metadata fallback failed for deleted $MediaType history metadata: $($_.Exception.Message)" "WARN"
+    }
+
+    if ($requestCompleted -and $null -eq $metadata) {
+        Write-Log "Plex hosted metadata recovery returned no exact match for the retained $MediaType GUID." "WARN"
     }
 
     if ($null -ne $metadata -and $MediaType -eq "show") {

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -4284,19 +4284,26 @@ function Get-PlexHostedMetadataLookupPath {
     if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return "" }
 
     $guid = $MetadataGuid.Trim()
-    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9]+)(?:\?.*)?$') {
+    if ($guid -match '(?i)^plex://(?:movie|show|season|episode)/(?<id>[a-z0-9][a-z0-9_-]*)(?:\?.*)?$') {
         return "/library/metadata/" + [Uri]::EscapeDataString([string]$Matches.id)
     }
 
     $externalGuid = ""
-    if ($guid -match '(?i)^(?:tmdb|imdb)://[^/?]+(?:\?.*)?$') {
-        $externalGuid = $guid -replace '\?.*$', ''
+    if ($guid -match '(?i)^tmdb://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
+        $externalGuid = "tmdb://" + [string]$Matches.id
     }
-    elseif ($guid -match '(?i)^com\.plexapp\.agents\.themoviedb://(?<id>[0-9]+)(?:\?.*)?$') {
+    elseif ($guid -match '(?i)^imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
+        $externalGuid = "imdb://" + [string]$Matches.id
+    }
+    elseif ($guid -match '(?i)^com\.plexapp\.agents\.(?:themoviedb|tmdb)://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
         $externalGuid = "tmdb://" + [string]$Matches.id
     }
     elseif ($guid -match '(?i)^com\.plexapp\.agents\.imdb://(?<id>tt[0-9]+)(?:\?.*)?$') {
         $externalGuid = "imdb://" + [string]$Matches.id
+    }
+    elseif ($MediaType -eq "show" -and
+        $guid -match '(?i)^(?:tvdb|com\.plexapp\.agents\.thetvdb)://(?<id>[0-9]+)(?:/[^?]*)?(?:\?.*)?$') {
+        $externalGuid = "tvdb://" + [string]$Matches.id
     }
 
     if ([string]::IsNullOrWhiteSpace($externalGuid)) { return "" }
@@ -4314,17 +4321,24 @@ function Get-PlexHostedMetadata {
         [string]$MediaType
     )
 
-    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
-    if ([string]::IsNullOrWhiteSpace($lookupPath)) { return $null }
+    if ([string]::IsNullOrWhiteSpace($MetadataGuid)) { return $null }
 
-    $cacheKey = $MediaType + ":" + $MetadataGuid
+    $cacheKey = $MediaType + ":" + $MetadataGuid.Trim()
     if ($script:PlexHostedMetadataCache.ContainsKey($cacheKey)) {
         return $script:PlexHostedMetadataCache[$cacheKey]
+    }
+
+    $lookupPath = Get-PlexHostedMetadataLookupPath -MetadataGuid $MetadataGuid -MediaType $MediaType
+    if ([string]::IsNullOrWhiteSpace($lookupPath)) {
+        Write-Log "Plex hosted metadata recovery skipped a retained $MediaType GUID because its exact provider format is unsupported." "WARN"
+        $script:PlexHostedMetadataCache[$cacheKey] = $null
+        return $null
     }
 
     $ctx = Get-DesignPlexContext
     $token = Get-OptionalStringProperty -InputObject $ctx -Name "Token"
     if ([string]::IsNullOrWhiteSpace($token)) {
+        Write-Log "Plex hosted metadata recovery requires the configured administrator Plex token." "WARN"
         $script:PlexHostedMetadataCache[$cacheKey] = $null
         return $null
     }
@@ -4338,12 +4352,14 @@ function Get-PlexHostedMetadata {
     }
 
     $metadata = $null
+    $requestCompleted = $false
     try {
         $raw = Invoke-RestMethod `
             -Uri ((Get-PlexMetadataProviderBaseUrl) + $lookupPath) `
             -Headers $headers `
             -Method Get `
             -TimeoutSec 60
+        $requestCompleted = $true
 
         if ($null -ne $raw -and $null -ne $raw.PSObject.Properties["MediaContainer"]) {
             $container = $raw.MediaContainer
@@ -4355,6 +4371,10 @@ function Get-PlexHostedMetadata {
     }
     catch {
         Write-Log "Plex hosted metadata fallback failed for deleted $MediaType history metadata: $($_.Exception.Message)" "WARN"
+    }
+
+    if ($requestCompleted -and $null -eq $metadata) {
+        Write-Log "Plex hosted metadata recovery returned no exact match for the retained $MediaType GUID." "WARN"
     }
 
     if ($null -ne $metadata -and $MediaType -eq "show") {

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -32,6 +32,7 @@ $engines = @(
     [PSCustomObject]@{ Name = 'nas-docker-linux-freebsd'; Source = 'platforms/nas-docker/app'; Renderer = 'TautWeekly.ps1'; Host = $(if ($null -ne $powerShell7) { $powerShell7.Source } else { '' }); Container = $true },
     [PSCustomObject]@{ Name = 'mac-docker'; Source = 'platforms/mac-docker/app'; Renderer = 'TautWeekly.ps1'; Host = $(if ($null -ne $powerShell7) { $powerShell7.Source } else { '' }); Container = $true }
 )
+$deletedHistoryScenarios = @('deleted-history-metadata', 'deleted-history-legacy-guid')
 
 $executed = 0
 foreach ($engine in $engines) {
@@ -40,7 +41,7 @@ foreach ($engine in $engines) {
         continue
     }
 
-    foreach ($scenario in @('active', 'quiet', 'tv-only', 'optional-hero-metadata', 'deleted-history-metadata')) {
+    foreach ($scenario in @('active', 'quiet', 'tv-only', 'optional-hero-metadata') + $deletedHistoryScenarios) {
         $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ('tautweekly-integration-' + [Guid]::NewGuid().ToString('N'))
         $appRoot = Join-Path $tempRoot 'app'
         $dataRoot = Join-Path $tempRoot 'data'
@@ -81,7 +82,7 @@ foreach ($engine in $engines) {
             $baseUrl = (Get-Content $readyFile -Raw).Trim()
 
             $smtpPort = 0
-            if ($scenario -in @('optional-hero-metadata', 'deleted-history-metadata')) {
+            if ($scenario -eq 'optional-hero-metadata' -or $scenario -in $deletedHistoryScenarios) {
                 $smtpPort = Get-FreeTcpPort
                 $smtpServer = Start-Process -FilePath $PythonPath -ArgumentList @(
                     '-u', $fakeSmtp, '--port', [string]$smtpPort,
@@ -111,7 +112,7 @@ foreach ($engine in $engines) {
                 MaxMovies = 4
                 MaxTv = 4
             }
-            if ($scenario -in @('optional-hero-metadata', 'deleted-history-metadata')) {
+            if ($scenario -eq 'optional-hero-metadata' -or $scenario -in $deletedHistoryScenarios) {
                 $configOverrides['SmtpHost'] = '127.0.0.1'
                 $configOverrides['SmtpPort'] = $smtpPort
                 $configOverrides['SmtpEnableSsl'] = $false
@@ -146,7 +147,7 @@ foreach ($engine in $engines) {
                     $env:TAUTWEEKLY_DATA_DIR = $dataRoot
                     $env:TAUTWEEKLY_CONFIG = $configPath
                 }
-                if ($scenario -eq 'deleted-history-metadata') {
+                if ($scenario -in $deletedHistoryScenarios) {
                     $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL = $baseUrl + '/hosted'
                     $env:TAUTWEEKLY_TEST_PLEX_WATCH_URL = $baseUrl + '/watch'
                 }
@@ -173,7 +174,7 @@ foreach ($engine in $engines) {
             Assert-True ((Get-ChildItem $outputRoot -Filter 'preview-all-*.html').Count -eq 7) "$($engine.Name)/$scenario did not generate all six states plus the index."
             $indexHtml = Get-Content $indexPath -Raw -Encoding UTF8
             $normalHtml = Get-Content $normalPath -Raw -Encoding UTF8
-            $expectedMode = if ($scenario -in @('quiet', 'deleted-history-metadata')) { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
+            $expectedMode = if ($scenario -eq 'quiet' -or $scenario -in $deletedHistoryScenarios) { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
             Assert-True ($indexHtml.Contains($expectedMode)) "$($engine.Name)/$scenario reported the wrong release mode."
             Assert-True ($normalHtml.Contains('Selected Movie')) "$($engine.Name)/$scenario lost the selected movie."
             Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the selected TV show."
@@ -183,7 +184,7 @@ foreach ($engine in $engines) {
             Assert-True ($normalHtml.Contains('1 TV show')) "$($engine.Name)/$scenario lost the unique TV-show breakdown."
             Assert-True (-not $normalHtml.Contains('0 movies')) "$($engine.Name)/$scenario rendered an empty Binge Champion movie category."
             Assert-True (-not $normalHtml.Contains('qualifying plays')) "$($engine.Name)/$scenario retained qualifying-play copy in Total Watched."
-            if ($scenario -ne 'deleted-history-metadata') {
+            if ($scenario -notin $deletedHistoryScenarios) {
                 Assert-True (-not $normalHtml.Contains('TV SHOWS WATCHED')) "$($engine.Name)/$scenario rendered an empty TV stats card."
             }
 
@@ -194,7 +195,7 @@ foreach ($engine in $engines) {
                 Assert-True (([regex]::Matches($normalHtml, 'Selected Show')).Count -ge 2) "$($engine.Name)/$scenario removed the TV release after using Trending as the hero."
             }
 
-            if ($scenario -eq 'deleted-history-metadata') {
+            if ($scenario -in $deletedHistoryScenarios) {
                 Assert-True ($normalHtml.Contains('TV SHOWS WATCHED')) "$($engine.Name)/$scenario did not render the deleted-history TV stats card."
                 Assert-True ($normalHtml.Contains('Hosted history show summary.')) "$($engine.Name)/$scenario did not restore the deleted TV summary."
                 Assert-True ($normalHtml.Contains('History Drama, Mystery, and more')) "$($engine.Name)/$scenario did not restore deleted movie genres."
@@ -224,12 +225,28 @@ foreach ($engine in $engines) {
                 [string]$_.query.section_id -notin @('10', '20')
             }).Count -eq 0) "$($engine.Name)/$scenario issued an unscoped/private media query."
 
-            if ($scenario -eq 'deleted-history-metadata') {
+            if ($scenario -in $deletedHistoryScenarios) {
                 $hostedCalls = @($calls | Where-Object { [string]$_.path -like '/hosted/library/metadata/*' })
                 Assert-True (@($hostedCalls | Where-Object { -not $_.has_plex_token }).Count -eq 0) "$($engine.Name)/$scenario called hosted metadata without the administrator Plex token."
-                Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedmovieguid' }).Count -gt 0) "$($engine.Name)/$scenario did not resolve the retained movie GUID."
-                Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedepisodeguid' }).Count -gt 0) "$($engine.Name)/$scenario did not resolve the retained episode GUID."
-                Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedshowguid' }).Count -gt 0) "$($engine.Name)/$scenario did not promote the retained episode GUID to show metadata."
+                if ($scenario -eq 'deleted-history-legacy-guid') {
+                    $legacyMovieCalls = @($hostedCalls | Where-Object {
+                        [string]$_.path -eq '/hosted/library/metadata/matches' -and
+                        [string]$_.query.guid -eq 'tmdb://12345' -and
+                        [string]$_.query.type -eq '1'
+                    })
+                    $legacyShowCalls = @($hostedCalls | Where-Object {
+                        [string]$_.path -eq '/hosted/library/metadata/matches' -and
+                        [string]$_.query.guid -eq 'tvdb://999' -and
+                        [string]$_.query.type -eq '2'
+                    })
+                    Assert-True ($legacyMovieCalls.Count -gt 0) "$($engine.Name)/$scenario did not resolve the exact legacy TMDB movie GUID."
+                    Assert-True ($legacyShowCalls.Count -gt 0) "$($engine.Name)/$scenario did not reduce the exact legacy TVDB episode GUID to its show identifier."
+                }
+                else {
+                    Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedmovieguid' }).Count -gt 0) "$($engine.Name)/$scenario did not resolve the retained movie GUID."
+                    Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedepisodeguid' }).Count -gt 0) "$($engine.Name)/$scenario did not resolve the retained episode GUID."
+                    Assert-True (@($hostedCalls | Where-Object { [string]$_.path -eq '/hosted/library/metadata/deletedshowguid' }).Count -gt 0) "$($engine.Name)/$scenario did not promote the retained episode GUID to show metadata."
+                }
                 Assert-True (@($calls | Where-Object { [string]$_.path -match 'private' }).Count -eq 0) "$($engine.Name)/$scenario leaked a private-library identifier to hosted metadata."
                 $watchCalls = @($calls | Where-Object { [string]$_.path -like '/watch/*' })
                 Assert-True (@($watchCalls | Where-Object { $_.has_plex_token }).Count -eq 0) "$($engine.Name)/$scenario forwarded the Plex token to the public rating fallback."
@@ -241,7 +258,7 @@ foreach ($engine in $engines) {
                 Assert-True (@($externalPosterCalls | Where-Object { $_.has_plex_token }).Count -eq 0) "$($engine.Name)/$scenario forwarded the Plex token to an external poster host."
             }
 
-            if ($scenario -in @('optional-hero-metadata', 'deleted-history-metadata')) {
+            if ($scenario -eq 'optional-hero-metadata' -or $scenario -in $deletedHistoryScenarios) {
                 $previewLog = Get-Content $stdout -Raw
                 Assert-True ($previewLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario did not exercise the recoverable direct Plex 404 fallback."
                 Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the global-history title fallback for sparse hero metadata."
@@ -277,7 +294,7 @@ foreach ($engine in $engines) {
                         $env:TAUTWEEKLY_DATA_DIR = $dataRoot
                         $env:TAUTWEEKLY_CONFIG = $configPath
                     }
-                    if ($scenario -eq 'deleted-history-metadata') {
+                    if ($scenario -in $deletedHistoryScenarios) {
                         Remove-Item -LiteralPath (Join-Path $outputRoot 'posters') -Recurse -Force -ErrorAction SilentlyContinue
                         New-Item -ItemType Directory -Force -Path (Join-Path $outputRoot 'posters') | Out-Null
                         $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL = $baseUrl + '/hosted'
@@ -301,7 +318,7 @@ foreach ($engine in $engines) {
                 $sendLog = Get-Content $sendStdout -Raw
                 Assert-True ($sendLog.Contains('Test email sent successfully.')) "$($engine.Name)/$scenario SendTest did not complete delivery."
                 Assert-True ($sendLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario SendTest did not preserve the direct Plex 404 warning."
-                if ($scenario -eq 'deleted-history-metadata') {
+                if ($scenario -in $deletedHistoryScenarios) {
                     Assert-True ($sendLog.Contains('Recovered deleted Plex movie history artwork')) "$($engine.Name)/$scenario SendTest did not recover deleted movie artwork."
                     Assert-True ($sendLog.Contains('Recovered deleted Plex show history artwork')) "$($engine.Name)/$scenario SendTest did not recover deleted TV artwork."
                 }

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -22,7 +22,9 @@ $requiredFunctions = @(
     'Convert-DesignRatingPercent',
     'ConvertTo-DesignGenreList',
     'Add-DesignRatingMetadata',
+    'Get-PlexMetadataProviderBaseUrl',
     'Get-PlexHostedMetadataLookupPath',
+    'Get-PlexHostedMetadata',
     'Get-PlexWatchBaseUrl',
     'Get-PlexWatchRatings',
     'Get-TautulliDefaultPosterHash',
@@ -242,7 +244,52 @@ foreach ($relativePath in $rendererPaths) {
 
     Assert-True ((Get-PlexHostedMetadataLookupPath -MetadataGuid 'plex://movie/5d123abc?lang=en' -MediaType 'movie') -eq '/library/metadata/5d123abc') "$relativePath did not normalize a retained Plex GUID"
     Assert-True ((Get-PlexHostedMetadataLookupPath -MetadataGuid 'com.plexapp.agents.themoviedb://12345?lang=en' -MediaType 'movie') -eq '/library/metadata/matches?guid=tmdb%3A%2F%2F12345&type=1') "$relativePath did not normalize a legacy TMDB movie GUID"
-    Assert-True ([string]::IsNullOrWhiteSpace((Get-PlexHostedMetadataLookupPath -MetadataGuid 'com.plexapp.agents.thetvdb://999/1/2' -MediaType 'show'))) "$relativePath guessed from an unsupported legacy TVDB GUID"
+    Assert-True ((Get-PlexHostedMetadataLookupPath -MetadataGuid 'com.plexapp.agents.tmdb://54321?lang=en' -MediaType 'movie') -eq '/library/metadata/matches?guid=tmdb%3A%2F%2F54321&type=1') "$relativePath did not normalize the alternate legacy TMDB movie agent"
+    Assert-True ((Get-PlexHostedMetadataLookupPath -MetadataGuid 'com.plexapp.agents.themoviedb://24680/1/2?lang=en' -MediaType 'show') -eq '/library/metadata/matches?guid=tmdb%3A%2F%2F24680&type=2') "$relativePath did not reduce a legacy TMDB episode GUID to its exact show identifier"
+    Assert-True ((Get-PlexHostedMetadataLookupPath -MetadataGuid 'com.plexapp.agents.thetvdb://999/1/2?lang=en' -MediaType 'show') -eq '/library/metadata/matches?guid=tvdb%3A%2F%2F999&type=2') "$relativePath did not reduce a legacy TVDB episode GUID to its exact show identifier"
+    Assert-True ([string]::IsNullOrWhiteSpace((Get-PlexHostedMetadataLookupPath -MetadataGuid 'tmdb://private-title' -MediaType 'movie'))) "$relativePath accepted a non-numeric external metadata identifier"
+    Assert-True ([string]::IsNullOrWhiteSpace((Get-PlexHostedMetadataLookupPath -MetadataGuid 'local://private-library-item' -MediaType 'movie'))) "$relativePath sent a private local-library GUID to hosted metadata"
+
+    $script:PlexHostedMetadataCache = @{}
+    $script:hostedMetadataRequestCount = 0
+    $script:hostedMetadataWarnings = New-Object System.Collections.Generic.List[string]
+    $env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL = 'http://127.0.0.1:32123/hosted'
+    function Write-Log {
+        param([string]$Message, [string]$Level = 'INFO')
+        if ($Level -eq 'WARN') { $script:hostedMetadataWarnings.Add($Message) }
+    }
+    function Get-DesignPlexContext {
+        return [PSCustomObject]@{ Token = 'virtual-plex-token' }
+    }
+    function Invoke-RestMethod {
+        param(
+            [string]$Uri,
+            [hashtable]$Headers,
+            [string]$Method,
+            [int]$TimeoutSec
+        )
+        Assert-True ($Uri -eq 'http://127.0.0.1:32123/hosted/library/metadata/noexactmatch') "$relativePath changed the exact retained Plex GUID request"
+        Assert-True ([string]$Headers['X-Plex-Token'] -eq 'virtual-plex-token') "$relativePath omitted the administrator Plex token from hosted metadata"
+        $script:hostedMetadataRequestCount++
+        return [PSCustomObject]@{ MediaContainer = [PSCustomObject]@{ Metadata = @() } }
+    }
+    try {
+        $emptyHostedMetadata = Get-PlexHostedMetadata -MetadataGuid 'plex://movie/noexactmatch' -MediaType 'movie'
+        $cachedEmptyHostedMetadata = Get-PlexHostedMetadata -MetadataGuid 'plex://movie/noexactmatch' -MediaType 'movie'
+        Assert-True ($null -eq $emptyHostedMetadata -and $null -eq $cachedEmptyHostedMetadata) "$relativePath accepted an empty hosted metadata response"
+        Assert-True ($script:hostedMetadataRequestCount -eq 1) "$relativePath did not cache an empty exact-match response"
+        Assert-True (@($script:hostedMetadataWarnings | Where-Object { $_ -like '*returned no exact match*' }).Count -eq 1) "$relativePath did not report an empty exact-match response exactly once"
+
+        $unsupportedHostedMetadata = Get-PlexHostedMetadata -MetadataGuid 'local://private-library-item' -MediaType 'movie'
+        $cachedUnsupportedHostedMetadata = Get-PlexHostedMetadata -MetadataGuid 'local://private-library-item' -MediaType 'movie'
+        Assert-True ($null -eq $unsupportedHostedMetadata -and $null -eq $cachedUnsupportedHostedMetadata) "$relativePath accepted an unsupported private-library GUID"
+        Assert-True ($script:hostedMetadataRequestCount -eq 1) "$relativePath sent an unsupported private-library GUID to hosted metadata"
+        Assert-True (@($script:hostedMetadataWarnings | Where-Object { $_ -like '*provider format is unsupported*' }).Count -eq 1) "$relativePath did not report an unsupported retained GUID exactly once"
+        Assert-True (-not (($script:hostedMetadataWarnings -join '; ').Contains('private-library-item'))) "$relativePath leaked a retained private-library identifier into diagnostics"
+    }
+    finally {
+        Remove-Item Env:TAUTWEEKLY_TEST_PLEX_METADATA_PROVIDER_URL -ErrorAction SilentlyContinue
+    }
 
     function Write-Log { param([string]$Message, [string]$Level = 'INFO') }
     function Get-DesignPlexMetadata { param([string]$RatingKey) return $null }

--- a/scripts/test-support/fake-tautulli.py
+++ b/scripts/test-support/fake-tautulli.py
@@ -11,6 +11,12 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 
+DELETED_HISTORY_SCENARIOS = (
+    "deleted-history-metadata",
+    "deleted-history-legacy-guid",
+)
+
+
 def media_rows(scenario: str) -> dict[str, list[dict[str, object]]]:
     now = int(time.time())
     old = now - (30 * 86400)
@@ -64,9 +70,13 @@ def media_rows(scenario: str) -> dict[str, list[dict[str, object]]]:
             }
         ],
     }
-    if scenario == "deleted-history-metadata":
-        rows["10"][0]["guid"] = "plex://movie/deletedmovieguid"
-        rows["20"][0]["guid"] = "plex://episode/deletedepisodeguid"
+    if scenario in DELETED_HISTORY_SCENARIOS:
+        if scenario == "deleted-history-legacy-guid":
+            rows["10"][0]["guid"] = "com.plexapp.agents.tmdb://12345?lang=en"
+            rows["20"][0]["guid"] = "com.plexapp.agents.thetvdb://999/1/2?lang=en"
+        else:
+            rows["10"][0]["guid"] = "plex://movie/deletedmovieguid"
+            rows["20"][0]["guid"] = "plex://episode/deletedepisodeguid"
         for field in (
             "year",
             "summary",
@@ -124,8 +134,12 @@ def history_rows(section_id: str, scenario: str) -> list[dict[str, object]]:
                 "group_count": 1,
             }
         ]
-        if scenario == "deleted-history-metadata":
-            rows[0]["guid"] = "plex://movie/deletedmovieguid"
+        if scenario in DELETED_HISTORY_SCENARIOS:
+            rows[0]["guid"] = (
+                "com.plexapp.agents.tmdb://12345?lang=en"
+                if scenario == "deleted-history-legacy-guid"
+                else "plex://movie/deletedmovieguid"
+            )
             for field in ("year", "summary", "rating", "audience_rating"):
                 rows[0].pop(field, None)
         return rows
@@ -153,8 +167,13 @@ def history_rows(section_id: str, scenario: str) -> list[dict[str, object]]:
                 "rating_image": "imdb://image.rating",
             }
         ]
-        if scenario == "deleted-history-metadata":
-            rows[0]["guid"] = "plex://episode/deletedepisodeguid"
+        if scenario in DELETED_HISTORY_SCENARIOS:
+            deleted_episode_guid = (
+                "com.plexapp.agents.thetvdb://999/1/2?lang=en"
+                if scenario == "deleted-history-legacy-guid"
+                else "plex://episode/deletedepisodeguid"
+            )
+            rows[0]["guid"] = deleted_episode_guid
             for field in ("year", "summary", "rating", "rating_image"):
                 rows[0].pop(field, None)
             rows.append(
@@ -167,7 +186,7 @@ def history_rows(section_id: str, scenario: str) -> list[dict[str, object]]:
                     "parent_title": "Season 1",
                     "title": "Viewer Deleted Episode",
                     "year": "2026",
-                    "guid": "plex://episode/deletedepisodeguid",
+                    "guid": deleted_episode_guid,
                     "user_id": "1",
                     "friendly_name": "Virtual Viewer",
                     "play_duration": 1800,
@@ -226,6 +245,62 @@ class Handler(BaseHTTPRequestHandler):
                 )
                 + "\n"
             )
+
+        if parsed.path == "/hosted/library/metadata/matches":
+            if not self.headers.get("X-Plex-Token"):
+                self.write_json({"error": "missing virtual Plex token"}, status=401)
+                return
+
+            external_guid = query.get("guid", "")
+            media_type = query.get("type", "")
+            if external_guid == "tmdb://12345" and media_type == "1":
+                self.write_json(
+                    {
+                        "MediaContainer": {
+                            "Metadata": [
+                                {
+                                    "type": "movie",
+                                    "guid": "plex://movie/deletedmovieguid",
+                                    "slug": "selected-movie",
+                                    "title": "Selected Movie",
+                                    "year": "2026",
+                                    "summary": "Hosted history movie summary.",
+                                    "thumb": f"http://localhost:{self.server.server_port}/hosted/deleted-movie.jpg",  # type: ignore[attr-defined]
+                                    "Genre": [
+                                        {"tag": "History Drama"},
+                                        {"tag": "Mystery"},
+                                        {"tag": "Archive"},
+                                    ],
+                                }
+                            ]
+                        }
+                    }
+                )
+                return
+
+            if external_guid == "tvdb://999" and media_type == "2":
+                self.write_json(
+                    {
+                        "MediaContainer": {
+                            "Metadata": [
+                                {
+                                    "type": "show",
+                                    "guid": "plex://show/deletedshowguid",
+                                    "slug": "selected-show",
+                                    "title": "Selected Show",
+                                    "year": "2024",
+                                    "summary": "Hosted history show summary.",
+                                    "thumb": f"{self.server.base_url}/hosted/deleted-show.jpg",  # type: ignore[attr-defined]
+                                    "Genre": [{"tag": "Drama"}, {"tag": "Mystery"}],
+                                }
+                            ]
+                        }
+                    }
+                )
+                return
+
+            self.write_json({"MediaContainer": {"Metadata": []}})
+            return
 
         if parsed.path.startswith("/hosted/library/metadata/"):
             metadata_id = parsed.path.rsplit("/", 1)[-1]
@@ -339,7 +414,7 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if parsed.path.startswith("/library/metadata/"):
-            if self.server.scenario in ("optional-hero-metadata", "deleted-history-metadata"):  # type: ignore[attr-defined]
+            if self.server.scenario == "optional-hero-metadata" or self.server.scenario in DELETED_HISTORY_SCENARIOS:  # type: ignore[attr-defined]
                 self.write_json({"error": "sanitized missing Plex metadata"}, status=404)
                 return
             self.write_json({"MediaContainer": {"size": 0, "Metadata": []}})
@@ -351,7 +426,7 @@ class Handler(BaseHTTPRequestHandler):
 
         command = query.get("cmd", "")
         if command == "pms_image_proxy":
-            marker = b"GENERIC-POSTER" if self.server.scenario == "deleted-history-metadata" else b"VIRTUAL-POSTER"  # type: ignore[attr-defined]
+            marker = b"GENERIC-POSTER" if self.server.scenario in DELETED_HISTORY_SCENARIOS else b"VIRTUAL-POSTER"  # type: ignore[attr-defined]
             payload = b"\xff\xd8" + (marker * 48) + b"\xff\xd9"
             self.send_response(200)
             self.send_header("Content-Type", "image/jpeg")
@@ -408,7 +483,7 @@ class Handler(BaseHTTPRequestHandler):
             return
         if command == "get_metadata":
             key = query.get("rating_key", "")
-            if self.server.scenario == "deleted-history-metadata" and key in (  # type: ignore[attr-defined]
+            if self.server.scenario in DELETED_HISTORY_SCENARIOS and key in (  # type: ignore[attr-defined]
                 "selected-movie",
                 "selected-show",
                 "champion-episode",
@@ -470,7 +545,14 @@ def main() -> None:
     parser.add_argument("--port", type=int, required=True)
     parser.add_argument(
         "--scenario",
-        choices=("active", "quiet", "tv-only", "optional-hero-metadata", "deleted-history-metadata"),
+        choices=(
+            "active",
+            "quiet",
+            "tv-only",
+            "optional-hero-metadata",
+            "deleted-history-metadata",
+            "deleted-history-legacy-guid",
+        ),
         required=True,
     )
     parser.add_argument("--call-log", type=Path, required=True)


### PR DESCRIPTION
## Summary

- normalize exact legacy TMDB agent aliases and TVDB episode/show GUIDs retained in Tautulli history
- keep modern `plex://` recovery intact while reporting unsupported and empty exact matches without logging identifiers
- add PreviewAll and SendTest regressions for modern and legacy deleted-history recovery across every maintained renderer

## Root cause

v0.8.0 only accepted modern `plex://` identifiers plus a narrow subset of legacy movie GUIDs. Tautulli can retain older `com.plexapp.agents.tmdb://…` and `com.plexapp.agents.thetvdb://…` identifiers after Plex deletes the item. Those formats returned before any hosted request or diagnostic, leaving posters and retained metadata blank.

## Privacy and security

Recovery remains exact-ID only. Legacy identifiers must contain validated numeric provider IDs; there is no title search. The configured administrator Plex token is sent only to Plex hosted metadata, never to external artwork or public watch pages, and retained identifiers are not written to diagnostics.

## Validation

- deterministic sanitized reproduction confirmed the legacy GUIDs returned no lookup path on v0.8.0
- corrected lookup paths verified for modern Plex, alternate TMDB, and legacy TVDB identifiers
- local fake hosted provider smoke-tested exact TMDB/TVDB query shapes and Plex-token presence
- Python fixture syntax and `git diff --check` pass
- full PowerShell/platform/package validation is delegated to the repository CI matrix because local PowerShell is restricted by host application-control policy

Fixes #41
