### PR TITLE
fix: preserve dark email rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-08-10
+
+### Fixed
+
+- Preserved the newsletter's single dark-first palette in Apple Mail by
+  declaring dark-only color-scheme support, and reinforced every maintained
+  renderer with explicit longhand backgrounds and table `bgcolor` fallbacks
+  for clients such as Gmail and Outlook that ignore or override scheme hints.
+  Reported by [@Demonmeister](https://github.com/Demonmeister) in
+  [#44](https://github.com/sparkmoxie/TautWeekly/issues/44).
+- Captured and decoded the integration test's delivered MIME message so the
+  preview variants and SMTP HTML must both retain the dark-mode metadata,
+  outer canvas, card colors, and compatibility fallbacks.
+
 ## [0.8.3] - 2026-08-10
 
 ### Fixed

--- a/platforms/freebsd-podman/CHANGELOG.txt
+++ b/platforms/freebsd-podman/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex FreeBSD Podman platform changelog
 
 Unreleased
+- Preserves the dark-first email palette with dark-only metadata, explicit longhand backgrounds, and table color fallbacks.
 - Supplies Plex's required deleted-history title and episode-index match context, validates responses, and keeps missing artwork nonfatal.
 - Retries empty modern Plex and legacy TMDB/TVDB exact matches through Plex's current provider POST contract.
 - Recovers deleted Plex history through legacy TMDB/TVDB exact identifiers and reports unsupported or empty matches safely.

--- a/platforms/linux/CHANGELOG.txt
+++ b/platforms/linux/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex native Linux platform changelog
 
 Unreleased
+- Preserves the dark-first email palette with dark-only metadata, explicit longhand backgrounds, and table color fallbacks.
 - Supplies Plex's required deleted-history title and episode-index match context, validates responses, and keeps missing artwork nonfatal.
 - Retries empty modern Plex and legacy TMDB/TVDB exact matches through Plex's current provider POST contract.
 - Recovers deleted Plex history through legacy TMDB/TVDB exact identifiers and reports unsupported or empty matches safely.

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- preserves the dark-first email palette with dark-only metadata, explicit longhand backgrounds, and table color fallbacks
 - supplies Plex's required deleted-history title and episode-index match context, validates responses, and keeps missing artwork nonfatal
 - retries empty modern Plex and legacy TMDB/TVDB exact matches through Plex's current provider POST contract
 - recovers deleted Plex history through legacy TMDB/TVDB exact identifiers and reports unsupported or empty matches safely

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -4958,7 +4958,7 @@ function Get-StatsMovieRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $title + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5020,7 +5020,7 @@ function Get-StatsEpisodeRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $showTitle + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5068,7 +5068,7 @@ function Get-StatsTvShowRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $showTitle + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5231,7 +5231,7 @@ function Get-ReleaseCardsHtml {
                 $posterHtml = '<img src="' + (HtmlEncode $posterSrc) + '" width="100%" alt="' + $title + ' poster" style="display:block;width:100%;height:auto;border:0;border-radius:8px 8px 0 0;">'
             }
             else {
-                $posterHtml = '<div style="height:260px;background:#222;border-radius:8px 8px 0 0;text-align:center;color:#777;font-size:12px;line-height:260px;">Poster unavailable</div>'
+                $posterHtml = '<div style="height:260px;background-color:#222;border-radius:8px 8px 0 0;text-align:center;color:#777;font-size:12px;line-height:260px;">Poster unavailable</div>'
             }
 
             $contentHeight = if ($Kind -eq "Movie") { 170 } else { 184 }
@@ -5319,7 +5319,7 @@ $genreHtml
 
             [void]$html.Append(@"
 <td width="50%" valign="top" style="padding:0 6px 18px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="width:100%;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;overflow:hidden;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;overflow:hidden;">
     <tr>
       <td valign="top" style="padding:0;">
         $posterHtml
@@ -5559,7 +5559,7 @@ $tvCards
         $welcomeBlock = @"
 <tr>
 <td class="pad" style="padding:4px 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #e5a00d;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #e5a00d;border-radius:10px;border-collapse:separate;">
     <tr>
       <td valign="middle" style="padding:20px 22px;">
         <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.4px;">
@@ -5703,7 +5703,7 @@ $tvCards
         $hotBlock = @"
 <tr class="design-hot-desktop">
 <td class="pad" style="padding:4px 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="205" valign="top" style="padding:16px 0 16px 16px;">
         $hotPosterHtml
@@ -5748,7 +5748,7 @@ $tvCards
 
 <tr class="design-hot-mobile" style="display:none;">
 <td class="pad" style="padding:0 12px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;overflow:hidden;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;overflow:hidden;">
     <tr>
       <td style="padding:0;">
         <div class="design-mobile-banner-wrap" style="position:relative;overflow:hidden;">
@@ -5820,7 +5820,7 @@ $tvCards
         $trendingBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       $posterCell
       <td width="56" valign="middle" style="padding:16px 0 16px 14px;">
@@ -5971,15 +5971,15 @@ $tvCards
     if ($movieDetailMode -and $tvShowDetailMode) {
         $mediaStatsRow = @"
 <tr>
-  <td width="50%" valign="top" style="padding:0 5px 10px 0;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$movieCardContent</td></tr></table></td>
-  <td width="50%" valign="top" style="padding:0 0 10px 5px;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$tvShowCardContent</td></tr></table></td>
+  <td width="50%" valign="top" style="padding:0 5px 10px 0;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$movieCardContent</td></tr></table></td>
+  <td width="50%" valign="top" style="padding:0 0 10px 5px;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$tvShowCardContent</td></tr></table></td>
 </tr>
 "@
     }
     elseif ($movieDetailMode -or $tvShowDetailMode) {
         $singleMediaContent = if ($movieDetailMode) { $movieCardContent } else { $tvShowCardContent }
         $mediaStatsRow = @"
-<tr><td colspan="2" width="100%" valign="top" style="padding:0 0 10px;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$singleMediaContent</td></tr></table></td></tr>
+<tr><td colspan="2" width="100%" valign="top" style="padding:0 0 10px;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$singleMediaContent</td></tr></table></td></tr>
 "@
     }
 
@@ -6005,7 +6005,7 @@ $tvCards
         $statsBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 16px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="72" valign="middle" style="padding:20px 0 20px 20px;">
         <img src="$zeroIconSrc" width="48" height="48" alt="$(HtmlEncode $zeroAlt)" style="display:block;width:48px;height:48px;border:0;">
@@ -6029,7 +6029,7 @@ $tvCards
 $mediaStatsRow
 <tr>
   <td width="50%" valign="top" style="padding:0 5px 10px 0;">
-    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+    <table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$statsCardHeight" valign="middle" style="height:${statsCardHeight}px;padding:17px;">
           <img src="$clockIconSrc" width="42" height="42" alt="Total watched" style="display:block;width:42px;height:42px;border:0;">
@@ -6040,7 +6040,7 @@ $mediaStatsRow
     </table>
   </td>
   <td width="50%" valign="top" style="padding:0 0 10px 5px;">
-    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
+    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="width:100%;height:${statsCardHeight}px;background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$statsCardHeight" valign="middle" style="height:${statsCardHeight}px;padding:17px;">
           <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
@@ -6064,7 +6064,7 @@ $mediaStatsRow
         $bingeStandaloneBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 24px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="84" valign="middle" style="padding:18px 0 18px 20px;">
         <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;">
@@ -6106,7 +6106,7 @@ $mediaStatsRow
         @"
 <tr>
 <td class="pad" style="padding:10px 20px 22px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td style="padding:20px 22px;">
         <div style="font-size:13px;color:#e5a00d;font-weight:800;">
@@ -6158,10 +6158,19 @@ $mediaStatsRow
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
 <title>TautWeekly for Plex</title>
 <style>
 /* Email-safe table-first layout; only the featured hero swaps at the mobile breakpoint. */
+:root { color-scheme:dark only; supported-color-schemes:dark; }
+.email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+.email-card { background-color:#181818 !important; }
 .design-hot-mobile { display:none; }
+@media (prefers-color-scheme: dark) {
+  .email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+  .email-card { background-color:#181818 !important; }
+}
 @media only screen and (max-width: 620px) {
   .container { width: 100% !important; }
   .pad { padding-left: 12px !important; padding-right: 12px !important; }
@@ -6173,12 +6182,12 @@ $mediaStatsRow
 }
 </style>
 </head>
-<body style="margin:0;padding:0;background:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
+<body class="email-background" bgcolor="#0f0f0f" style="margin:0;padding:0;background-color:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
 <div style="display:none!important;font-size:1px;line-height:1px;max-height:0;max-width:0;overflow:hidden;opacity:0;color:transparent;mso-hide:all;">$(HtmlEncode $preheader)$preheaderPadding</div>
-<table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#0f0f0f;">
+<table class="email-background" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="background-color:#0f0f0f;">
 <tr>
-<td align="center" style="padding:28px 10px;">
-<table class="container" width="640" cellspacing="0" cellpadding="0" border="0" style="width:640px;max-width:640px;">
+<td class="email-background" align="center" bgcolor="#0f0f0f" style="padding:28px 10px;background-color:#0f0f0f;">
+<table class="container email-background" width="640" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="width:640px;max-width:640px;background-color:#0f0f0f;">
 <tr>
 <td class="pad" style="padding:0 20px 18px;">
   <div style="font-size:13px;font-weight:800;letter-spacing:2px;color:#e5a00d;">$(HtmlEncode $serverLabel)</div>
@@ -6208,7 +6217,7 @@ $trendingBlock
 
 <tr>
 <td class="pad" align="center" style="padding:8px 20px 18px;">
-  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:13px 24px;border-radius:7px;">OPEN PLEX</a>
+  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background-color:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:13px 24px;border-radius:7px;">OPEN PLEX</a>
 </td>
 </tr>
 
@@ -6447,14 +6456,25 @@ function Build-WelcomeHtml {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
 <title>Welcome aboard</title>
+<style>
+:root { color-scheme:dark only; supported-color-schemes:dark; }
+.email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+.email-card { background-color:#181818 !important; }
+@media (prefers-color-scheme: dark) {
+  .email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+  .email-card { background-color:#181818 !important; }
+}
+</style>
 </head>
-<body style="margin:0;padding:0;background:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
+<body class="email-background" bgcolor="#0f0f0f" style="margin:0;padding:0;background-color:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
 <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;mso-hide:all;">Your access to $(HtmlEncode $footerServerName) is live.</div>
-<table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#0f0f0f;">
+<table class="email-background" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="background-color:#0f0f0f;">
 <tr>
-<td align="center" style="padding:34px 12px;">
-<table width="600" cellspacing="0" cellpadding="0" border="0" style="width:600px;max-width:600px;">
+<td class="email-background" align="center" bgcolor="#0f0f0f" style="padding:34px 12px;background-color:#0f0f0f;">
+<table class="email-background" width="600" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="width:600px;max-width:600px;background-color:#0f0f0f;">
 <tr>
 <td style="padding:0 20px 20px;">
   <div style="font-size:12px;color:#e5a00d;font-weight:800;letter-spacing:1.8px;">
@@ -6467,7 +6487,7 @@ function Build-WelcomeHtml {
 </tr>
 <tr>
 <td style="padding:0 20px 22px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td style="padding:20px 22px;">
         <div style="font-size:13px;color:#e5a00d;font-weight:800;">🍿 $($deliveryDay.ToUpperInvariant()) DROPS</div>
@@ -6485,7 +6505,7 @@ function Build-WelcomeHtml {
 </tr>
 <tr>
 <td align="center" style="padding:4px 20px 24px;">
-  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:14px 28px;border-radius:7px;">OPEN PLEX</a>
+  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background-color:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:14px 28px;border-radius:7px;">OPEN PLEX</a>
 </td>
 </tr>
 <tr>
@@ -7559,7 +7579,7 @@ if ($Mode -eq "PreviewAll") {
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>TautWeekly for Plex — All Email Types</title>
 <style>
-body{margin:0;background:#0f0f0f;color:#fff;font-family:Arial,Helvetica,sans-serif;padding:32px 18px}.wrap{max-width:900px;margin:auto}.eyebrow{color:#e5a00d;font-size:12px;font-weight:800;letter-spacing:1.5px}.card{margin-top:14px;padding:18px 20px;background:#181818;border:1px solid #2b2b2b;border-radius:10px}.title{font-size:18px;font-weight:800}.subject{color:#aaa;margin-top:7px;font-size:13px;line-height:1.45}.btn{display:inline-block;margin-top:13px;background:#e5a00d;color:#111;text-decoration:none;font-weight:800;padding:10px 15px;border-radius:7px}.note{margin-top:20px;color:#999;font-size:12px;line-height:1.55;border-left:3px solid #e5a00d;padding-left:12px}.meta{color:#888;font-size:13px;line-height:1.55;margin-top:8px}
+body{margin:0;background-color:#0f0f0f;color:#fff;font-family:Arial,Helvetica,sans-serif;padding:32px 18px}.wrap{max-width:900px;margin:auto}.eyebrow{color:#e5a00d;font-size:12px;font-weight:800;letter-spacing:1.5px}.card{margin-top:14px;padding:18px 20px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px}.title{font-size:18px;font-weight:800}.subject{color:#aaa;margin-top:7px;font-size:13px;line-height:1.45}.btn{display:inline-block;margin-top:13px;background-color:#e5a00d;color:#111;text-decoration:none;font-weight:800;padding:10px 15px;border-radius:7px}.note{margin-top:20px;color:#999;font-size:12px;line-height:1.55;border-left:3px solid #e5a00d;padding-left:12px}.meta{color:#888;font-size:13px;line-height:1.55;margin-top:8px}
 </style></head><body><div class="wrap">
 <div class="eyebrow">TAUTWEEKLY FOR PLEX — ALL EMAIL TYPES</div>
 <h1 style="margin:8px 0 0;font-size:30px;">The real email layout, across every state.</h1>

--- a/platforms/nas-docker/CHANGELOG.txt
+++ b/platforms/nas-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX NAS PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- preserves the dark-first email palette with dark-only metadata, explicit longhand backgrounds, and table color fallbacks
 - supplies Plex's required deleted-history title and episode-index match context, validates responses, and keeps missing artwork nonfatal
 - retries empty modern Plex and legacy TMDB/TVDB exact matches through Plex's current provider POST contract
 - recovers deleted Plex history through legacy TMDB/TVDB exact identifiers and reports unsupported or empty matches safely

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -4959,7 +4959,7 @@ function Get-StatsMovieRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $title + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5021,7 +5021,7 @@ function Get-StatsEpisodeRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $showTitle + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5069,7 +5069,7 @@ function Get-StatsTvShowRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $showTitle + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5232,7 +5232,7 @@ function Get-ReleaseCardsHtml {
                 $posterHtml = '<img src="' + (HtmlEncode $posterSrc) + '" width="100%" alt="' + $title + ' poster" style="display:block;width:100%;height:auto;border:0;border-radius:8px 8px 0 0;">'
             }
             else {
-                $posterHtml = '<div style="height:260px;background:#222;border-radius:8px 8px 0 0;text-align:center;color:#777;font-size:12px;line-height:260px;">Poster unavailable</div>'
+                $posterHtml = '<div style="height:260px;background-color:#222;border-radius:8px 8px 0 0;text-align:center;color:#777;font-size:12px;line-height:260px;">Poster unavailable</div>'
             }
 
             $contentHeight = if ($Kind -eq "Movie") { 170 } else { 184 }
@@ -5320,7 +5320,7 @@ $genreHtml
 
             [void]$html.Append(@"
 <td width="50%" valign="top" style="padding:0 6px 18px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="width:100%;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;overflow:hidden;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;overflow:hidden;">
     <tr>
       <td valign="top" style="padding:0;">
         $posterHtml
@@ -5560,7 +5560,7 @@ $tvCards
         $welcomeBlock = @"
 <tr>
 <td class="pad" style="padding:4px 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #e5a00d;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #e5a00d;border-radius:10px;border-collapse:separate;">
     <tr>
       <td valign="middle" style="padding:20px 22px;">
         <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.4px;">
@@ -5704,7 +5704,7 @@ $tvCards
         $hotBlock = @"
 <tr class="design-hot-desktop">
 <td class="pad" style="padding:4px 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="205" valign="top" style="padding:16px 0 16px 16px;">
         $hotPosterHtml
@@ -5749,7 +5749,7 @@ $tvCards
 
 <tr class="design-hot-mobile" style="display:none;">
 <td class="pad" style="padding:0 12px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;overflow:hidden;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;overflow:hidden;">
     <tr>
       <td style="padding:0;">
         <div class="design-mobile-banner-wrap" style="position:relative;overflow:hidden;">
@@ -5821,7 +5821,7 @@ $tvCards
         $trendingBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       $posterCell
       <td width="56" valign="middle" style="padding:16px 0 16px 14px;">
@@ -5972,15 +5972,15 @@ $tvCards
     if ($movieDetailMode -and $tvShowDetailMode) {
         $mediaStatsRow = @"
 <tr>
-  <td width="50%" valign="top" style="padding:0 5px 10px 0;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$movieCardContent</td></tr></table></td>
-  <td width="50%" valign="top" style="padding:0 0 10px 5px;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$tvShowCardContent</td></tr></table></td>
+  <td width="50%" valign="top" style="padding:0 5px 10px 0;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$movieCardContent</td></tr></table></td>
+  <td width="50%" valign="top" style="padding:0 0 10px 5px;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$tvShowCardContent</td></tr></table></td>
 </tr>
 "@
     }
     elseif ($movieDetailMode -or $tvShowDetailMode) {
         $singleMediaContent = if ($movieDetailMode) { $movieCardContent } else { $tvShowCardContent }
         $mediaStatsRow = @"
-<tr><td colspan="2" width="100%" valign="top" style="padding:0 0 10px;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$singleMediaContent</td></tr></table></td></tr>
+<tr><td colspan="2" width="100%" valign="top" style="padding:0 0 10px;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$singleMediaContent</td></tr></table></td></tr>
 "@
     }
 
@@ -6006,7 +6006,7 @@ $tvCards
         $statsBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 16px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="72" valign="middle" style="padding:20px 0 20px 20px;">
         <img src="$zeroIconSrc" width="48" height="48" alt="$(HtmlEncode $zeroAlt)" style="display:block;width:48px;height:48px;border:0;">
@@ -6030,7 +6030,7 @@ $tvCards
 $mediaStatsRow
 <tr>
   <td width="50%" valign="top" style="padding:0 5px 10px 0;">
-    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+    <table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$statsCardHeight" valign="middle" style="height:${statsCardHeight}px;padding:17px;">
           <img src="$clockIconSrc" width="42" height="42" alt="Total watched" style="display:block;width:42px;height:42px;border:0;">
@@ -6041,7 +6041,7 @@ $mediaStatsRow
     </table>
   </td>
   <td width="50%" valign="top" style="padding:0 0 10px 5px;">
-    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
+    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="width:100%;height:${statsCardHeight}px;background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$statsCardHeight" valign="middle" style="height:${statsCardHeight}px;padding:17px;">
           <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
@@ -6065,7 +6065,7 @@ $mediaStatsRow
         $bingeStandaloneBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 24px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="84" valign="middle" style="padding:18px 0 18px 20px;">
         <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;">
@@ -6107,7 +6107,7 @@ $mediaStatsRow
         @"
 <tr>
 <td class="pad" style="padding:10px 20px 22px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td style="padding:20px 22px;">
         <div style="font-size:13px;color:#e5a00d;font-weight:800;">
@@ -6159,10 +6159,19 @@ $mediaStatsRow
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
 <title>TautWeekly for Plex</title>
 <style>
 /* Email-safe table-first layout; only the featured hero swaps at the mobile breakpoint. */
+:root { color-scheme:dark only; supported-color-schemes:dark; }
+.email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+.email-card { background-color:#181818 !important; }
 .design-hot-mobile { display:none; }
+@media (prefers-color-scheme: dark) {
+  .email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+  .email-card { background-color:#181818 !important; }
+}
 @media only screen and (max-width: 620px) {
   .container { width: 100% !important; }
   .pad { padding-left: 12px !important; padding-right: 12px !important; }
@@ -6174,12 +6183,12 @@ $mediaStatsRow
 }
 </style>
 </head>
-<body style="margin:0;padding:0;background:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
+<body class="email-background" bgcolor="#0f0f0f" style="margin:0;padding:0;background-color:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
 <div style="display:none!important;font-size:1px;line-height:1px;max-height:0;max-width:0;overflow:hidden;opacity:0;color:transparent;mso-hide:all;">$(HtmlEncode $preheader)$preheaderPadding</div>
-<table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#0f0f0f;">
+<table class="email-background" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="background-color:#0f0f0f;">
 <tr>
-<td align="center" style="padding:28px 10px;">
-<table class="container" width="640" cellspacing="0" cellpadding="0" border="0" style="width:640px;max-width:640px;">
+<td class="email-background" align="center" bgcolor="#0f0f0f" style="padding:28px 10px;background-color:#0f0f0f;">
+<table class="container email-background" width="640" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="width:640px;max-width:640px;background-color:#0f0f0f;">
 <tr>
 <td class="pad" style="padding:0 20px 18px;">
   <div style="font-size:13px;font-weight:800;letter-spacing:2px;color:#e5a00d;">$(HtmlEncode $serverLabel)</div>
@@ -6209,7 +6218,7 @@ $trendingBlock
 
 <tr>
 <td class="pad" align="center" style="padding:8px 20px 18px;">
-  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:13px 24px;border-radius:7px;">OPEN PLEX</a>
+  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background-color:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:13px 24px;border-radius:7px;">OPEN PLEX</a>
 </td>
 </tr>
 
@@ -6448,14 +6457,25 @@ function Build-WelcomeHtml {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
 <title>Welcome aboard</title>
+<style>
+:root { color-scheme:dark only; supported-color-schemes:dark; }
+.email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+.email-card { background-color:#181818 !important; }
+@media (prefers-color-scheme: dark) {
+  .email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+  .email-card { background-color:#181818 !important; }
+}
+</style>
 </head>
-<body style="margin:0;padding:0;background:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
+<body class="email-background" bgcolor="#0f0f0f" style="margin:0;padding:0;background-color:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
 <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;mso-hide:all;">Your access to $(HtmlEncode $footerServerName) is live.</div>
-<table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#0f0f0f;">
+<table class="email-background" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="background-color:#0f0f0f;">
 <tr>
-<td align="center" style="padding:34px 12px;">
-<table width="600" cellspacing="0" cellpadding="0" border="0" style="width:600px;max-width:600px;">
+<td class="email-background" align="center" bgcolor="#0f0f0f" style="padding:34px 12px;background-color:#0f0f0f;">
+<table class="email-background" width="600" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="width:600px;max-width:600px;background-color:#0f0f0f;">
 <tr>
 <td style="padding:0 20px 20px;">
   <div style="font-size:12px;color:#e5a00d;font-weight:800;letter-spacing:1.8px;">
@@ -6468,7 +6488,7 @@ function Build-WelcomeHtml {
 </tr>
 <tr>
 <td style="padding:0 20px 22px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td style="padding:20px 22px;">
         <div style="font-size:13px;color:#e5a00d;font-weight:800;">🍿 $($deliveryDay.ToUpperInvariant()) DROPS</div>
@@ -6486,7 +6506,7 @@ function Build-WelcomeHtml {
 </tr>
 <tr>
 <td align="center" style="padding:4px 20px 24px;">
-  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:14px 28px;border-radius:7px;">OPEN PLEX</a>
+  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background-color:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:14px 28px;border-radius:7px;">OPEN PLEX</a>
 </td>
 </tr>
 <tr>
@@ -7560,7 +7580,7 @@ if ($Mode -eq "PreviewAll") {
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>TautWeekly for Plex — All Email Types</title>
 <style>
-body{margin:0;background:#0f0f0f;color:#fff;font-family:Arial,Helvetica,sans-serif;padding:32px 18px}.wrap{max-width:900px;margin:auto}.eyebrow{color:#e5a00d;font-size:12px;font-weight:800;letter-spacing:1.5px}.card{margin-top:14px;padding:18px 20px;background:#181818;border:1px solid #2b2b2b;border-radius:10px}.title{font-size:18px;font-weight:800}.subject{color:#aaa;margin-top:7px;font-size:13px;line-height:1.45}.btn{display:inline-block;margin-top:13px;background:#e5a00d;color:#111;text-decoration:none;font-weight:800;padding:10px 15px;border-radius:7px}.note{margin-top:20px;color:#999;font-size:12px;line-height:1.55;border-left:3px solid #e5a00d;padding-left:12px}.meta{color:#888;font-size:13px;line-height:1.55;margin-top:8px}
+body{margin:0;background-color:#0f0f0f;color:#fff;font-family:Arial,Helvetica,sans-serif;padding:32px 18px}.wrap{max-width:900px;margin:auto}.eyebrow{color:#e5a00d;font-size:12px;font-weight:800;letter-spacing:1.5px}.card{margin-top:14px;padding:18px 20px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px}.title{font-size:18px;font-weight:800}.subject{color:#aaa;margin-top:7px;font-size:13px;line-height:1.45}.btn{display:inline-block;margin-top:13px;background-color:#e5a00d;color:#111;text-decoration:none;font-weight:800;padding:10px 15px;border-radius:7px}.note{margin-top:20px;color:#999;font-size:12px;line-height:1.55;border-left:3px solid #e5a00d;padding-left:12px}.meta{color:#888;font-size:13px;line-height:1.55;margin-top:8px}
 </style></head><body><div class="wrap">
 <div class="eyebrow">TAUTWEEKLY FOR PLEX — ALL EMAIL TYPES</div>
 <h1 style="margin:8px 0 0;font-size:30px;">The real email layout, across every state.</h1>

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX PORTABLE CHANGELOG
 
 Unreleased
 ----------
+- preserves the dark-first email palette with dark-only metadata, explicit longhand backgrounds, and table color fallbacks
 - supplies Plex's required deleted-history title and episode-index match context, validates responses, and keeps missing artwork nonfatal
 - retries empty modern Plex and legacy TMDB/TVDB exact matches through Plex's current provider POST contract
 - recovers deleted Plex history through legacy TMDB/TVDB exact identifiers and reports unsupported or empty matches safely

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -4996,7 +4996,7 @@ function Get-StatsMovieRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $title + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5058,7 +5058,7 @@ function Get-StatsEpisodeRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $showTitle + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5106,7 +5106,7 @@ function Get-StatsTvShowRowsHtml {
             -ImageMode $ImageMode
 
         $posterHtml = if ([string]::IsNullOrWhiteSpace($posterSrc)) {
-            '<div style="width:42px;height:62px;border-radius:5px;background:#262626;border:1px solid #363636;"></div>'
+            '<div style="width:42px;height:62px;border-radius:5px;background-color:#262626;border:1px solid #363636;"></div>'
         } else {
             '<img src="' + (HtmlEncode $posterSrc) + '" width="42" height="62" alt="' + $showTitle + ' poster" style="display:block;width:42px;height:62px;object-fit:cover;border:1px solid #363636;border-radius:5px;">'
         }
@@ -5269,7 +5269,7 @@ function Get-ReleaseCardsHtml {
                 $posterHtml = '<img src="' + (HtmlEncode $posterSrc) + '" width="100%" alt="' + $title + ' poster" style="display:block;width:100%;height:auto;border:0;border-radius:8px 8px 0 0;">'
             }
             else {
-                $posterHtml = '<div style="height:260px;background:#222;border-radius:8px 8px 0 0;text-align:center;color:#777;font-size:12px;line-height:260px;">Poster unavailable</div>'
+                $posterHtml = '<div style="height:260px;background-color:#222;border-radius:8px 8px 0 0;text-align:center;color:#777;font-size:12px;line-height:260px;">Poster unavailable</div>'
             }
 
             $contentHeight = if ($Kind -eq "Movie") { 170 } else { 184 }
@@ -5357,7 +5357,7 @@ $genreHtml
 
             [void]$html.Append(@"
 <td width="50%" valign="top" style="padding:0 6px 18px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="width:100%;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;overflow:hidden;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;overflow:hidden;">
     <tr>
       <td valign="top" style="padding:0;">
         $posterHtml
@@ -5597,7 +5597,7 @@ $tvCards
         $welcomeBlock = @"
 <tr>
 <td class="pad" style="padding:4px 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #e5a00d;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #e5a00d;border-radius:10px;border-collapse:separate;">
     <tr>
       <td valign="middle" style="padding:20px 22px;">
         <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.4px;">
@@ -5741,7 +5741,7 @@ $tvCards
         $hotBlock = @"
 <tr class="design-hot-desktop">
 <td class="pad" style="padding:4px 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="205" valign="top" style="padding:16px 0 16px 16px;">
         $hotPosterHtml
@@ -5786,7 +5786,7 @@ $tvCards
 
 <tr class="design-hot-mobile" style="display:none;">
 <td class="pad" style="padding:0 12px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;overflow:hidden;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid $hotBorderColor;border-radius:10px;border-collapse:separate;overflow:hidden;">
     <tr>
       <td style="padding:0;">
         <div class="design-mobile-banner-wrap" style="position:relative;overflow:hidden;">
@@ -5858,7 +5858,7 @@ $tvCards
         $trendingBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 26px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       $posterCell
       <td width="56" valign="middle" style="padding:16px 0 16px 14px;">
@@ -6009,15 +6009,15 @@ $tvCards
     if ($movieDetailMode -and $tvShowDetailMode) {
         $mediaStatsRow = @"
 <tr>
-  <td width="50%" valign="top" style="padding:0 5px 10px 0;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$movieCardContent</td></tr></table></td>
-  <td width="50%" valign="top" style="padding:0 0 10px 5px;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$tvShowCardContent</td></tr></table></td>
+  <td width="50%" valign="top" style="padding:0 5px 10px 0;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$movieCardContent</td></tr></table></td>
+  <td width="50%" valign="top" style="padding:0 0 10px 5px;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$tvShowCardContent</td></tr></table></td>
 </tr>
 "@
     }
     elseif ($movieDetailMode -or $tvShowDetailMode) {
         $singleMediaContent = if ($movieDetailMode) { $movieCardContent } else { $tvShowCardContent }
         $mediaStatsRow = @"
-<tr><td colspan="2" width="100%" valign="top" style="padding:0 0 10px;"><table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$singleMediaContent</td></tr></table></td></tr>
+<tr><td colspan="2" width="100%" valign="top" style="padding:0 0 10px;"><table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;"><tr><td height="$statsCardHeight" valign="top" style="height:${statsCardHeight}px;padding:14px;">$singleMediaContent</td></tr></table></td></tr>
 "@
     }
 
@@ -6043,7 +6043,7 @@ $tvCards
         $statsBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 16px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="72" valign="middle" style="padding:20px 0 20px 20px;">
         <img src="$zeroIconSrc" width="48" height="48" alt="$(HtmlEncode $zeroAlt)" style="display:block;width:48px;height:48px;border:0;">
@@ -6067,7 +6067,7 @@ $tvCards
 $mediaStatsRow
 <tr>
   <td width="50%" valign="top" style="padding:0 5px 10px 0;">
-    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+    <table class="email-card" width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${statsCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$statsCardHeight" valign="middle" style="height:${statsCardHeight}px;padding:17px;">
           <img src="$clockIconSrc" width="42" height="42" alt="Total watched" style="display:block;width:42px;height:42px;border:0;">
@@ -6078,7 +6078,7 @@ $mediaStatsRow
     </table>
   </td>
   <td width="50%" valign="top" style="padding:0 0 10px 5px;">
-    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" style="width:100%;height:${statsCardHeight}px;background:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
+    <table width="100%" height="$statsCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="width:100%;height:${statsCardHeight}px;background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$statsCardHeight" valign="middle" style="height:${statsCardHeight}px;padding:17px;">
           <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
@@ -6102,7 +6102,7 @@ $mediaStatsRow
         $bingeStandaloneBlock = @"
 <tr>
 <td class="pad" style="padding:0 20px 24px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
     <tr>
       <td width="84" valign="middle" style="padding:18px 0 18px 20px;">
         <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;">
@@ -6144,7 +6144,7 @@ $mediaStatsRow
         @"
 <tr>
 <td class="pad" style="padding:10px 20px 22px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td style="padding:20px 22px;">
         <div style="font-size:13px;color:#e5a00d;font-weight:800;">
@@ -6196,10 +6196,19 @@ $mediaStatsRow
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
 <title>TautWeekly for Plex</title>
 <style>
 /* Email-safe table-first layout; only the featured hero swaps at the mobile breakpoint. */
+:root { color-scheme:dark only; supported-color-schemes:dark; }
+.email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+.email-card { background-color:#181818 !important; }
 .design-hot-mobile { display:none; }
+@media (prefers-color-scheme: dark) {
+  .email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+  .email-card { background-color:#181818 !important; }
+}
 @media only screen and (max-width: 620px) {
   .container { width: 100% !important; }
   .pad { padding-left: 12px !important; padding-right: 12px !important; }
@@ -6211,12 +6220,12 @@ $mediaStatsRow
 }
 </style>
 </head>
-<body style="margin:0;padding:0;background:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
+<body class="email-background" bgcolor="#0f0f0f" style="margin:0;padding:0;background-color:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
 <div style="display:none!important;font-size:1px;line-height:1px;max-height:0;max-width:0;overflow:hidden;opacity:0;color:transparent;mso-hide:all;">$(HtmlEncode $preheader)$preheaderPadding</div>
-<table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#0f0f0f;">
+<table class="email-background" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="background-color:#0f0f0f;">
 <tr>
-<td align="center" style="padding:28px 10px;">
-<table class="container" width="640" cellspacing="0" cellpadding="0" border="0" style="width:640px;max-width:640px;">
+<td class="email-background" align="center" bgcolor="#0f0f0f" style="padding:28px 10px;background-color:#0f0f0f;">
+<table class="container email-background" width="640" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="width:640px;max-width:640px;background-color:#0f0f0f;">
 <tr>
 <td class="pad" style="padding:0 20px 18px;">
   <div style="font-size:13px;font-weight:800;letter-spacing:2px;color:#e5a00d;">$(HtmlEncode $serverLabel)</div>
@@ -6246,7 +6255,7 @@ $trendingBlock
 
 <tr>
 <td class="pad" align="center" style="padding:8px 20px 18px;">
-  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:13px 24px;border-radius:7px;">OPEN PLEX</a>
+  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background-color:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:13px 24px;border-radius:7px;">OPEN PLEX</a>
 </td>
 </tr>
 
@@ -6485,14 +6494,25 @@ function Build-WelcomeHtml {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
 <title>Welcome aboard</title>
+<style>
+:root { color-scheme:dark only; supported-color-schemes:dark; }
+.email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+.email-card { background-color:#181818 !important; }
+@media (prefers-color-scheme: dark) {
+  .email-background { background-color:#0f0f0f !important; color:#ffffff !important; }
+  .email-card { background-color:#181818 !important; }
+}
+</style>
 </head>
-<body style="margin:0;padding:0;background:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
+<body class="email-background" bgcolor="#0f0f0f" style="margin:0;padding:0;background-color:#0f0f0f;color:#ffffff;font-family:Arial,Helvetica,sans-serif;">
 <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;mso-hide:all;">Your access to $(HtmlEncode $footerServerName) is live.</div>
-<table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#0f0f0f;">
+<table class="email-background" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="background-color:#0f0f0f;">
 <tr>
-<td align="center" style="padding:34px 12px;">
-<table width="600" cellspacing="0" cellpadding="0" border="0" style="width:600px;max-width:600px;">
+<td class="email-background" align="center" bgcolor="#0f0f0f" style="padding:34px 12px;background-color:#0f0f0f;">
+<table class="email-background" width="600" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f0f0f" style="width:600px;max-width:600px;background-color:#0f0f0f;">
 <tr>
 <td style="padding:0 20px 20px;">
   <div style="font-size:12px;color:#e5a00d;font-weight:800;letter-spacing:1.8px;">
@@ -6505,7 +6525,7 @@ function Build-WelcomeHtml {
 </tr>
 <tr>
 <td style="padding:0 20px 22px;">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
+  <table class="email-card" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
     <tr>
       <td style="padding:20px 22px;">
         <div style="font-size:13px;color:#e5a00d;font-weight:800;">🍿 $($deliveryDay.ToUpperInvariant()) DROPS</div>
@@ -6523,7 +6543,7 @@ function Build-WelcomeHtml {
 </tr>
 <tr>
 <td align="center" style="padding:4px 20px 24px;">
-  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:14px 28px;border-radius:7px;">OPEN PLEX</a>
+  <a href="$(HtmlEncode $plexUrl)" style="display:inline-block;background-color:#e5a00d;color:#111111;text-decoration:none;font-size:14px;font-weight:800;padding:14px 28px;border-radius:7px;">OPEN PLEX</a>
 </td>
 </tr>
 <tr>
@@ -7597,7 +7617,7 @@ if ($Mode -eq "PreviewAll") {
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>TautWeekly for Plex — All Email Types</title>
 <style>
-body{margin:0;background:#0f0f0f;color:#fff;font-family:Arial,Helvetica,sans-serif;padding:32px 18px}.wrap{max-width:900px;margin:auto}.eyebrow{color:#e5a00d;font-size:12px;font-weight:800;letter-spacing:1.5px}.card{margin-top:14px;padding:18px 20px;background:#181818;border:1px solid #2b2b2b;border-radius:10px}.title{font-size:18px;font-weight:800}.subject{color:#aaa;margin-top:7px;font-size:13px;line-height:1.45}.btn{display:inline-block;margin-top:13px;background:#e5a00d;color:#111;text-decoration:none;font-weight:800;padding:10px 15px;border-radius:7px}.note{margin-top:20px;color:#999;font-size:12px;line-height:1.55;border-left:3px solid #e5a00d;padding-left:12px}.meta{color:#888;font-size:13px;line-height:1.55;margin-top:8px}
+body{margin:0;background-color:#0f0f0f;color:#fff;font-family:Arial,Helvetica,sans-serif;padding:32px 18px}.wrap{max-width:900px;margin:auto}.eyebrow{color:#e5a00d;font-size:12px;font-weight:800;letter-spacing:1.5px}.card{margin-top:14px;padding:18px 20px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px}.title{font-size:18px;font-weight:800}.subject{color:#aaa;margin-top:7px;font-size:13px;line-height:1.45}.btn{display:inline-block;margin-top:13px;background-color:#e5a00d;color:#111;text-decoration:none;font-weight:800;padding:10px 15px;border-radius:7px}.note{margin-top:20px;color:#999;font-size:12px;line-height:1.55;border-left:3px solid #e5a00d;padding-left:12px}.meta{color:#888;font-size:13px;line-height:1.55;margin-top:8px}
 </style></head><body><div class="wrap">
 <div class="eyebrow">TAUTWEEKLY FOR PLEX — ALL EMAIL TYPES</div>
 <h1 style="margin:8px 0 0;font-size:30px;">The real email layout, across every state.</h1>

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -12,6 +12,7 @@ if ([string]::IsNullOrWhiteSpace($Root)) { $Root = Split-Path -Parent $PSScriptR
 $Root = [IO.Path]::GetFullPath($Root)
 $fakeServer = Join-Path $Root 'scripts/test-support/fake-tautulli.py'
 $fakeSmtp = Join-Path $Root 'scripts/test-support/fake-smtp.py'
+$emailThemeAssertion = Join-Path $Root 'scripts/test-support/assert-email-theme.py'
 $headlessRunner = Join-Path $Root 'scripts/test-support/invoke-renderer-headless.ps1'
 $windowsPowerShell = Join-Path $env:SystemRoot 'System32/WindowsPowerShell/v1.0/powershell.exe'
 $powerShell7 = Get-Command pwsh -ErrorAction SilentlyContinue
@@ -52,6 +53,7 @@ foreach ($engine in $engines) {
         $serverStdout = Join-Path $tempRoot 'server.stdout.txt'
         $serverStderr = Join-Path $tempRoot 'server.stderr.txt'
         $smtpCallLog = Join-Path $tempRoot 'smtp-calls.jsonl'
+        $smtpDataFile = Join-Path $tempRoot 'smtp-message.eml'
         $smtpReadyFile = Join-Path $tempRoot 'smtp-ready.txt'
         $smtpStdout = Join-Path $tempRoot 'smtp.stdout.txt'
         $smtpStderr = Join-Path $tempRoot 'smtp.stderr.txt'
@@ -86,7 +88,8 @@ foreach ($engine in $engines) {
                 $smtpPort = Get-FreeTcpPort
                 $smtpServer = Start-Process -FilePath $PythonPath -ArgumentList @(
                     '-u', $fakeSmtp, '--port', [string]$smtpPort,
-                    '--call-log', $smtpCallLog, '--ready-file', $smtpReadyFile
+                    '--call-log', $smtpCallLog, '--ready-file', $smtpReadyFile,
+                    '--data-file', $smtpDataFile
                 ) -PassThru -WindowStyle Hidden -RedirectStandardOutput $smtpStdout -RedirectStandardError $smtpStderr
                 for ($attempt = 0; $attempt -lt 100 -and -not (Test-Path $smtpReadyFile); $attempt++) {
                     if ($smtpServer.HasExited) {
@@ -175,6 +178,27 @@ foreach ($engine in $engines) {
             Assert-True ((Get-ChildItem $outputRoot -Filter 'preview-all-*.html').Count -eq 7) "$($engine.Name)/$scenario did not generate all six states plus the index."
             $indexHtml = Get-Content $indexPath -Raw -Encoding UTF8
             $normalHtml = Get-Content $normalPath -Raw -Encoding UTF8
+            $previewThemeMarkers = @(
+                '<meta name="color-scheme" content="dark">',
+                '<meta name="supported-color-schemes" content="dark">',
+                ':root { color-scheme:dark only; supported-color-schemes:dark; }',
+                '@media (prefers-color-scheme: dark)',
+                'class="email-background"',
+                'bgcolor="#0f0f0f"',
+                'background-color:#0f0f0f'
+            )
+            $previewPaths = @(Get-ChildItem $outputRoot -Filter 'preview-all-*.html' | Where-Object { $_.Name -ne 'preview-all-00-INDEX.html' })
+            foreach ($previewPath in $previewPaths) {
+                $previewHtml = Get-Content $previewPath.FullName -Raw -Encoding UTF8
+                foreach ($marker in $previewThemeMarkers) {
+                    Assert-True ($previewHtml.Contains($marker)) "$($engine.Name)/$scenario $($previewPath.Name) lost dark-theme marker: $marker"
+                }
+                Assert-True (-not $previewHtml.Contains('background:#0f0f0f')) "$($engine.Name)/$scenario $($previewPath.Name) retained the outer background shorthand."
+                Assert-True (-not $previewHtml.Contains('background:#181818')) "$($engine.Name)/$scenario $($previewPath.Name) retained the card background shorthand."
+            }
+            Assert-True ($normalHtml.Contains('class="email-card"')) "$($engine.Name)/$scenario lost explicit dark card classes."
+            Assert-True ($normalHtml.Contains('bgcolor="#181818"')) "$($engine.Name)/$scenario lost the legacy dark card fallback."
+            Assert-True ($normalHtml.Contains('background-color:#181818')) "$($engine.Name)/$scenario lost the longhand dark card fallback."
             $expectedMode = if ($scenario -eq 'quiet' -or $scenario -in $deletedHistoryScenarios) { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
             Assert-True ($indexHtml.Contains($expectedMode)) "$($engine.Name)/$scenario reported the wrong release mode."
             Assert-True ($normalHtml.Contains('Selected Movie')) "$($engine.Name)/$scenario lost the selected movie."
@@ -362,6 +386,9 @@ foreach ($engine in $engines) {
                 }
                 $smtpCommands = @(Get-Content $smtpCallLog | ForEach-Object { ($_ | ConvertFrom-Json).command })
                 Assert-True ('DATA' -in $smtpCommands) "$($engine.Name)/$scenario SendTest did not submit an SMTP message."
+                Assert-True (Test-Path $smtpDataFile) "$($engine.Name)/$scenario SendTest did not preserve the captured MIME message."
+                & $PythonPath $emailThemeAssertion $smtpDataFile
+                Assert-True ($LASTEXITCODE -eq 0) "$($engine.Name)/$scenario delivered HTML lost the dark email contract."
             }
 
             $executed++

--- a/scripts/test-support/assert-email-theme.py
+++ b/scripts/test-support/assert-email-theme.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Assert that a captured SMTP message preserves the dark email contract."""
+
+from __future__ import annotations
+
+import argparse
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+
+
+REQUIRED_HTML = (
+    '<meta name="color-scheme" content="dark">',
+    '<meta name="supported-color-schemes" content="dark">',
+    ':root { color-scheme:dark only; supported-color-schemes:dark; }',
+    '@media (prefers-color-scheme: dark)',
+    'class="email-background"',
+    'bgcolor="#0f0f0f"',
+    'background-color:#0f0f0f',
+    'class="email-card"',
+    'bgcolor="#181818"',
+    'background-color:#181818',
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("message", type=Path)
+    args = parser.parse_args()
+
+    message = BytesParser(policy=policy.default).parsebytes(args.message.read_bytes())
+    html_parts = [part for part in message.walk() if part.get_content_type() == "text/html"]
+    plain_parts = [part for part in message.walk() if part.get_content_type() == "text/plain"]
+    if len(html_parts) != 1:
+        raise AssertionError(f"expected one HTML MIME part, found {len(html_parts)}")
+    if len(plain_parts) != 1:
+        raise AssertionError(f"expected one plain-text MIME part, found {len(plain_parts)}")
+
+    html = html_parts[0].get_content()
+    for marker in REQUIRED_HTML:
+        if marker not in html:
+            raise AssertionError(f"delivered HTML lost dark-theme marker: {marker}")
+    for shorthand in ("background:#0f0f0f", "background:#181818"):
+        if shorthand in html:
+            raise AssertionError(f"delivered HTML retained unsupported color shorthand: {shorthand}")
+
+    print("[PASS] Captured SMTP HTML preserves dark-only metadata and explicit background fallbacks.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-support/fake-smtp.py
+++ b/scripts/test-support/fake-smtp.py
@@ -37,8 +37,17 @@ class Handler(socketserver.StreamRequestHandler):
                 self.send("250 Accepted")
             elif upper == "DATA":
                 self.send("354 End data with <CR><LF>.<CR><LF>")
-                while self.read() != ".":
-                    pass
+                data_lines: list[str] = []
+                while True:
+                    data_line = self.read()
+                    if data_line == ".":
+                        break
+                    if data_line.startswith(".."):
+                        data_line = data_line[1:]
+                    data_lines.append(data_line)
+                data_file: Path | None = self.server.data_file  # type: ignore[attr-defined]
+                if data_file is not None:
+                    data_file.write_bytes(("\r\n".join(data_lines) + "\r\n").encode("utf-8"))
                 self.send("250 Queued")
             elif upper == "QUIT":
                 self.send("221 Bye")
@@ -56,11 +65,13 @@ def main() -> None:
     parser.add_argument("--port", type=int, required=True)
     parser.add_argument("--call-log", type=Path, required=True)
     parser.add_argument("--ready-file", type=Path, required=True)
+    parser.add_argument("--data-file", type=Path)
     args = parser.parse_args()
 
     args.call_log.write_text("", encoding="utf-8")
     with Server(("127.0.0.1", args.port), Handler) as server:
         server.call_log = args.call_log  # type: ignore[attr-defined]
+        server.data_file = args.data_file  # type: ignore[attr-defined]
         args.ready_file.write_text(str(server.server_address[1]), encoding="utf-8")
         server.serve_forever()
 


### PR DESCRIPTION
## Summary

- declare the shipped newsletter as a single dark-only color scheme for Apple Mail/WebKit
- replace color shorthands with explicit longhand backgrounds and add table `bgcolor` fallbacks across Windows, NAS/Linux/FreeBSD, and macOS renderers
- capture SMTP DATA in the sanitized integration sink and decode the MIME HTML part to verify the dark contract survives delivery
- prepare the v0.8.4 changelog entry for issue #44

## Root cause

The renderer already generated a dark body and cards, and SMTP serialization preserved them. Apple Mail could still auto-transform those colors because the production message did not declare its supported color scheme. Gmail and Outlook do not consistently honor that declaration, so the markup now also carries explicit longhand and legacy table fallbacks.

## User impact

There is no light/dark selector and no second theme. The existing dark-first palette is declared more defensively, while clients or accessibility modes that intentionally override sender colors may still transform it.

## Validation

- `scripts/validate-powershell.ps1`
- `scripts/test-newsletter-integration.ps1` - 6 Windows scenarios; captured SMTP HTML passed in every send scenario
- `scripts/test-renderer-collections.ps1` - all three maintained renderers
- `scripts/test-smtp-transport.py`
- repository, platform, documentation, and relative-link validators
- `scripts/build-releases.ps1 -Version 0.8.4`
- `scripts/test-release-artifacts.ps1`