### PR TITLE
docs: credit issue 58 bug report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrected the Tautulli fallback for movie Rotten Tomatoes ratings: item
   exports no longer request the library-only `individual_files` option, and
   rating-only downloads are parsed as JSON instead of being rejected for not
-  being ZIP archives.
+  being ZIP archives. Reported by
+  [@Rocknrolldoggie](https://github.com/Rocknrolldoggie) in
+  [#58](https://github.com/sparkmoxie/TautWeekly/issues/58).
 - Accepted Tautulli's flattened rating fields and Plex's nested rating entries,
   including the Rotten/spilled low-score icon states. A sanitized integration
   scenario now keeps direct Plex unavailable and requires the item-export

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ proposal.
 | [@Joloxx9](https://github.com/Joloxx9) | 🐛 `bug` | [#15: Tautulli user-roster compatibility](https://github.com/sparkmoxie/TautWeekly/issues/15) | [PR #16](https://github.com/sparkmoxie/TautWeekly/pull/16) · [v0.5.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.5.2) |
 | [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#31: selected-library and sparse-metadata renderer fixes](https://github.com/sparkmoxie/TautWeekly/issues/31) | [PR #33](https://github.com/sparkmoxie/TautWeekly/pull/33) · [v0.6.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.1)<br>[PR #36](https://github.com/sparkmoxie/TautWeekly/pull/36) · [v0.6.2](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.2) |
 | [@gianfelicevincenzo](https://github.com/gianfelicevincenzo) | 🐛 `bug` | [#38: container exec PUID/PGID ownership](https://github.com/sparkmoxie/TautWeekly/issues/38) | [PR #39](https://github.com/sparkmoxie/TautWeekly/pull/39) · [v0.6.3](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.6.3) |
+| [@Rocknrolldoggie](https://github.com/Rocknrolldoggie) | 🐛 `bug` | [#58: missing newsletter ratings](https://github.com/sparkmoxie/TautWeekly/issues/58) | [PR #59](https://github.com/sparkmoxie/TautWeekly/pull/59) · [v0.9.1](https://github.com/sparkmoxie/TautWeekly/releases/tag/v0.9.1) |
 
 Only public GitHub handles and links are recorded. Bug credit requires an
 evidence-backed correction in the repository; enhancement credit requires an


### PR DESCRIPTION
Adds the repository-required post-shipment attribution for the issue #58 reporter, linking the public report, merged fix PR #59, and first containing release v0.9.1. No runtime behavior or release artifact changes.