### PR TITLE
fix: render selected Tautulli ratings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-08-11
+
+### Fixed
+
+- Accepted recognized provider-labelled IMDb, TMDB, and TVDB values from both
+  Tautulli rating field pairs while preserving the dedicated Rotten Tomatoes
+  movie and IMDb TV presentation. Current Tautulli TV metadata can place its
+  selected TMDB score in `audience_rating` / `audience_rating_image` while
+  leaving `rating_image` empty; v0.9.2 ignored that valid shape.
+- Rendered the selected-provider fallback on movie, TV, episode, and personal
+  statistics rows across Windows, NAS/Docker, and macOS, and retained the two
+  bounded presentation fields in the exact-GUID deleted-item cache.
+- Replaced the prior synthetic show-export fixture with Tautulli's maintained
+  TV field contract, then exercised PreviewAll and decoded SendTest delivery
+  with direct Plex deliberately unavailable. Follow-up evidence was provided
+  by [@Rocknrolldoggie](https://github.com/Rocknrolldoggie) in
+  [#58](https://github.com/sparkmoxie/TautWeekly/issues/58).
+
+### Security
+
+- Kept rating export requests at metadata level 1 with media information and
+  file locations disabled. Only known provider identifiers with a numeric
+  score from 0 through 10 are accepted; unknown or unlabeled values remain
+  omitted.
+
 ## [0.9.3] - 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ setup, storage, scheduling, and lifecycle wrappers remain platform-specific.
 
 ## Current newsletter behavior
 
+- Movie Rotten Tomatoes and TV IMDb retain their dedicated icon treatments.
+  If Plex selects another rating source, TautWeekly also accepts a numeric
+  IMDb, TMDB, or TVDB score only when Tautulli supplies the matching provider
+  identifier; unlabeled and unknown-provider values remain omitted.
 - A private pre-deletion cache stores only the minimum reusable presentation
   record for a live item: exact stable GUID and media type, title/year/summary,
   up to eight genres, displayed ratings, one poster, hashes, and timestamps.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -30,13 +30,17 @@ host is also fetched without the Plex token.
 
 Posters and hero art can still succeed through Tautulli's image proxy when the
 direct Plex URL is unreachable. That does not prove that direct rating,
-background, or selected-logo metadata is available. v0.9.2 uses Tautulli's
-single-item JSON exporter as a movie RT and show IMDb fallback; it requests
-only metadata level 1, disables media information, and does not request
-library/user individual files. The provider-labelled rating fields are
-requested explicitly so the fallback does not depend on a Tautulli version's
-level map. Provider-free numbers and unavailable logo resources remain omitted
-rather than guessed.
+background, or selected-logo metadata is available. v0.9.4 uses Tautulli's
+normal metadata and single-item JSON exporter for provider-labelled ratings;
+it requests only metadata level 1, disables media information, and does not
+request library/user individual files. Movie Rotten Tomatoes and TV IMDb keep
+their dedicated presentation, while recognized selected IMDb, TMDB, or TVDB
+values can come from either the rating or audience field pair. This matters
+because Tautulli's documented TV/episode example leaves `rating_image` empty
+and returns a TMDB score through `audience_rating` and
+`audience_rating_image`. Provider-free numbers, unknown provider identifiers,
+out-of-range scores, and unavailable logo resources remain omitted rather than
+guessed.
 
 The [Tautulli `get_history` API](https://github.com/Tautulli/Tautulli/wiki/Tautulli-API-Reference#get_history)
 retains descriptive fields such as GUID/rating keys, titles, years, episode

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -171,6 +171,14 @@ the four provider-labelled rating fields. It applies the item-export fallback
 to movie RT and show IMDb, and validates controlled SendTest delivery
 separately from browser preview.
 
+Update to v0.9.4 or newer if v0.9.2 completes the rich exports but still logs
+all ratings as unavailable. Tautulli's documented TV/episode metadata can
+leave `rating_image` empty while placing the selected TMDB score in
+`audience_rating` with `audience_rating_image=themoviedb://image.rating`.
+v0.9.2's test fixture incorrectly assumed a show export could identify IMDb
+through `ratingImage`; v0.9.4 accepts the maintained rating and audience field
+pairs and renders recognized IMDb, TMDB, or TVDB selected scores.
+
 If the log also says every direct Plex request failed, verify
 `PlexServerUrl` from the TautWeekly runtime. In a separate Docker container,
 `localhost` and `127.0.0.1` refer to TautWeekly itself, not the Plex
@@ -179,11 +187,12 @@ trusted LAN URL reachable from inside the container, normally on port 32400,
 and keep `PlexToken` private. Re-run the platform verifier, PreviewAll, and a
 controlled SendTest after correcting the private configuration.
 
-TautWeekly omits a rating rather than guessing its provider. TV/episode IMDb
-scores therefore still require an IMDb-labelled source, and a logo is omitted
-when Plex/Tautulli has no selected logo resource. Do not post `config.json`,
-diagnostic JSON, generated previews, or full logs; share only sanitized warning
-text if further help is required.
+TautWeekly omits a rating rather than guessing its provider. A dedicated IMDb
+or Rotten Tomatoes badge still requires that provider label, while selected
+TMDB/TVDB values use a text badge. Unknown labels and unlabeled numbers remain
+hidden, and a logo is omitted when Plex/Tautulli has no selected logo resource.
+Do not post `config.json`, diagnostic JSON, generated previews, or full logs;
+share only sanitized warning text if further help is required.
 
 ## Deleted item still has no poster or metadata
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -179,6 +179,12 @@ v0.9.2's test fixture incorrectly assumed a show export could identify IMDb
 through `ratingImage`; v0.9.4 accepts the maintained rating and audience field
 pairs and renders recognized IMDb, TMDB, or TVDB selected scores.
 
+If ratings work on Windows but not in Docker, that can mean Windows reached
+Plex directly while the container fell through to Tautulli; it does not imply
+that the packages maintain different rating renderers. v0.9.4 corrects that
+shared fallback, but the container's direct Plex warnings should still be
+investigated separately for backgrounds, selected logos, and richer metadata.
+
 If the log also says every direct Plex request failed, verify
 `PlexServerUrl` from the TautWeekly runtime. In a separate Docker container,
 `localhost` and `127.0.0.1` refer to TautWeekly itself, not the Plex

--- a/docs/releases/v0.9.4.md
+++ b/docs/releases/v0.9.4.md
@@ -1,0 +1,55 @@
+# TautWeekly for Plex v0.9.4
+
+v0.9.4 corrects the provider-selection path used when Tautulli can return a
+rating but direct Plex metadata is unavailable.
+
+## Diagnosis and correction
+
+The previous fallback treated movie Rotten Tomatoes and TV IMDb as the only
+usable shapes. Its virtual show export supplied `ratingImage=imdb`, but
+Tautulli's maintained TV export fields do not guarantee `ratingImage` and its
+documented `get_metadata` example instead returns a selected TMDB score through
+`audience_rating` and `audience_rating_image` while `rating_image` is empty.
+The export therefore completed successfully, but v0.9.2 discarded the valid
+provider-labelled value and rendered no rating.
+
+v0.9.4 reads both selected rating field pairs. The dedicated Rotten Tomatoes
+movie icons and IMDb TV icon remain preferred. When those values are absent,
+recognized IMDb, TMDB, or TVDB identifiers render a compact text badge on
+movie, TV, episode, and personal-statistics rows. Unknown provider identifiers,
+unlabeled numbers, and values outside 0 through 10 fail closed.
+
+The behavior follows Tautulli's current
+[`get_metadata` API example](https://github.com/Tautulli/Tautulli/wiki/Tautulli-API-Reference#get_metadata),
+[`export_metadata` API contract](https://github.com/Tautulli/Tautulli/wiki/Tautulli-API-Reference#export_metadata),
+and [Exporter Guide](https://github.com/Tautulli/Tautulli/wiki/Exporter-Guide).
+
+## Preview and SendTest regression
+
+The sanitized regression deliberately makes direct Plex metadata return 404.
+It returns low Rotten Tomatoes critic/audience scores for a movie and models a
+show export without `ratingImage`, using the documented TMDB audience fields.
+PreviewAll must render all three values, and SendTest must deliver them in the
+decoded MIME HTML. The same parser and renderer assertions cover Windows,
+NAS/Docker, and macOS sources; hosted CI supplies PowerShell 7 coverage for the
+container variants.
+
+## Privacy and boundaries
+
+The Tautulli item export remains limited to the four rating presentation fields
+at metadata level 1. Media information, file locations, recipient identity,
+viewing history, generated newsletters, and credentials are not requested or
+persisted. The exact-GUID deleted-item cache adds only a bounded provider name
+and numeric value to its existing presentation record.
+
+This change does not make an unreachable Plex URL reachable and does not invent
+missing backgrounds or selected logos. It only renders a rating that Tautulli
+already labels with a recognized provider.
+
+## Platform baselines
+
+- Windows Portable 1.8.0
+- NAS/Docker Portable 1.2.0
+- macOS Portable 1.1.0
+- Native Linux 1.1.0
+- FreeBSD/Podman 1.1.0

--- a/docs/releases/v0.9.4.md
+++ b/docs/releases/v0.9.4.md
@@ -13,6 +13,12 @@ documented `get_metadata` example instead returns a selected TMDB score through
 The export therefore completed successfully, but v0.9.2 discarded the valid
 provider-labelled value and rendered no rating.
 
+Ratings working on Windows while remaining absent in Docker is consistent
+with this diagnosis, not evidence of divergent renderer code. A Windows host
+that can reach Plex directly can fill the rating before the fallback runs; a
+container whose direct Plex requests fail must rely on the affected Tautulli
+path. All maintained packages receive the same correction.
+
 v0.9.4 reads both selected rating field pairs. The dedicated Rotten Tomatoes
 movie icons and IMDb TV icon remain preferred. When those values are absent,
 recognized IMDb, TMDB, or TVDB identifiers render a compact text badge on

--- a/platforms/freebsd-podman/CHANGELOG.txt
+++ b/platforms/freebsd-podman/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex FreeBSD Podman platform changelog
 
 Unreleased
+- Renders recognized selected IMDb, TMDB, and TVDB ratings from either Tautulli rating field pair.
 - Makes Tautulli field discovery compatible and explicitly requests provider-labelled rating fields.
 - Accepts valid minimal rating-only JSON exports instead of rejecting responses under 64 bytes.
 - Displays recovered show IMDb ratings on TV release cards.

--- a/platforms/linux/CHANGELOG.txt
+++ b/platforms/linux/CHANGELOG.txt
@@ -1,6 +1,7 @@
 TautWeekly for Plex native Linux platform changelog
 
 Unreleased
+- Renders recognized selected IMDb, TMDB, and TVDB ratings from either Tautulli rating field pair.
 - Makes Tautulli field discovery compatible and explicitly requests provider-labelled rating fields.
 - Accepts valid minimal rating-only JSON exports instead of rejecting responses under 64 bytes.
 - Displays recovered show IMDb ratings on TV release cards.

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 
 v1.1.0 Portable
 ---------------
+- renders recognized selected IMDb, TMDB, and TVDB ratings from either Tautulli rating field pair
 - makes Tautulli field discovery compatible and explicitly requests provider-labelled rating fields
 - accepts valid minimal rating-only JSON exports instead of rejecting responses under 64 bytes
 - displays recovered show IMDb ratings on TV release cards

--- a/platforms/mac-docker/app/DeletedItemCache.ps1
+++ b/platforms/mac-docker/app/DeletedItemCache.ps1
@@ -475,6 +475,8 @@ function Update-TautWeeklyDeletedItemCache {
                 RtCritic       = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtCritic") 8
                 RtAudience     = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtAudience") 8
                 Imdb           = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignImdbRating") 8
+                Provider       = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRatingProvider") 12
+                ProviderValue  = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRatingValue") 8
                 RtCriticImage  = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtCriticImage") 100
                 RtAudienceImage = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtAudienceImage") 100
             }

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -170,6 +170,53 @@ function Get-OptionalStringProperty {
     return [string]$property.Value
 }
 
+function Get-DesignProviderRating {
+    param(
+        [string]$RatingImage = "",
+        [AllowNull()][object]$RatingValue = $null,
+        [string]$AudienceImage = "",
+        [AllowNull()][object]$AudienceValue = $null
+    )
+
+    foreach ($candidate in @(
+        [PSCustomObject]@{ Image = $RatingImage; Value = $RatingValue },
+        [PSCustomObject]@{ Image = $AudienceImage; Value = $AudienceValue }
+    )) {
+        $image = ([string]$candidate.Image).Trim().ToLowerInvariant()
+        $value = if ($candidate.Value -is [IFormattable]) {
+            ([IFormattable]$candidate.Value).ToString($null, [Globalization.CultureInfo]::InvariantCulture).Trim()
+        }
+        else {
+            ([string]$candidate.Value).Trim()
+        }
+        if ([string]::IsNullOrWhiteSpace($image) -or
+            $value -notmatch '^(?:10(?:\.0+)?|[0-9](?:\.[0-9]+)?)$') {
+            continue
+        }
+
+        $provider = if ($image -like 'imdb://image.rating*') {
+            'IMDb'
+        }
+        elseif ($image -like 'themoviedb://image.rating*' -or
+            $image -like 'tmdb://image.rating*') {
+            'TMDB'
+        }
+        elseif ($image -like 'thetvdb://image.rating*' -or
+            $image -like 'tvdb://image.rating*') {
+            'TVDB'
+        }
+        else {
+            ''
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($provider)) {
+            return [PSCustomObject]@{ Provider = $provider; Value = $value }
+        }
+    }
+
+    return [PSCustomObject]@{ Provider = ''; Value = '' }
+}
+
 function Safe-Int64 {
     param([AllowNull()][object]$Value)
     if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) { return [int64]0 }
@@ -794,9 +841,16 @@ function New-ReleaseData {
                 if (-not [string]::IsNullOrWhiteSpace($episodeTitle)) {
                     $ratingImage = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
                     $ratingValue = Get-OptionalStringProperty -InputObject $item -Name "rating"
+                    $audienceImage = Get-OptionalStringProperty -InputObject $item -Name "audience_rating_image"
+                    $audienceValue = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+                    $selectedRating = Get-DesignProviderRating `
+                        -RatingImage $ratingImage `
+                        -RatingValue $ratingValue `
+                        -AudienceImage $audienceImage `
+                        -AudienceValue $audienceValue
                     $nativeImdbRating = ""
-                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                        $nativeImdbRating = $ratingValue
+                    if ($selectedRating.Provider -eq "IMDb") {
+                        $nativeImdbRating = $selectedRating.Value
                     }
 
                     $entry.Episodes.Add([PSCustomObject]@{
@@ -805,6 +859,8 @@ function New-ReleaseData {
                         AddedAt     = Safe-Int64 $item.added_at
                         ImdbRating  = $nativeImdbRating
                         RatingImage = $ratingImage
+                        DesignRatingProvider = $selectedRating.Provider
+                        DesignRatingValue = $selectedRating.Value
                         Season      = Safe-Int $item.parent_media_index
                         Episode     = Safe-Int $item.media_index
                     })
@@ -1076,10 +1132,16 @@ function Get-TvEpisodeSnapshotFromTautulli {
 
         $ratingImage = Get-OptionalStringProperty -InputObject $episode -Name "rating_image"
         $ratingValue = Get-OptionalStringProperty -InputObject $episode -Name "rating"
+        $audienceImage = Get-OptionalStringProperty -InputObject $episode -Name "audience_rating_image"
+        $audienceValue = Get-OptionalStringProperty -InputObject $episode -Name "audience_rating"
+        $selectedRating = Get-DesignProviderRating `
+            -RatingImage $ratingImage `
+            -RatingValue $ratingValue `
+            -AudienceImage $audienceImage `
+            -AudienceValue $audienceValue
         $nativeImdbRating = ""
-        if ($ratingImage -match '(?i)^imdb://' -and
-            -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-            $nativeImdbRating = $ratingValue
+        if ($selectedRating.Provider -eq "IMDb") {
+            $nativeImdbRating = $selectedRating.Value
         }
 
         $result.Add([PSCustomObject]@{
@@ -1088,6 +1150,8 @@ function Get-TvEpisodeSnapshotFromTautulli {
             AddedAt     = Safe-Int64 $episode.added_at
             ImdbRating  = $nativeImdbRating
             RatingImage = $ratingImage
+            DesignRatingProvider = $selectedRating.Provider
+            DesignRatingValue = $selectedRating.Value
             Season      = $seasonIndex
             Episode     = $episodeIndex
         })
@@ -1203,24 +1267,32 @@ function Enrich-TvEpisodeMetadata {
 
             $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+            $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+            $audienceValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+            $selectedRating = Get-DesignProviderRating `
+                -RatingImage $ratingImage `
+                -RatingValue $ratingValue `
+                -AudienceImage $audienceImage `
+                -AudienceValue $audienceValue
             if (-not [string]::IsNullOrWhiteSpace($ratingImage)) {
                 $episode.RatingImage = $ratingImage
             }
 
             $episode.ImdbRating = ""
+            $episode | Add-Member -NotePropertyName "DesignRatingProvider" -NotePropertyValue $selectedRating.Provider -Force
+            $episode | Add-Member -NotePropertyName "DesignRatingValue" -NotePropertyValue $selectedRating.Value -Force
 
             # Fast path: Tautulli explicitly identifies IMDb as the selected
             # episode rating provider.
-            if ($ratingImage -match '(?i)^imdb://') {
-                if (-not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                    $episode.ImdbRating = $ratingValue
-                }
+            if ($selectedRating.Provider -eq "IMDb") {
+                $episode.ImdbRating = $selectedRating.Value
             }
 
             # Plex UI can show IMDb alongside other providers even when
             # Tautulli's flattened rating_image does not select IMDb.
             # Fall back to Plex's native Rating[] / legacy XML metadata.
-            if ([string]::IsNullOrWhiteSpace([string]$episode.ImdbRating)) {
+            if ([string]::IsNullOrWhiteSpace([string]$episode.ImdbRating) -and
+                [string]::IsNullOrWhiteSpace([string]$selectedRating.Provider)) {
                 $episode.ImdbRating = Get-DesignEpisodeImdbRating `
                     -RatingKey $ratingKey `
                     -TautulliMetadata $meta
@@ -1427,9 +1499,15 @@ function Get-UserStats {
                     $nativeImdb = ""
                     $ratingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
                     $ratingValue = Get-OptionalStringProperty -InputObject $row -Name "rating"
-                    if ($ratingImage -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                        $nativeImdb = $ratingValue
+                    $audienceImage = Get-OptionalStringProperty -InputObject $row -Name "audience_rating_image"
+                    $audienceValue = Get-OptionalStringProperty -InputObject $row -Name "audience_rating"
+                    $selectedRating = Get-DesignProviderRating `
+                        -RatingImage $ratingImage `
+                        -RatingValue $ratingValue `
+                        -AudienceImage $audienceImage `
+                        -AudienceValue $audienceValue
+                    if ($selectedRating.Provider -eq "IMDb") {
+                        $nativeImdb = $selectedRating.Value
                     }
 
                     $episodeItems.Add([PSCustomObject]@{
@@ -1442,6 +1520,8 @@ function Get-UserStats {
                         Season          = Safe-Int $row.parent_media_index
                         Episode         = Safe-Int $row.media_index
                         ImdbRating      = $nativeImdb
+                        DesignRatingProvider = $selectedRating.Provider
+                        DesignRatingValue = $selectedRating.Value
                         Plays           = Get-HistoryRowPlayCount -Row $row
                     })
                 }
@@ -2810,7 +2890,9 @@ function Find-DesignProviderRatingsRecursive {
         [AllowNull()][object]$Node,
         [ref]$Critic,
         [ref]$Audience,
-        [ref]$Imdb
+        [ref]$Imdb,
+        [ref]$Provider,
+        [ref]$ProviderValue
     )
 
     if ($null -eq $Node) { return }
@@ -2826,7 +2908,9 @@ function Find-DesignProviderRatingsRecursive {
                 -Node $child `
                 -Critic $Critic `
                 -Audience $Audience `
-                -Imdb $Imdb
+                -Imdb $Imdb `
+                -Provider $Provider `
+                -ProviderValue $ProviderValue
         }
         return
     }
@@ -2866,6 +2950,16 @@ function Find-DesignProviderRatingsRecursive {
                 $Audience.Value = Convert-DesignRatingPercent $audienceValue
             }
 
+            if ([string]::IsNullOrWhiteSpace($Provider.Value)) {
+                $selected = Get-DesignProviderRating `
+                    -RatingImage $ratingImage `
+                    -RatingValue $ratingValue `
+                    -AudienceImage $audienceImage `
+                    -AudienceValue $audienceValue
+                $Provider.Value = $selected.Provider
+                $ProviderValue.Value = $selected.Value
+            }
+
             $imageProp = $props["image"]
             $valueProp = $props["value"]
 
@@ -2891,6 +2985,11 @@ function Find-DesignProviderRatingsRecursive {
                         }
                     }
                 }
+                elseif ([string]::IsNullOrWhiteSpace($Provider.Value)) {
+                    $selected = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                    $Provider.Value = $selected.Provider
+                    $ProviderValue.Value = $selected.Value
+                }
             }
 
             foreach ($p in $props) {
@@ -2898,7 +2997,9 @@ function Find-DesignProviderRatingsRecursive {
                     -Node $p.Value `
                     -Critic $Critic `
                     -Audience $Audience `
-                    -Imdb $Imdb
+                    -Imdb $Imdb `
+                    -Provider $Provider `
+                    -ProviderValue $ProviderValue
             }
             return
         }
@@ -3148,6 +3249,8 @@ function Get-DesignRichExport {
             RtCritic = ""
             RtAudience = ""
             Imdb = ""
+            Provider = ""
+            ProviderValue = ""
             LogoSrc = ""
             DiagnosticFile = ""
         }
@@ -3168,6 +3271,8 @@ function Get-DesignRichExport {
         RtCritic = ""
         RtAudience = ""
         Imdb = ""
+        Provider = ""
+        ProviderValue = ""
         LogoSrc = ""
         DiagnosticFile = ""
     }
@@ -3204,9 +3309,10 @@ function Get-DesignRichExport {
         $params = @{
             rating_key       = $RatingKey
             file_format      = "json"
-            # Tautulli metadata level 1 contains movie rating, ratingImage,
-            # audienceRating, and audienceRatingImage. Higher levels can add
-            # private media paths that this presentation fallback never needs.
+            # Availability differs by media type (show exports can omit
+            # ratingImage), so the selected provider fields are also requested
+            # explicitly. Higher levels can add private media paths that this
+            # presentation fallback never needs.
             metadata_level   = 1
             media_info_level = 0
             thumb_level      = 0
@@ -3224,7 +3330,7 @@ function Get-DesignRichExport {
             $params.custom_fields = ($customFields -join ",")
         }
 
-        Write-Log ("TautWeekly for Plex: Tautulli item export for {0} (RT rating fields{1})..." -f `
+        Write-Log ("TautWeekly for Plex: Tautulli item export for {0} (provider-labelled rating fields{1})..." -f `
             $RatingKey,
             $(if ($NeedLogo) { " + selected logo level 9" } else { "" })
         )
@@ -3277,6 +3383,8 @@ function Get-DesignRichExport {
         $critic = ""
         $audience = ""
         $imdb = ""
+        $provider = ""
+        $providerValue = ""
         $jsonFiles = @()
         $exportedFiles = @()
         $bytes = [IO.File]::ReadAllBytes($downloadPath)
@@ -3299,7 +3407,9 @@ function Get-DesignRichExport {
                         -Node $parsed `
                         -Critic ([ref]$critic) `
                         -Audience ([ref]$audience) `
-                        -Imdb ([ref]$imdb)
+                        -Imdb ([ref]$imdb) `
+                        -Provider ([ref]$provider) `
+                        -ProviderValue ([ref]$providerValue)
 
                     if (-not [string]::IsNullOrWhiteSpace($critic) -and
                         -not [string]::IsNullOrWhiteSpace($audience)) {
@@ -3316,7 +3426,9 @@ function Get-DesignRichExport {
                     -Node $parsed `
                     -Critic ([ref]$critic) `
                     -Audience ([ref]$audience) `
-                    -Imdb ([ref]$imdb)
+                    -Imdb ([ref]$imdb) `
+                    -Provider ([ref]$provider) `
+                    -ProviderValue ([ref]$providerValue)
             }
             catch {
                 throw "Downloaded item export was neither a ZIP archive nor valid JSON."
@@ -3326,6 +3438,8 @@ function Get-DesignRichExport {
         $result.RtCritic = $critic
         $result.RtAudience = $audience
         $result.Imdb = $imdb
+        $result.Provider = $provider
+        $result.ProviderValue = $providerValue
 
         if ($NeedLogo) {
             if (-not $isZip) {
@@ -3373,6 +3487,8 @@ function Get-DesignRichExport {
             RtCritic = $result.RtCritic
             RtAudience = $result.RtAudience
             Imdb = $result.Imdb
+            Provider = $result.Provider
+            ProviderValue = $result.ProviderValue
             LogoExportLevel = $(if ($NeedLogo) { 9 } else { 0 })
             LogoFound = -not [string]::IsNullOrWhiteSpace($result.LogoSrc)
             JsonFiles = @($jsonFiles | ForEach-Object { $_.Name })
@@ -3383,10 +3499,11 @@ function Get-DesignRichExport {
         $diag | ConvertTo-Json -Depth 8 | Set-Content -Path $diagPath -Encoding UTF8
         $result.DiagnosticFile = "media/" + $diagPath.Split([IO.Path]::DirectorySeparatorChar)[-1]
 
-        Write-Log ("Design rich export result: RT critic={0}, audience={1}, IMDb={2}, logo={3}" -f `
+        Write-Log ("Design rich export result: RT critic={0}, audience={1}, IMDb={2}, selected={3}, logo={4}" -f `
             $(if ($result.RtCritic) { $result.RtCritic + "%" } else { "n/a" }),
             $(if ($result.RtAudience) { $result.RtAudience } else { "n/a" }),
             $(if ($result.Imdb) { $result.Imdb } else { "n/a" }),
+            $(if ($result.Provider) { $result.Provider + " " + $result.ProviderValue } else { "n/a" }),
             $(if ($result.LogoSrc) { "yes" } else { "no" })
         )
     }
@@ -3521,6 +3638,8 @@ function Add-DesignRatingMetadata {
         $critic = ""
         $audience = ""
         $imdb = ""
+        $provider = ""
+        $providerValue = ""
         $criticImage = ""
         $audienceImageState = ""
         $genres = @()
@@ -3529,8 +3648,9 @@ function Add-DesignRatingMetadata {
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
-        # Primary source for the newsletter: Tautulli already exposes selected
-        # movie RT and TV IMDb scores plus their provider IDs.
+        # Primary source for the newsletter: Tautulli exposes Plex's selected,
+        # provider-labelled rating fields. Keep the dedicated RT/IMDb display
+        # paths, then retain another recognized provider as a text badge.
         try {
             $meta = Invoke-TautulliApi -Command "get_metadata" -Parameters @{
                 rating_key = $ratingKey
@@ -3541,6 +3661,13 @@ function Add-DesignRatingMetadata {
             $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+            $selectedRating = Get-DesignProviderRating `
+                -RatingImage $ratingImage `
+                -RatingValue $ratingValue `
+                -AudienceImage $audienceImage `
+                -AudienceValue $audienceRatingValue
+            $provider = $selectedRating.Provider
+            $providerValue = $selectedRating.Value
 
             if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
                 $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
@@ -3583,10 +3710,11 @@ function Add-DesignRatingMetadata {
         # Optional secondary source: Plex's full Rating[] if direct access
         # happens to be available on this install.
         $needsDirectRatings = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsDirectRatings) {
             try {
@@ -3620,6 +3748,12 @@ function Add-DesignRatingMetadata {
                             [string]::IsNullOrWhiteSpace($imdb) -and
                             $image -like "imdb://image.rating*") {
                             $imdb = [string]$value
+                        }
+
+                        if ([string]::IsNullOrWhiteSpace($provider)) {
+                            $selectedRating = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                            $provider = $selectedRating.Provider
+                            $providerValue = $selectedRating.Value
                         }
 
                         if ($mediaType -eq "movie" -and
@@ -3680,13 +3814,16 @@ function Add-DesignRatingMetadata {
                 if ([string]::IsNullOrWhiteSpace($imdb)) { $imdb = Get-OptionalStringProperty $cachedEntry.Ratings "Imdb" }
                 if ([string]::IsNullOrWhiteSpace($criticImage)) { $criticImage = Get-OptionalStringProperty $cachedEntry.Ratings "RtCriticImage" }
                 if ([string]::IsNullOrWhiteSpace($audienceImageState)) { $audienceImageState = Get-OptionalStringProperty $cachedEntry.Ratings "RtAudienceImage" }
+                if ([string]::IsNullOrWhiteSpace($provider)) { $provider = Get-OptionalStringProperty $cachedEntry.Ratings "Provider" }
+                if ([string]::IsNullOrWhiteSpace($providerValue)) { $providerValue = Get-OptionalStringProperty $cachedEntry.Ratings "ProviderValue" }
             }
         }
         $needsHostedRating = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         $needsHostedMetadata = (
             -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
@@ -3760,6 +3897,15 @@ function Add-DesignRatingMetadata {
                         $hostedRatingImage -like 'imdb://image.rating*') {
                         $imdb = $hostedRating
                     }
+                    if ([string]::IsNullOrWhiteSpace($provider)) {
+                        $selectedRating = Get-DesignProviderRating `
+                            -RatingImage $hostedRatingImage `
+                            -RatingValue $hostedRating `
+                            -AudienceImage $hostedAudienceImage `
+                            -AudienceValue $hostedAudience
+                        $provider = $selectedRating.Provider
+                        $providerValue = $selectedRating.Value
+                    }
 
                     if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
                         foreach ($ratingEntry in @($hostedMeta.Rating)) {
@@ -3771,6 +3917,11 @@ function Add-DesignRatingMetadata {
                                 [string]::IsNullOrWhiteSpace($imdb) -and
                                 $image -like 'imdb://image.rating*') {
                                 $imdb = $value
+                            }
+                            if ([string]::IsNullOrWhiteSpace($provider)) {
+                                $selectedRating = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                                $provider = $selectedRating.Provider
+                                $providerValue = $selectedRating.Value
                             }
                             if ($mediaType -eq "movie" -and
                                 [string]::IsNullOrWhiteSpace($critic) -and
@@ -3801,10 +3952,11 @@ function Add-DesignRatingMetadata {
         # without a Plex token or title search, and fail closed when a provider
         # does not publish the expected movie RT or TV IMDb value.
         $needsWatchRating = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsWatchRating -and -not [string]::IsNullOrWhiteSpace($watchSlug)) {
             $watchRatings = Get-PlexWatchRatings -Slug $watchSlug -MediaType $mediaType
@@ -3824,11 +3976,12 @@ function Add-DesignRatingMetadata {
         # Last resort: Tautulli's provider-labelled item export can still reach
         # Plex through Tautulli when this runtime cannot connect directly.
         $needsRichExport = if ([string]$item.Type -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or
-                [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or
+                [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsRichExport) {
 
@@ -3848,22 +4001,37 @@ function Add-DesignRatingMetadata {
             elseif ([string]::IsNullOrWhiteSpace($imdb)) {
                 $imdb = [string]$rich.Imdb
             }
+            if ([string]::IsNullOrWhiteSpace($provider)) {
+                $provider = [string]$rich.Provider
+                $providerValue = [string]$rich.ProviderValue
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($imdb) -and $provider -eq "IMDb") {
+            $imdb = $providerValue
         }
 
         if ($mediaType -eq "show") {
-            Write-Log ("Design ratings: {0} -> IMDb {1}" -f $item.Title, $(if ($imdb) { $imdb } else { "n/a" }))
+            Write-Log ("Design ratings: {0} -> IMDb {1}, selected {2}" -f `
+                $item.Title,
+                $(if ($imdb) { $imdb } else { "n/a" }),
+                $(if ($provider) { $provider + " " + $providerValue } else { "n/a" })
+            )
         }
         else {
-            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
+            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}, selected {3}" -f `
                 $item.Title,
                 $(if ($critic) { $critic + "%" } else { "n/a" }),
-                $(if ($audience) { $audience } else { "n/a" })
+                $(if ($audience) { $audience } else { "n/a" }),
+                $(if ($provider) { $provider + " " + $providerValue } else { "n/a" })
             )
         }
 
         $item | Add-Member -NotePropertyName "DesignRtCritic" -NotePropertyValue $critic -Force
         $item | Add-Member -NotePropertyName "DesignRtAudience" -NotePropertyValue $audience -Force
         $item | Add-Member -NotePropertyName "DesignImdbRating" -NotePropertyValue $imdb -Force
+        $item | Add-Member -NotePropertyName "DesignRatingProvider" -NotePropertyValue $provider -Force
+        $item | Add-Member -NotePropertyName "DesignRatingValue" -NotePropertyValue $providerValue -Force
         $item | Add-Member -NotePropertyName "DesignRtCriticImage" -NotePropertyValue $criticImage -Force
         $item | Add-Member -NotePropertyName "DesignRtAudienceImage" -NotePropertyValue $audienceImageState -Force
         $item | Add-Member -NotePropertyName "DesignGenres" -NotePropertyValue @($genres) -Force
@@ -3918,6 +4086,27 @@ function Get-DesignRtIconUrl {
     return "assets/" + $assetName
 }
 
+function Get-DesignProviderRatingHtml {
+    param(
+        [string]$Provider,
+        [string]$Value,
+        [int]$MarginLeft = 0
+    )
+
+    if ($Provider -notin @("IMDb", "TMDB", "TVDB") -or
+        $Value -notmatch '^(?:10(?:\.0+)?|[0-9](?:\.[0-9]+)?)$') {
+        return ""
+    }
+
+    $margin = if ($MarginLeft -gt 0) { "margin-left:${MarginLeft}px;" } else { "" }
+    return '<span style="display:inline-block;' + $margin + 'white-space:nowrap;">' +
+        '<span style="display:inline-block;padding:1px 4px;border:1px solid #a87500;border-radius:3px;margin-right:4px;font-size:9px;line-height:1.1;font-weight:800;letter-spacing:.2px;vertical-align:1px;">' +
+        (HtmlEncode $Provider) +
+        '</span>' +
+        (HtmlEncode $Value) +
+        '</span>'
+}
+
 function Get-DesignRatingLine {
     param(
         [object]$Item,
@@ -3936,7 +4125,7 @@ function Get-DesignRatingLine {
     }
 
     $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
-    if ([string]$Item.Type -eq "show" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+    if (-not [string]::IsNullOrWhiteSpace($imdb)) {
         $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
         $pieces.Add(
             '<span class="design-rating-item">' +
@@ -3945,6 +4134,16 @@ function Get-DesignRatingLine {
             (HtmlEncode $imdb) +
             '</span>'
         )
+    }
+
+    $provider = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingProvider"
+    $providerValue = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingValue"
+    if (-not [string]::IsNullOrWhiteSpace($provider) -and
+        -not ($provider -eq "IMDb" -and -not [string]::IsNullOrWhiteSpace($imdb))) {
+        $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+        if (-not [string]::IsNullOrWhiteSpace($providerHtml)) {
+            $pieces.Add('<span class="design-rating-item">' + $providerHtml + '</span>')
+        }
     }
 
     $critic = ""
@@ -4362,7 +4561,7 @@ function Get-PlexWatchRatings {
             -Uri ((Get-PlexWatchBaseUrl) + "/" + $MediaType + "/" + $slugValue) `
             -Headers @{
                 "Accept-Language" = "en-US,en;q=0.9"
-                "User-Agent"      = "TautWeekly-for-Plex/0.9.3"
+                "User-Agent"      = "TautWeekly-for-Plex/0.9.4"
             } `
             -TimeoutSec 60
         $content = [string]$response.Content
@@ -4616,7 +4815,7 @@ function Get-PlexHostedMetadata {
         "Accept"                   = "application/json"
         "X-Plex-Token"             = $token
         "X-Plex-Product"           = "TautWeekly for Plex"
-        "X-Plex-Version"           = "0.9.3"
+        "X-Plex-Version"           = "0.9.4"
         "X-Plex-Client-Identifier" = "tautweekly-history-artwork"
     }
 
@@ -5082,6 +5281,29 @@ function Get-StatsMovieRatingHtml {
         )
     }
 
+    $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
+    if (-not [string]::IsNullOrWhiteSpace($imdb)) {
+        $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
+        $pieces.Add(
+            '<span style="display:inline-block;white-space:nowrap;">' +
+            '<img src="' + (HtmlEncode $imdbIcon) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
+            (HtmlEncode $imdb) +
+            '</span>'
+        )
+    }
+
+    $provider = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingProvider"
+    $providerValue = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingValue"
+    $providerHtml = if ($provider -eq "IMDb" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+        ""
+    }
+    else {
+        Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+    }
+    if (-not [string]::IsNullOrWhiteSpace($providerHtml)) {
+        $pieces.Add($providerHtml)
+    }
+
     if ($pieces.Count -eq 0) {
         return '<span style="color:#6f6f6f;">Ratings unavailable</span>'
     }
@@ -5175,8 +5397,16 @@ function Get-StatsEpisodeRowsHtml {
         }
 
         $imdb = [string]$item.ImdbRating
+        $provider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+        $providerValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
         $imdbHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            '<span style="color:#6f6f6f;">IMDb unavailable</span>'
+            $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+            if ([string]::IsNullOrWhiteSpace($providerHtml)) {
+                '<span style="color:#6f6f6f;">Rating unavailable</span>'
+            }
+            else {
+                $providerHtml
+            }
         } else {
             '<span style="display:inline-block;white-space:nowrap;">' +
             '<img src="' + (HtmlEncode $ImdbIconSrc) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
@@ -5230,7 +5460,15 @@ function Get-StatsTvShowRowsHtml {
 
         $imdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
         $imdbHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            '<span style="color:#6f6f6f;">IMDb unavailable</span>'
+            $provider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+            $providerValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
+            $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+            if ([string]::IsNullOrWhiteSpace($providerHtml)) {
+                '<span style="color:#6f6f6f;">Rating unavailable</span>'
+            }
+            else {
+                $providerHtml
+            }
         } else {
             $imdbIconSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
             '<span style="display:inline-block;white-space:nowrap;">' +
@@ -5295,8 +5533,14 @@ function Get-TvEpisodeLinesHtml {
             $imdb = [string]$episode.ImdbRating
         }
 
+        $provider = Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+        $providerValue = Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
+
         $ratingHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            ""
+            Get-DesignProviderRatingHtml `
+                -Provider $provider `
+                -Value $providerValue `
+                -MarginLeft 8
         }
         else {
             $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "assets/imdb.png" }
@@ -5420,8 +5664,13 @@ $genreHtml
             }
             else {
                 $showImdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
+                $showProvider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+                $showProviderValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
                 $showRatingHtml = if ([string]::IsNullOrWhiteSpace($showImdb)) {
-                    ""
+                    Get-DesignProviderRatingHtml `
+                        -Provider $showProvider `
+                        -Value $showProviderValue `
+                        -MarginLeft 8
                 }
                 else {
                     $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
@@ -7376,6 +7625,8 @@ function Get-PopulatedPreviewStats {
                 Season=Safe-Int $episode.Season
                 Episode=Safe-Int $episode.Episode
                 ImdbRating=[string]$episode.ImdbRating
+                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
             })
             if ($sampleEpisodes.Count -ge 3) { break }
         }

--- a/platforms/nas-docker/CHANGELOG.txt
+++ b/platforms/nas-docker/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX NAS PORTABLE CHANGELOG
 
 v1.2.0 Portable
 ---------------
+- renders recognized selected IMDb, TMDB, and TVDB ratings from either Tautulli rating field pair
 - makes Tautulli field discovery compatible and explicitly requests provider-labelled rating fields
 - accepts valid minimal rating-only JSON exports instead of rejecting responses under 64 bytes
 - displays recovered show IMDb ratings on TV release cards

--- a/platforms/nas-docker/app/DeletedItemCache.ps1
+++ b/platforms/nas-docker/app/DeletedItemCache.ps1
@@ -475,6 +475,8 @@ function Update-TautWeeklyDeletedItemCache {
                 RtCritic       = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtCritic") 8
                 RtAudience     = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtAudience") 8
                 Imdb           = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignImdbRating") 8
+                Provider       = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRatingProvider") 12
+                ProviderValue  = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRatingValue") 8
                 RtCriticImage  = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtCriticImage") 100
                 RtAudienceImage = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtAudienceImage") 100
             }

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -170,6 +170,53 @@ function Get-OptionalStringProperty {
     return [string]$property.Value
 }
 
+function Get-DesignProviderRating {
+    param(
+        [string]$RatingImage = "",
+        [AllowNull()][object]$RatingValue = $null,
+        [string]$AudienceImage = "",
+        [AllowNull()][object]$AudienceValue = $null
+    )
+
+    foreach ($candidate in @(
+        [PSCustomObject]@{ Image = $RatingImage; Value = $RatingValue },
+        [PSCustomObject]@{ Image = $AudienceImage; Value = $AudienceValue }
+    )) {
+        $image = ([string]$candidate.Image).Trim().ToLowerInvariant()
+        $value = if ($candidate.Value -is [IFormattable]) {
+            ([IFormattable]$candidate.Value).ToString($null, [Globalization.CultureInfo]::InvariantCulture).Trim()
+        }
+        else {
+            ([string]$candidate.Value).Trim()
+        }
+        if ([string]::IsNullOrWhiteSpace($image) -or
+            $value -notmatch '^(?:10(?:\.0+)?|[0-9](?:\.[0-9]+)?)$') {
+            continue
+        }
+
+        $provider = if ($image -like 'imdb://image.rating*') {
+            'IMDb'
+        }
+        elseif ($image -like 'themoviedb://image.rating*' -or
+            $image -like 'tmdb://image.rating*') {
+            'TMDB'
+        }
+        elseif ($image -like 'thetvdb://image.rating*' -or
+            $image -like 'tvdb://image.rating*') {
+            'TVDB'
+        }
+        else {
+            ''
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($provider)) {
+            return [PSCustomObject]@{ Provider = $provider; Value = $value }
+        }
+    }
+
+    return [PSCustomObject]@{ Provider = ''; Value = '' }
+}
+
 function Safe-Int64 {
     param([AllowNull()][object]$Value)
     if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) { return [int64]0 }
@@ -795,9 +842,16 @@ function New-ReleaseData {
                 if (-not [string]::IsNullOrWhiteSpace($episodeTitle)) {
                     $ratingImage = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
                     $ratingValue = Get-OptionalStringProperty -InputObject $item -Name "rating"
+                    $audienceImage = Get-OptionalStringProperty -InputObject $item -Name "audience_rating_image"
+                    $audienceValue = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+                    $selectedRating = Get-DesignProviderRating `
+                        -RatingImage $ratingImage `
+                        -RatingValue $ratingValue `
+                        -AudienceImage $audienceImage `
+                        -AudienceValue $audienceValue
                     $nativeImdbRating = ""
-                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                        $nativeImdbRating = $ratingValue
+                    if ($selectedRating.Provider -eq "IMDb") {
+                        $nativeImdbRating = $selectedRating.Value
                     }
 
                     $entry.Episodes.Add([PSCustomObject]@{
@@ -806,6 +860,8 @@ function New-ReleaseData {
                         AddedAt     = Safe-Int64 $item.added_at
                         ImdbRating  = $nativeImdbRating
                         RatingImage = $ratingImage
+                        DesignRatingProvider = $selectedRating.Provider
+                        DesignRatingValue = $selectedRating.Value
                         Season      = Safe-Int $item.parent_media_index
                         Episode     = Safe-Int $item.media_index
                     })
@@ -1077,10 +1133,16 @@ function Get-TvEpisodeSnapshotFromTautulli {
 
         $ratingImage = Get-OptionalStringProperty -InputObject $episode -Name "rating_image"
         $ratingValue = Get-OptionalStringProperty -InputObject $episode -Name "rating"
+        $audienceImage = Get-OptionalStringProperty -InputObject $episode -Name "audience_rating_image"
+        $audienceValue = Get-OptionalStringProperty -InputObject $episode -Name "audience_rating"
+        $selectedRating = Get-DesignProviderRating `
+            -RatingImage $ratingImage `
+            -RatingValue $ratingValue `
+            -AudienceImage $audienceImage `
+            -AudienceValue $audienceValue
         $nativeImdbRating = ""
-        if ($ratingImage -match '(?i)^imdb://' -and
-            -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-            $nativeImdbRating = $ratingValue
+        if ($selectedRating.Provider -eq "IMDb") {
+            $nativeImdbRating = $selectedRating.Value
         }
 
         $result.Add([PSCustomObject]@{
@@ -1089,6 +1151,8 @@ function Get-TvEpisodeSnapshotFromTautulli {
             AddedAt     = Safe-Int64 $episode.added_at
             ImdbRating  = $nativeImdbRating
             RatingImage = $ratingImage
+            DesignRatingProvider = $selectedRating.Provider
+            DesignRatingValue = $selectedRating.Value
             Season      = $seasonIndex
             Episode     = $episodeIndex
         })
@@ -1204,24 +1268,32 @@ function Enrich-TvEpisodeMetadata {
 
             $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+            $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+            $audienceValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+            $selectedRating = Get-DesignProviderRating `
+                -RatingImage $ratingImage `
+                -RatingValue $ratingValue `
+                -AudienceImage $audienceImage `
+                -AudienceValue $audienceValue
             if (-not [string]::IsNullOrWhiteSpace($ratingImage)) {
                 $episode.RatingImage = $ratingImage
             }
 
             $episode.ImdbRating = ""
+            $episode | Add-Member -NotePropertyName "DesignRatingProvider" -NotePropertyValue $selectedRating.Provider -Force
+            $episode | Add-Member -NotePropertyName "DesignRatingValue" -NotePropertyValue $selectedRating.Value -Force
 
             # Fast path: Tautulli explicitly identifies IMDb as the selected
             # episode rating provider.
-            if ($ratingImage -match '(?i)^imdb://') {
-                if (-not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                    $episode.ImdbRating = $ratingValue
-                }
+            if ($selectedRating.Provider -eq "IMDb") {
+                $episode.ImdbRating = $selectedRating.Value
             }
 
             # Plex UI can show IMDb alongside other providers even when
             # Tautulli's flattened rating_image does not select IMDb.
             # Fall back to Plex's native Rating[] / legacy XML metadata.
-            if ([string]::IsNullOrWhiteSpace([string]$episode.ImdbRating)) {
+            if ([string]::IsNullOrWhiteSpace([string]$episode.ImdbRating) -and
+                [string]::IsNullOrWhiteSpace([string]$selectedRating.Provider)) {
                 $episode.ImdbRating = Get-DesignEpisodeImdbRating `
                     -RatingKey $ratingKey `
                     -TautulliMetadata $meta
@@ -1428,9 +1500,15 @@ function Get-UserStats {
                     $nativeImdb = ""
                     $ratingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
                     $ratingValue = Get-OptionalStringProperty -InputObject $row -Name "rating"
-                    if ($ratingImage -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                        $nativeImdb = $ratingValue
+                    $audienceImage = Get-OptionalStringProperty -InputObject $row -Name "audience_rating_image"
+                    $audienceValue = Get-OptionalStringProperty -InputObject $row -Name "audience_rating"
+                    $selectedRating = Get-DesignProviderRating `
+                        -RatingImage $ratingImage `
+                        -RatingValue $ratingValue `
+                        -AudienceImage $audienceImage `
+                        -AudienceValue $audienceValue
+                    if ($selectedRating.Provider -eq "IMDb") {
+                        $nativeImdb = $selectedRating.Value
                     }
 
                     $episodeItems.Add([PSCustomObject]@{
@@ -1443,6 +1521,8 @@ function Get-UserStats {
                         Season          = Safe-Int $row.parent_media_index
                         Episode         = Safe-Int $row.media_index
                         ImdbRating      = $nativeImdb
+                        DesignRatingProvider = $selectedRating.Provider
+                        DesignRatingValue = $selectedRating.Value
                         Plays           = Get-HistoryRowPlayCount -Row $row
                     })
                 }
@@ -2811,7 +2891,9 @@ function Find-DesignProviderRatingsRecursive {
         [AllowNull()][object]$Node,
         [ref]$Critic,
         [ref]$Audience,
-        [ref]$Imdb
+        [ref]$Imdb,
+        [ref]$Provider,
+        [ref]$ProviderValue
     )
 
     if ($null -eq $Node) { return }
@@ -2827,7 +2909,9 @@ function Find-DesignProviderRatingsRecursive {
                 -Node $child `
                 -Critic $Critic `
                 -Audience $Audience `
-                -Imdb $Imdb
+                -Imdb $Imdb `
+                -Provider $Provider `
+                -ProviderValue $ProviderValue
         }
         return
     }
@@ -2867,6 +2951,16 @@ function Find-DesignProviderRatingsRecursive {
                 $Audience.Value = Convert-DesignRatingPercent $audienceValue
             }
 
+            if ([string]::IsNullOrWhiteSpace($Provider.Value)) {
+                $selected = Get-DesignProviderRating `
+                    -RatingImage $ratingImage `
+                    -RatingValue $ratingValue `
+                    -AudienceImage $audienceImage `
+                    -AudienceValue $audienceValue
+                $Provider.Value = $selected.Provider
+                $ProviderValue.Value = $selected.Value
+            }
+
             $imageProp = $props["image"]
             $valueProp = $props["value"]
 
@@ -2892,6 +2986,11 @@ function Find-DesignProviderRatingsRecursive {
                         }
                     }
                 }
+                elseif ([string]::IsNullOrWhiteSpace($Provider.Value)) {
+                    $selected = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                    $Provider.Value = $selected.Provider
+                    $ProviderValue.Value = $selected.Value
+                }
             }
 
             foreach ($p in $props) {
@@ -2899,7 +2998,9 @@ function Find-DesignProviderRatingsRecursive {
                     -Node $p.Value `
                     -Critic $Critic `
                     -Audience $Audience `
-                    -Imdb $Imdb
+                    -Imdb $Imdb `
+                    -Provider $Provider `
+                    -ProviderValue $ProviderValue
             }
             return
         }
@@ -3149,6 +3250,8 @@ function Get-DesignRichExport {
             RtCritic = ""
             RtAudience = ""
             Imdb = ""
+            Provider = ""
+            ProviderValue = ""
             LogoSrc = ""
             DiagnosticFile = ""
         }
@@ -3169,6 +3272,8 @@ function Get-DesignRichExport {
         RtCritic = ""
         RtAudience = ""
         Imdb = ""
+        Provider = ""
+        ProviderValue = ""
         LogoSrc = ""
         DiagnosticFile = ""
     }
@@ -3205,9 +3310,10 @@ function Get-DesignRichExport {
         $params = @{
             rating_key       = $RatingKey
             file_format      = "json"
-            # Tautulli metadata level 1 contains movie rating, ratingImage,
-            # audienceRating, and audienceRatingImage. Higher levels can add
-            # private media paths that this presentation fallback never needs.
+            # Availability differs by media type (show exports can omit
+            # ratingImage), so the selected provider fields are also requested
+            # explicitly. Higher levels can add private media paths that this
+            # presentation fallback never needs.
             metadata_level   = 1
             media_info_level = 0
             thumb_level      = 0
@@ -3225,7 +3331,7 @@ function Get-DesignRichExport {
             $params.custom_fields = ($customFields -join ",")
         }
 
-        Write-Log ("TautWeekly for Plex: Tautulli item export for {0} (RT rating fields{1})..." -f `
+        Write-Log ("TautWeekly for Plex: Tautulli item export for {0} (provider-labelled rating fields{1})..." -f `
             $RatingKey,
             $(if ($NeedLogo) { " + selected logo level 9" } else { "" })
         )
@@ -3278,6 +3384,8 @@ function Get-DesignRichExport {
         $critic = ""
         $audience = ""
         $imdb = ""
+        $provider = ""
+        $providerValue = ""
         $jsonFiles = @()
         $exportedFiles = @()
         $bytes = [IO.File]::ReadAllBytes($downloadPath)
@@ -3300,7 +3408,9 @@ function Get-DesignRichExport {
                         -Node $parsed `
                         -Critic ([ref]$critic) `
                         -Audience ([ref]$audience) `
-                        -Imdb ([ref]$imdb)
+                        -Imdb ([ref]$imdb) `
+                        -Provider ([ref]$provider) `
+                        -ProviderValue ([ref]$providerValue)
 
                     if (-not [string]::IsNullOrWhiteSpace($critic) -and
                         -not [string]::IsNullOrWhiteSpace($audience)) {
@@ -3317,7 +3427,9 @@ function Get-DesignRichExport {
                     -Node $parsed `
                     -Critic ([ref]$critic) `
                     -Audience ([ref]$audience) `
-                    -Imdb ([ref]$imdb)
+                    -Imdb ([ref]$imdb) `
+                    -Provider ([ref]$provider) `
+                    -ProviderValue ([ref]$providerValue)
             }
             catch {
                 throw "Downloaded item export was neither a ZIP archive nor valid JSON."
@@ -3327,6 +3439,8 @@ function Get-DesignRichExport {
         $result.RtCritic = $critic
         $result.RtAudience = $audience
         $result.Imdb = $imdb
+        $result.Provider = $provider
+        $result.ProviderValue = $providerValue
 
         if ($NeedLogo) {
             if (-not $isZip) {
@@ -3374,6 +3488,8 @@ function Get-DesignRichExport {
             RtCritic = $result.RtCritic
             RtAudience = $result.RtAudience
             Imdb = $result.Imdb
+            Provider = $result.Provider
+            ProviderValue = $result.ProviderValue
             LogoExportLevel = $(if ($NeedLogo) { 9 } else { 0 })
             LogoFound = -not [string]::IsNullOrWhiteSpace($result.LogoSrc)
             JsonFiles = @($jsonFiles | ForEach-Object { $_.Name })
@@ -3384,10 +3500,11 @@ function Get-DesignRichExport {
         $diag | ConvertTo-Json -Depth 8 | Set-Content -Path $diagPath -Encoding UTF8
         $result.DiagnosticFile = "media/" + $diagPath.Split([IO.Path]::DirectorySeparatorChar)[-1]
 
-        Write-Log ("Design rich export result: RT critic={0}, audience={1}, IMDb={2}, logo={3}" -f `
+        Write-Log ("Design rich export result: RT critic={0}, audience={1}, IMDb={2}, selected={3}, logo={4}" -f `
             $(if ($result.RtCritic) { $result.RtCritic + "%" } else { "n/a" }),
             $(if ($result.RtAudience) { $result.RtAudience } else { "n/a" }),
             $(if ($result.Imdb) { $result.Imdb } else { "n/a" }),
+            $(if ($result.Provider) { $result.Provider + " " + $result.ProviderValue } else { "n/a" }),
             $(if ($result.LogoSrc) { "yes" } else { "no" })
         )
     }
@@ -3522,6 +3639,8 @@ function Add-DesignRatingMetadata {
         $critic = ""
         $audience = ""
         $imdb = ""
+        $provider = ""
+        $providerValue = ""
         $criticImage = ""
         $audienceImageState = ""
         $genres = @()
@@ -3530,8 +3649,9 @@ function Add-DesignRatingMetadata {
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
-        # Primary source for the newsletter: Tautulli already exposes selected
-        # movie RT and TV IMDb scores plus their provider IDs.
+        # Primary source for the newsletter: Tautulli exposes Plex's selected,
+        # provider-labelled rating fields. Keep the dedicated RT/IMDb display
+        # paths, then retain another recognized provider as a text badge.
         try {
             $meta = Invoke-TautulliApi -Command "get_metadata" -Parameters @{
                 rating_key = $ratingKey
@@ -3542,6 +3662,13 @@ function Add-DesignRatingMetadata {
             $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+            $selectedRating = Get-DesignProviderRating `
+                -RatingImage $ratingImage `
+                -RatingValue $ratingValue `
+                -AudienceImage $audienceImage `
+                -AudienceValue $audienceRatingValue
+            $provider = $selectedRating.Provider
+            $providerValue = $selectedRating.Value
 
             if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
                 $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
@@ -3584,10 +3711,11 @@ function Add-DesignRatingMetadata {
         # Optional secondary source: Plex's full Rating[] if direct access
         # happens to be available on this install.
         $needsDirectRatings = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsDirectRatings) {
             try {
@@ -3621,6 +3749,12 @@ function Add-DesignRatingMetadata {
                             [string]::IsNullOrWhiteSpace($imdb) -and
                             $image -like "imdb://image.rating*") {
                             $imdb = [string]$value
+                        }
+
+                        if ([string]::IsNullOrWhiteSpace($provider)) {
+                            $selectedRating = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                            $provider = $selectedRating.Provider
+                            $providerValue = $selectedRating.Value
                         }
 
                         if ($mediaType -eq "movie" -and
@@ -3681,13 +3815,16 @@ function Add-DesignRatingMetadata {
                 if ([string]::IsNullOrWhiteSpace($imdb)) { $imdb = Get-OptionalStringProperty $cachedEntry.Ratings "Imdb" }
                 if ([string]::IsNullOrWhiteSpace($criticImage)) { $criticImage = Get-OptionalStringProperty $cachedEntry.Ratings "RtCriticImage" }
                 if ([string]::IsNullOrWhiteSpace($audienceImageState)) { $audienceImageState = Get-OptionalStringProperty $cachedEntry.Ratings "RtAudienceImage" }
+                if ([string]::IsNullOrWhiteSpace($provider)) { $provider = Get-OptionalStringProperty $cachedEntry.Ratings "Provider" }
+                if ([string]::IsNullOrWhiteSpace($providerValue)) { $providerValue = Get-OptionalStringProperty $cachedEntry.Ratings "ProviderValue" }
             }
         }
         $needsHostedRating = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         $needsHostedMetadata = (
             -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
@@ -3761,6 +3898,15 @@ function Add-DesignRatingMetadata {
                         $hostedRatingImage -like 'imdb://image.rating*') {
                         $imdb = $hostedRating
                     }
+                    if ([string]::IsNullOrWhiteSpace($provider)) {
+                        $selectedRating = Get-DesignProviderRating `
+                            -RatingImage $hostedRatingImage `
+                            -RatingValue $hostedRating `
+                            -AudienceImage $hostedAudienceImage `
+                            -AudienceValue $hostedAudience
+                        $provider = $selectedRating.Provider
+                        $providerValue = $selectedRating.Value
+                    }
 
                     if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
                         foreach ($ratingEntry in @($hostedMeta.Rating)) {
@@ -3772,6 +3918,11 @@ function Add-DesignRatingMetadata {
                                 [string]::IsNullOrWhiteSpace($imdb) -and
                                 $image -like 'imdb://image.rating*') {
                                 $imdb = $value
+                            }
+                            if ([string]::IsNullOrWhiteSpace($provider)) {
+                                $selectedRating = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                                $provider = $selectedRating.Provider
+                                $providerValue = $selectedRating.Value
                             }
                             if ($mediaType -eq "movie" -and
                                 [string]::IsNullOrWhiteSpace($critic) -and
@@ -3802,10 +3953,11 @@ function Add-DesignRatingMetadata {
         # without a Plex token or title search, and fail closed when a provider
         # does not publish the expected movie RT or TV IMDb value.
         $needsWatchRating = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsWatchRating -and -not [string]::IsNullOrWhiteSpace($watchSlug)) {
             $watchRatings = Get-PlexWatchRatings -Slug $watchSlug -MediaType $mediaType
@@ -3825,11 +3977,12 @@ function Add-DesignRatingMetadata {
         # Last resort: Tautulli's provider-labelled item export can still reach
         # Plex through Tautulli when this runtime cannot connect directly.
         $needsRichExport = if ([string]$item.Type -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or
-                [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or
+                [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsRichExport) {
 
@@ -3849,22 +4002,37 @@ function Add-DesignRatingMetadata {
             elseif ([string]::IsNullOrWhiteSpace($imdb)) {
                 $imdb = [string]$rich.Imdb
             }
+            if ([string]::IsNullOrWhiteSpace($provider)) {
+                $provider = [string]$rich.Provider
+                $providerValue = [string]$rich.ProviderValue
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($imdb) -and $provider -eq "IMDb") {
+            $imdb = $providerValue
         }
 
         if ($mediaType -eq "show") {
-            Write-Log ("Design ratings: {0} -> IMDb {1}" -f $item.Title, $(if ($imdb) { $imdb } else { "n/a" }))
+            Write-Log ("Design ratings: {0} -> IMDb {1}, selected {2}" -f `
+                $item.Title,
+                $(if ($imdb) { $imdb } else { "n/a" }),
+                $(if ($provider) { $provider + " " + $providerValue } else { "n/a" })
+            )
         }
         else {
-            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
+            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}, selected {3}" -f `
                 $item.Title,
                 $(if ($critic) { $critic + "%" } else { "n/a" }),
-                $(if ($audience) { $audience } else { "n/a" })
+                $(if ($audience) { $audience } else { "n/a" }),
+                $(if ($provider) { $provider + " " + $providerValue } else { "n/a" })
             )
         }
 
         $item | Add-Member -NotePropertyName "DesignRtCritic" -NotePropertyValue $critic -Force
         $item | Add-Member -NotePropertyName "DesignRtAudience" -NotePropertyValue $audience -Force
         $item | Add-Member -NotePropertyName "DesignImdbRating" -NotePropertyValue $imdb -Force
+        $item | Add-Member -NotePropertyName "DesignRatingProvider" -NotePropertyValue $provider -Force
+        $item | Add-Member -NotePropertyName "DesignRatingValue" -NotePropertyValue $providerValue -Force
         $item | Add-Member -NotePropertyName "DesignRtCriticImage" -NotePropertyValue $criticImage -Force
         $item | Add-Member -NotePropertyName "DesignRtAudienceImage" -NotePropertyValue $audienceImageState -Force
         $item | Add-Member -NotePropertyName "DesignGenres" -NotePropertyValue @($genres) -Force
@@ -3919,6 +4087,27 @@ function Get-DesignRtIconUrl {
     return "assets/" + $assetName
 }
 
+function Get-DesignProviderRatingHtml {
+    param(
+        [string]$Provider,
+        [string]$Value,
+        [int]$MarginLeft = 0
+    )
+
+    if ($Provider -notin @("IMDb", "TMDB", "TVDB") -or
+        $Value -notmatch '^(?:10(?:\.0+)?|[0-9](?:\.[0-9]+)?)$') {
+        return ""
+    }
+
+    $margin = if ($MarginLeft -gt 0) { "margin-left:${MarginLeft}px;" } else { "" }
+    return '<span style="display:inline-block;' + $margin + 'white-space:nowrap;">' +
+        '<span style="display:inline-block;padding:1px 4px;border:1px solid #a87500;border-radius:3px;margin-right:4px;font-size:9px;line-height:1.1;font-weight:800;letter-spacing:.2px;vertical-align:1px;">' +
+        (HtmlEncode $Provider) +
+        '</span>' +
+        (HtmlEncode $Value) +
+        '</span>'
+}
+
 function Get-DesignRatingLine {
     param(
         [object]$Item,
@@ -3937,7 +4126,7 @@ function Get-DesignRatingLine {
     }
 
     $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
-    if ([string]$Item.Type -eq "show" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+    if (-not [string]::IsNullOrWhiteSpace($imdb)) {
         $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
         $pieces.Add(
             '<span class="design-rating-item">' +
@@ -3946,6 +4135,16 @@ function Get-DesignRatingLine {
             (HtmlEncode $imdb) +
             '</span>'
         )
+    }
+
+    $provider = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingProvider"
+    $providerValue = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingValue"
+    if (-not [string]::IsNullOrWhiteSpace($provider) -and
+        -not ($provider -eq "IMDb" -and -not [string]::IsNullOrWhiteSpace($imdb))) {
+        $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+        if (-not [string]::IsNullOrWhiteSpace($providerHtml)) {
+            $pieces.Add('<span class="design-rating-item">' + $providerHtml + '</span>')
+        }
     }
 
     $critic = ""
@@ -4363,7 +4562,7 @@ function Get-PlexWatchRatings {
             -Uri ((Get-PlexWatchBaseUrl) + "/" + $MediaType + "/" + $slugValue) `
             -Headers @{
                 "Accept-Language" = "en-US,en;q=0.9"
-                "User-Agent"      = "TautWeekly-for-Plex/0.9.3"
+                "User-Agent"      = "TautWeekly-for-Plex/0.9.4"
             } `
             -TimeoutSec 60
         $content = [string]$response.Content
@@ -4617,7 +4816,7 @@ function Get-PlexHostedMetadata {
         "Accept"                   = "application/json"
         "X-Plex-Token"             = $token
         "X-Plex-Product"           = "TautWeekly for Plex"
-        "X-Plex-Version"           = "0.9.3"
+        "X-Plex-Version"           = "0.9.4"
         "X-Plex-Client-Identifier" = "tautweekly-history-artwork"
     }
 
@@ -5083,6 +5282,29 @@ function Get-StatsMovieRatingHtml {
         )
     }
 
+    $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
+    if (-not [string]::IsNullOrWhiteSpace($imdb)) {
+        $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
+        $pieces.Add(
+            '<span style="display:inline-block;white-space:nowrap;">' +
+            '<img src="' + (HtmlEncode $imdbIcon) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
+            (HtmlEncode $imdb) +
+            '</span>'
+        )
+    }
+
+    $provider = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingProvider"
+    $providerValue = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingValue"
+    $providerHtml = if ($provider -eq "IMDb" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+        ""
+    }
+    else {
+        Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+    }
+    if (-not [string]::IsNullOrWhiteSpace($providerHtml)) {
+        $pieces.Add($providerHtml)
+    }
+
     if ($pieces.Count -eq 0) {
         return '<span style="color:#6f6f6f;">Ratings unavailable</span>'
     }
@@ -5176,8 +5398,16 @@ function Get-StatsEpisodeRowsHtml {
         }
 
         $imdb = [string]$item.ImdbRating
+        $provider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+        $providerValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
         $imdbHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            '<span style="color:#6f6f6f;">IMDb unavailable</span>'
+            $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+            if ([string]::IsNullOrWhiteSpace($providerHtml)) {
+                '<span style="color:#6f6f6f;">Rating unavailable</span>'
+            }
+            else {
+                $providerHtml
+            }
         } else {
             '<span style="display:inline-block;white-space:nowrap;">' +
             '<img src="' + (HtmlEncode $ImdbIconSrc) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
@@ -5231,7 +5461,15 @@ function Get-StatsTvShowRowsHtml {
 
         $imdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
         $imdbHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            '<span style="color:#6f6f6f;">IMDb unavailable</span>'
+            $provider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+            $providerValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
+            $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+            if ([string]::IsNullOrWhiteSpace($providerHtml)) {
+                '<span style="color:#6f6f6f;">Rating unavailable</span>'
+            }
+            else {
+                $providerHtml
+            }
         } else {
             $imdbIconSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
             '<span style="display:inline-block;white-space:nowrap;">' +
@@ -5296,8 +5534,14 @@ function Get-TvEpisodeLinesHtml {
             $imdb = [string]$episode.ImdbRating
         }
 
+        $provider = Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+        $providerValue = Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
+
         $ratingHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            ""
+            Get-DesignProviderRatingHtml `
+                -Provider $provider `
+                -Value $providerValue `
+                -MarginLeft 8
         }
         else {
             $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "assets/imdb.png" }
@@ -5421,8 +5665,13 @@ $genreHtml
             }
             else {
                 $showImdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
+                $showProvider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+                $showProviderValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
                 $showRatingHtml = if ([string]::IsNullOrWhiteSpace($showImdb)) {
-                    ""
+                    Get-DesignProviderRatingHtml `
+                        -Provider $showProvider `
+                        -Value $showProviderValue `
+                        -MarginLeft 8
                 }
                 else {
                     $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
@@ -7377,6 +7626,8 @@ function Get-PopulatedPreviewStats {
                 Season=Safe-Int $episode.Season
                 Episode=Safe-Int $episode.Episode
                 ImdbRating=[string]$episode.ImdbRating
+                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
             })
             if ($sampleEpisodes.Count -ge 3) { break }
         }

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -3,6 +3,7 @@ TAUTWEEKLY FOR PLEX PORTABLE CHANGELOG
 
 v1.8.0 Portable
 ---------------
+- renders recognized selected IMDb, TMDB, and TVDB ratings from either Tautulli rating field pair
 - makes Tautulli field discovery compatible and explicitly requests provider-labelled rating fields
 - accepts valid minimal rating-only JSON exports instead of rejecting responses under 64 bytes
 - displays recovered show IMDb ratings on TV release cards

--- a/platforms/windows/DeletedItemCache.ps1
+++ b/platforms/windows/DeletedItemCache.ps1
@@ -475,6 +475,8 @@ function Update-TautWeeklyDeletedItemCache {
                 RtCritic       = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtCritic") 8
                 RtAudience     = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtAudience") 8
                 Imdb           = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignImdbRating") 8
+                Provider       = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRatingProvider") 12
+                ProviderValue  = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRatingValue") 8
                 RtCriticImage  = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtCriticImage") 100
                 RtAudienceImage = ConvertTo-TwDeletedCacheText (Get-OptionalStringProperty $Item "DesignRtAudienceImage") 100
             }

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -103,6 +103,53 @@ function Get-OptionalStringProperty {
     return [string]$property.Value
 }
 
+function Get-DesignProviderRating {
+    param(
+        [string]$RatingImage = "",
+        [AllowNull()][object]$RatingValue = $null,
+        [string]$AudienceImage = "",
+        [AllowNull()][object]$AudienceValue = $null
+    )
+
+    foreach ($candidate in @(
+        [PSCustomObject]@{ Image = $RatingImage; Value = $RatingValue },
+        [PSCustomObject]@{ Image = $AudienceImage; Value = $AudienceValue }
+    )) {
+        $image = ([string]$candidate.Image).Trim().ToLowerInvariant()
+        $value = if ($candidate.Value -is [IFormattable]) {
+            ([IFormattable]$candidate.Value).ToString($null, [Globalization.CultureInfo]::InvariantCulture).Trim()
+        }
+        else {
+            ([string]$candidate.Value).Trim()
+        }
+        if ([string]::IsNullOrWhiteSpace($image) -or
+            $value -notmatch '^(?:10(?:\.0+)?|[0-9](?:\.[0-9]+)?)$') {
+            continue
+        }
+
+        $provider = if ($image -like 'imdb://image.rating*') {
+            'IMDb'
+        }
+        elseif ($image -like 'themoviedb://image.rating*' -or
+            $image -like 'tmdb://image.rating*') {
+            'TMDB'
+        }
+        elseif ($image -like 'thetvdb://image.rating*' -or
+            $image -like 'tvdb://image.rating*') {
+            'TVDB'
+        }
+        else {
+            ''
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($provider)) {
+            return [PSCustomObject]@{ Provider = $provider; Value = $value }
+        }
+    }
+
+    return [PSCustomObject]@{ Provider = ''; Value = '' }
+}
+
 function Safe-Int64 {
     param([AllowNull()][object]$Value)
     if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) { return [int64]0 }
@@ -756,9 +803,16 @@ function New-ReleaseData {
                 if (-not [string]::IsNullOrWhiteSpace($episodeTitle)) {
                     $ratingImage = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
                     $ratingValue = Get-OptionalStringProperty -InputObject $item -Name "rating"
+                    $audienceImage = Get-OptionalStringProperty -InputObject $item -Name "audience_rating_image"
+                    $audienceValue = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+                    $selectedRating = Get-DesignProviderRating `
+                        -RatingImage $ratingImage `
+                        -RatingValue $ratingValue `
+                        -AudienceImage $audienceImage `
+                        -AudienceValue $audienceValue
                     $nativeImdbRating = ""
-                    if ($ratingImage -like 'imdb://*' -and -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                        $nativeImdbRating = $ratingValue
+                    if ($selectedRating.Provider -eq "IMDb") {
+                        $nativeImdbRating = $selectedRating.Value
                     }
 
                     $entry.Episodes.Add([PSCustomObject]@{
@@ -767,6 +821,8 @@ function New-ReleaseData {
                         AddedAt     = Safe-Int64 $item.added_at
                         ImdbRating  = $nativeImdbRating
                         RatingImage = $ratingImage
+                        DesignRatingProvider = $selectedRating.Provider
+                        DesignRatingValue = $selectedRating.Value
                         Season      = Safe-Int $item.parent_media_index
                         Episode     = Safe-Int $item.media_index
                     })
@@ -1038,10 +1094,16 @@ function Get-TvEpisodeSnapshotFromTautulli {
 
         $ratingImage = Get-OptionalStringProperty -InputObject $episode -Name "rating_image"
         $ratingValue = Get-OptionalStringProperty -InputObject $episode -Name "rating"
+        $audienceImage = Get-OptionalStringProperty -InputObject $episode -Name "audience_rating_image"
+        $audienceValue = Get-OptionalStringProperty -InputObject $episode -Name "audience_rating"
+        $selectedRating = Get-DesignProviderRating `
+            -RatingImage $ratingImage `
+            -RatingValue $ratingValue `
+            -AudienceImage $audienceImage `
+            -AudienceValue $audienceValue
         $nativeImdbRating = ""
-        if ($ratingImage -match '(?i)^imdb://' -and
-            -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-            $nativeImdbRating = $ratingValue
+        if ($selectedRating.Provider -eq "IMDb") {
+            $nativeImdbRating = $selectedRating.Value
         }
 
         $result.Add([PSCustomObject]@{
@@ -1050,6 +1112,8 @@ function Get-TvEpisodeSnapshotFromTautulli {
             AddedAt     = Safe-Int64 $episode.added_at
             ImdbRating  = $nativeImdbRating
             RatingImage = $ratingImage
+            DesignRatingProvider = $selectedRating.Provider
+            DesignRatingValue = $selectedRating.Value
             Season      = $seasonIndex
             Episode     = $episodeIndex
         })
@@ -1165,24 +1229,32 @@ function Enrich-TvEpisodeMetadata {
 
             $ratingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+            $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+            $audienceValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+            $selectedRating = Get-DesignProviderRating `
+                -RatingImage $ratingImage `
+                -RatingValue $ratingValue `
+                -AudienceImage $audienceImage `
+                -AudienceValue $audienceValue
             if (-not [string]::IsNullOrWhiteSpace($ratingImage)) {
                 $episode.RatingImage = $ratingImage
             }
 
             $episode.ImdbRating = ""
+            $episode | Add-Member -NotePropertyName "DesignRatingProvider" -NotePropertyValue $selectedRating.Provider -Force
+            $episode | Add-Member -NotePropertyName "DesignRatingValue" -NotePropertyValue $selectedRating.Value -Force
 
             # Fast path: Tautulli explicitly identifies IMDb as the selected
             # episode rating provider.
-            if ($ratingImage -match '(?i)^imdb://') {
-                if (-not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                    $episode.ImdbRating = $ratingValue
-                }
+            if ($selectedRating.Provider -eq "IMDb") {
+                $episode.ImdbRating = $selectedRating.Value
             }
 
             # Plex UI can show IMDb alongside other providers even when
             # Tautulli's flattened rating_image does not select IMDb.
             # Fall back to Plex's native Rating[] / legacy XML metadata.
-            if ([string]::IsNullOrWhiteSpace([string]$episode.ImdbRating)) {
+            if ([string]::IsNullOrWhiteSpace([string]$episode.ImdbRating) -and
+                [string]::IsNullOrWhiteSpace([string]$selectedRating.Provider)) {
                 $episode.ImdbRating = Get-DesignEpisodeImdbRating `
                     -RatingKey $ratingKey `
                     -TautulliMetadata $meta
@@ -1403,9 +1475,15 @@ function Get-UserStats {
                     $nativeImdb = ""
                     $ratingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
                     $ratingValue = Get-OptionalStringProperty -InputObject $row -Name "rating"
-                    if ($ratingImage -match '(?i)^imdb://' -and
-                        -not [string]::IsNullOrWhiteSpace($ratingValue)) {
-                        $nativeImdb = $ratingValue
+                    $audienceImage = Get-OptionalStringProperty -InputObject $row -Name "audience_rating_image"
+                    $audienceValue = Get-OptionalStringProperty -InputObject $row -Name "audience_rating"
+                    $selectedRating = Get-DesignProviderRating `
+                        -RatingImage $ratingImage `
+                        -RatingValue $ratingValue `
+                        -AudienceImage $audienceImage `
+                        -AudienceValue $audienceValue
+                    if ($selectedRating.Provider -eq "IMDb") {
+                        $nativeImdb = $selectedRating.Value
                     }
 
                     $episodeItems.Add([PSCustomObject]@{
@@ -1418,6 +1496,8 @@ function Get-UserStats {
                         Season          = Safe-Int $row.parent_media_index
                         Episode         = Safe-Int $row.media_index
                         ImdbRating      = $nativeImdb
+                        DesignRatingProvider = $selectedRating.Provider
+                        DesignRatingValue = $selectedRating.Value
                         Plays           = Get-HistoryRowPlayCount -Row $row
                     })
                 }
@@ -2848,7 +2928,9 @@ function Find-DesignProviderRatingsRecursive {
         [AllowNull()][object]$Node,
         [ref]$Critic,
         [ref]$Audience,
-        [ref]$Imdb
+        [ref]$Imdb,
+        [ref]$Provider,
+        [ref]$ProviderValue
     )
 
     if ($null -eq $Node) { return }
@@ -2864,7 +2946,9 @@ function Find-DesignProviderRatingsRecursive {
                 -Node $child `
                 -Critic $Critic `
                 -Audience $Audience `
-                -Imdb $Imdb
+                -Imdb $Imdb `
+                -Provider $Provider `
+                -ProviderValue $ProviderValue
         }
         return
     }
@@ -2904,6 +2988,16 @@ function Find-DesignProviderRatingsRecursive {
                 $Audience.Value = Convert-DesignRatingPercent $audienceValue
             }
 
+            if ([string]::IsNullOrWhiteSpace($Provider.Value)) {
+                $selected = Get-DesignProviderRating `
+                    -RatingImage $ratingImage `
+                    -RatingValue $ratingValue `
+                    -AudienceImage $audienceImage `
+                    -AudienceValue $audienceValue
+                $Provider.Value = $selected.Provider
+                $ProviderValue.Value = $selected.Value
+            }
+
             $imageProp = $props["image"]
             $valueProp = $props["value"]
 
@@ -2929,6 +3023,11 @@ function Find-DesignProviderRatingsRecursive {
                         }
                     }
                 }
+                elseif ([string]::IsNullOrWhiteSpace($Provider.Value)) {
+                    $selected = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                    $Provider.Value = $selected.Provider
+                    $ProviderValue.Value = $selected.Value
+                }
             }
 
             foreach ($p in $props) {
@@ -2936,7 +3035,9 @@ function Find-DesignProviderRatingsRecursive {
                     -Node $p.Value `
                     -Critic $Critic `
                     -Audience $Audience `
-                    -Imdb $Imdb
+                    -Imdb $Imdb `
+                    -Provider $Provider `
+                    -ProviderValue $ProviderValue
             }
             return
         }
@@ -3186,6 +3287,8 @@ function Get-DesignRichExport {
             RtCritic = ""
             RtAudience = ""
             Imdb = ""
+            Provider = ""
+            ProviderValue = ""
             LogoSrc = ""
             DiagnosticFile = ""
         }
@@ -3206,6 +3309,8 @@ function Get-DesignRichExport {
         RtCritic = ""
         RtAudience = ""
         Imdb = ""
+        Provider = ""
+        ProviderValue = ""
         LogoSrc = ""
         DiagnosticFile = ""
     }
@@ -3242,9 +3347,10 @@ function Get-DesignRichExport {
         $params = @{
             rating_key       = $RatingKey
             file_format      = "json"
-            # Tautulli metadata level 1 contains movie rating, ratingImage,
-            # audienceRating, and audienceRatingImage. Higher levels can add
-            # private media paths that this presentation fallback never needs.
+            # Availability differs by media type (show exports can omit
+            # ratingImage), so the selected provider fields are also requested
+            # explicitly. Higher levels can add private media paths that this
+            # presentation fallback never needs.
             metadata_level   = 1
             media_info_level = 0
             thumb_level      = 0
@@ -3262,7 +3368,7 @@ function Get-DesignRichExport {
             $params.custom_fields = ($customFields -join ",")
         }
 
-        Write-Log ("TautWeekly for Plex: Tautulli item export for {0} (RT rating fields{1})..." -f `
+        Write-Log ("TautWeekly for Plex: Tautulli item export for {0} (provider-labelled rating fields{1})..." -f `
             $RatingKey,
             $(if ($NeedLogo) { " + selected logo level 9" } else { "" })
         )
@@ -3315,6 +3421,8 @@ function Get-DesignRichExport {
         $critic = ""
         $audience = ""
         $imdb = ""
+        $provider = ""
+        $providerValue = ""
         $jsonFiles = @()
         $exportedFiles = @()
         $bytes = [IO.File]::ReadAllBytes($downloadPath)
@@ -3337,7 +3445,9 @@ function Get-DesignRichExport {
                         -Node $parsed `
                         -Critic ([ref]$critic) `
                         -Audience ([ref]$audience) `
-                        -Imdb ([ref]$imdb)
+                        -Imdb ([ref]$imdb) `
+                        -Provider ([ref]$provider) `
+                        -ProviderValue ([ref]$providerValue)
 
                     if (-not [string]::IsNullOrWhiteSpace($critic) -and
                         -not [string]::IsNullOrWhiteSpace($audience)) {
@@ -3354,7 +3464,9 @@ function Get-DesignRichExport {
                     -Node $parsed `
                     -Critic ([ref]$critic) `
                     -Audience ([ref]$audience) `
-                    -Imdb ([ref]$imdb)
+                    -Imdb ([ref]$imdb) `
+                    -Provider ([ref]$provider) `
+                    -ProviderValue ([ref]$providerValue)
             }
             catch {
                 throw "Downloaded item export was neither a ZIP archive nor valid JSON."
@@ -3364,6 +3476,8 @@ function Get-DesignRichExport {
         $result.RtCritic = $critic
         $result.RtAudience = $audience
         $result.Imdb = $imdb
+        $result.Provider = $provider
+        $result.ProviderValue = $providerValue
 
         if ($NeedLogo) {
             if (-not $isZip) {
@@ -3411,6 +3525,8 @@ function Get-DesignRichExport {
             RtCritic = $result.RtCritic
             RtAudience = $result.RtAudience
             Imdb = $result.Imdb
+            Provider = $result.Provider
+            ProviderValue = $result.ProviderValue
             LogoExportLevel = $(if ($NeedLogo) { 9 } else { 0 })
             LogoFound = -not [string]::IsNullOrWhiteSpace($result.LogoSrc)
             JsonFiles = @($jsonFiles | ForEach-Object { $_.Name })
@@ -3421,10 +3537,11 @@ function Get-DesignRichExport {
         $diag | ConvertTo-Json -Depth 8 | Set-Content -Path $diagPath -Encoding UTF8
         $result.DiagnosticFile = "media/" + $diagPath.Split([IO.Path]::DirectorySeparatorChar)[-1]
 
-        Write-Log ("Design rich export result: RT critic={0}, audience={1}, IMDb={2}, logo={3}" -f `
+        Write-Log ("Design rich export result: RT critic={0}, audience={1}, IMDb={2}, selected={3}, logo={4}" -f `
             $(if ($result.RtCritic) { $result.RtCritic + "%" } else { "n/a" }),
             $(if ($result.RtAudience) { $result.RtAudience } else { "n/a" }),
             $(if ($result.Imdb) { $result.Imdb } else { "n/a" }),
+            $(if ($result.Provider) { $result.Provider + " " + $result.ProviderValue } else { "n/a" }),
             $(if ($result.LogoSrc) { "yes" } else { "no" })
         )
     }
@@ -3559,6 +3676,8 @@ function Add-DesignRatingMetadata {
         $critic = ""
         $audience = ""
         $imdb = ""
+        $provider = ""
+        $providerValue = ""
         $criticImage = ""
         $audienceImageState = ""
         $genres = @()
@@ -3567,8 +3686,9 @@ function Add-DesignRatingMetadata {
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
-        # Primary source for the newsletter: Tautulli already exposes selected
-        # movie RT and TV IMDb scores plus their provider IDs.
+        # Primary source for the newsletter: Tautulli exposes Plex's selected,
+        # provider-labelled rating fields. Keep the dedicated RT/IMDb display
+        # paths, then retain another recognized provider as a text badge.
         try {
             $meta = Invoke-TautulliApi -Command "get_metadata" -Parameters @{
                 rating_key = $ratingKey
@@ -3579,6 +3699,13 @@ function Add-DesignRatingMetadata {
             $audienceImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
             $ratingValue = Get-OptionalStringProperty -InputObject $meta -Name "rating"
             $audienceRatingValue = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+            $selectedRating = Get-DesignProviderRating `
+                -RatingImage $ratingImage `
+                -RatingValue $ratingValue `
+                -AudienceImage $audienceImage `
+                -AudienceValue $audienceRatingValue
+            $provider = $selectedRating.Provider
+            $providerValue = $selectedRating.Value
 
             if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
                 $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
@@ -3621,10 +3748,11 @@ function Add-DesignRatingMetadata {
         # Optional secondary source: Plex's full Rating[] if direct access
         # happens to be available on this install.
         $needsDirectRatings = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsDirectRatings) {
             try {
@@ -3658,6 +3786,12 @@ function Add-DesignRatingMetadata {
                             [string]::IsNullOrWhiteSpace($imdb) -and
                             $image -like "imdb://image.rating*") {
                             $imdb = [string]$value
+                        }
+
+                        if ([string]::IsNullOrWhiteSpace($provider)) {
+                            $selectedRating = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                            $provider = $selectedRating.Provider
+                            $providerValue = $selectedRating.Value
                         }
 
                         if ($mediaType -eq "movie" -and
@@ -3718,13 +3852,16 @@ function Add-DesignRatingMetadata {
                 if ([string]::IsNullOrWhiteSpace($imdb)) { $imdb = Get-OptionalStringProperty $cachedEntry.Ratings "Imdb" }
                 if ([string]::IsNullOrWhiteSpace($criticImage)) { $criticImage = Get-OptionalStringProperty $cachedEntry.Ratings "RtCriticImage" }
                 if ([string]::IsNullOrWhiteSpace($audienceImageState)) { $audienceImageState = Get-OptionalStringProperty $cachedEntry.Ratings "RtAudienceImage" }
+                if ([string]::IsNullOrWhiteSpace($provider)) { $provider = Get-OptionalStringProperty $cachedEntry.Ratings "Provider" }
+                if ([string]::IsNullOrWhiteSpace($providerValue)) { $providerValue = Get-OptionalStringProperty $cachedEntry.Ratings "ProviderValue" }
             }
         }
         $needsHostedRating = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         $needsHostedMetadata = (
             -not [string]::IsNullOrWhiteSpace($metadataGuid) -and
@@ -3798,6 +3935,15 @@ function Add-DesignRatingMetadata {
                         $hostedRatingImage -like 'imdb://image.rating*') {
                         $imdb = $hostedRating
                     }
+                    if ([string]::IsNullOrWhiteSpace($provider)) {
+                        $selectedRating = Get-DesignProviderRating `
+                            -RatingImage $hostedRatingImage `
+                            -RatingValue $hostedRating `
+                            -AudienceImage $hostedAudienceImage `
+                            -AudienceValue $hostedAudience
+                        $provider = $selectedRating.Provider
+                        $providerValue = $selectedRating.Value
+                    }
 
                     if ($null -ne $hostedMeta.PSObject.Properties["Rating"]) {
                         foreach ($ratingEntry in @($hostedMeta.Rating)) {
@@ -3809,6 +3955,11 @@ function Add-DesignRatingMetadata {
                                 [string]::IsNullOrWhiteSpace($imdb) -and
                                 $image -like 'imdb://image.rating*') {
                                 $imdb = $value
+                            }
+                            if ([string]::IsNullOrWhiteSpace($provider)) {
+                                $selectedRating = Get-DesignProviderRating -RatingImage $image -RatingValue $value
+                                $provider = $selectedRating.Provider
+                                $providerValue = $selectedRating.Value
                             }
                             if ($mediaType -eq "movie" -and
                                 [string]::IsNullOrWhiteSpace($critic) -and
@@ -3839,10 +3990,11 @@ function Add-DesignRatingMetadata {
         # without a Plex token or title search, and fail closed when a provider
         # does not publish the expected movie RT or TV IMDb value.
         $needsWatchRating = if ($mediaType -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsWatchRating -and -not [string]::IsNullOrWhiteSpace($watchSlug)) {
             $watchRatings = Get-PlexWatchRatings -Slug $watchSlug -MediaType $mediaType
@@ -3862,11 +4014,12 @@ function Add-DesignRatingMetadata {
         # Last resort: Tautulli's provider-labelled item export can still reach
         # Plex through Tautulli when this runtime cannot connect directly.
         $needsRichExport = if ([string]$item.Type -eq "movie") {
-            [string]::IsNullOrWhiteSpace($critic) -or
-                [string]::IsNullOrWhiteSpace($audience)
+            ([string]::IsNullOrWhiteSpace($critic) -or
+                [string]::IsNullOrWhiteSpace($audience)) -and
+                [string]::IsNullOrWhiteSpace($provider)
         }
         else {
-            [string]::IsNullOrWhiteSpace($imdb)
+            [string]::IsNullOrWhiteSpace($imdb) -and [string]::IsNullOrWhiteSpace($provider)
         }
         if ($needsRichExport) {
 
@@ -3886,22 +4039,37 @@ function Add-DesignRatingMetadata {
             elseif ([string]::IsNullOrWhiteSpace($imdb)) {
                 $imdb = [string]$rich.Imdb
             }
+            if ([string]::IsNullOrWhiteSpace($provider)) {
+                $provider = [string]$rich.Provider
+                $providerValue = [string]$rich.ProviderValue
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($imdb) -and $provider -eq "IMDb") {
+            $imdb = $providerValue
         }
 
         if ($mediaType -eq "show") {
-            Write-Log ("Design ratings: {0} -> IMDb {1}" -f $item.Title, $(if ($imdb) { $imdb } else { "n/a" }))
+            Write-Log ("Design ratings: {0} -> IMDb {1}, selected {2}" -f `
+                $item.Title,
+                $(if ($imdb) { $imdb } else { "n/a" }),
+                $(if ($provider) { $provider + " " + $providerValue } else { "n/a" })
+            )
         }
         else {
-            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}" -f `
+            Write-Log ("Design ratings: {0} -> RT critic {1}, audience {2}, selected {3}" -f `
                 $item.Title,
                 $(if ($critic) { $critic + "%" } else { "n/a" }),
-                $(if ($audience) { $audience } else { "n/a" })
+                $(if ($audience) { $audience } else { "n/a" }),
+                $(if ($provider) { $provider + " " + $providerValue } else { "n/a" })
             )
         }
 
         $item | Add-Member -NotePropertyName "DesignRtCritic" -NotePropertyValue $critic -Force
         $item | Add-Member -NotePropertyName "DesignRtAudience" -NotePropertyValue $audience -Force
         $item | Add-Member -NotePropertyName "DesignImdbRating" -NotePropertyValue $imdb -Force
+        $item | Add-Member -NotePropertyName "DesignRatingProvider" -NotePropertyValue $provider -Force
+        $item | Add-Member -NotePropertyName "DesignRatingValue" -NotePropertyValue $providerValue -Force
         $item | Add-Member -NotePropertyName "DesignRtCriticImage" -NotePropertyValue $criticImage -Force
         $item | Add-Member -NotePropertyName "DesignRtAudienceImage" -NotePropertyValue $audienceImageState -Force
         $item | Add-Member -NotePropertyName "DesignGenres" -NotePropertyValue @($genres) -Force
@@ -3956,6 +4124,27 @@ function Get-DesignRtIconUrl {
     return "../assets/" + $assetName
 }
 
+function Get-DesignProviderRatingHtml {
+    param(
+        [string]$Provider,
+        [string]$Value,
+        [int]$MarginLeft = 0
+    )
+
+    if ($Provider -notin @("IMDb", "TMDB", "TVDB") -or
+        $Value -notmatch '^(?:10(?:\.0+)?|[0-9](?:\.[0-9]+)?)$') {
+        return ""
+    }
+
+    $margin = if ($MarginLeft -gt 0) { "margin-left:${MarginLeft}px;" } else { "" }
+    return '<span style="display:inline-block;' + $margin + 'white-space:nowrap;">' +
+        '<span style="display:inline-block;padding:1px 4px;border:1px solid #a87500;border-radius:3px;margin-right:4px;font-size:9px;line-height:1.1;font-weight:800;letter-spacing:.2px;vertical-align:1px;">' +
+        (HtmlEncode $Provider) +
+        '</span>' +
+        (HtmlEncode $Value) +
+        '</span>'
+}
+
 function Get-DesignRatingLine {
     param(
         [object]$Item,
@@ -3974,7 +4163,7 @@ function Get-DesignRatingLine {
     }
 
     $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
-    if ([string]$Item.Type -eq "show" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+    if (-not [string]::IsNullOrWhiteSpace($imdb)) {
         $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
         $pieces.Add(
             '<span class="design-rating-item">' +
@@ -3983,6 +4172,16 @@ function Get-DesignRatingLine {
             (HtmlEncode $imdb) +
             '</span>'
         )
+    }
+
+    $provider = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingProvider"
+    $providerValue = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingValue"
+    if (-not [string]::IsNullOrWhiteSpace($provider) -and
+        -not ($provider -eq "IMDb" -and -not [string]::IsNullOrWhiteSpace($imdb))) {
+        $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+        if (-not [string]::IsNullOrWhiteSpace($providerHtml)) {
+            $pieces.Add('<span class="design-rating-item">' + $providerHtml + '</span>')
+        }
     }
 
     $critic = ""
@@ -4400,7 +4599,7 @@ function Get-PlexWatchRatings {
             -Uri ((Get-PlexWatchBaseUrl) + "/" + $MediaType + "/" + $slugValue) `
             -Headers @{
                 "Accept-Language" = "en-US,en;q=0.9"
-                "User-Agent"      = "TautWeekly-for-Plex/0.9.3"
+                "User-Agent"      = "TautWeekly-for-Plex/0.9.4"
             } `
             -TimeoutSec 60
         $content = [string]$response.Content
@@ -4654,7 +4853,7 @@ function Get-PlexHostedMetadata {
         "Accept"                   = "application/json"
         "X-Plex-Token"             = $token
         "X-Plex-Product"           = "TautWeekly for Plex"
-        "X-Plex-Version"           = "0.9.3"
+        "X-Plex-Version"           = "0.9.4"
         "X-Plex-Client-Identifier" = "tautweekly-history-artwork"
     }
 
@@ -5120,6 +5319,29 @@ function Get-StatsMovieRatingHtml {
         )
     }
 
+    $imdb = Get-OptionalStringProperty -InputObject $Item -Name "DesignImdbRating"
+    if (-not [string]::IsNullOrWhiteSpace($imdb)) {
+        $imdbIcon = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
+        $pieces.Add(
+            '<span style="display:inline-block;white-space:nowrap;">' +
+            '<img src="' + (HtmlEncode $imdbIcon) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
+            (HtmlEncode $imdb) +
+            '</span>'
+        )
+    }
+
+    $provider = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingProvider"
+    $providerValue = Get-OptionalStringProperty -InputObject $Item -Name "DesignRatingValue"
+    $providerHtml = if ($provider -eq "IMDb" -and -not [string]::IsNullOrWhiteSpace($imdb)) {
+        ""
+    }
+    else {
+        Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+    }
+    if (-not [string]::IsNullOrWhiteSpace($providerHtml)) {
+        $pieces.Add($providerHtml)
+    }
+
     if ($pieces.Count -eq 0) {
         return '<span style="color:#6f6f6f;">Ratings unavailable</span>'
     }
@@ -5213,8 +5435,16 @@ function Get-StatsEpisodeRowsHtml {
         }
 
         $imdb = [string]$item.ImdbRating
+        $provider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+        $providerValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
         $imdbHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            '<span style="color:#6f6f6f;">IMDb unavailable</span>'
+            $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+            if ([string]::IsNullOrWhiteSpace($providerHtml)) {
+                '<span style="color:#6f6f6f;">Rating unavailable</span>'
+            }
+            else {
+                $providerHtml
+            }
         } else {
             '<span style="display:inline-block;white-space:nowrap;">' +
             '<img src="' + (HtmlEncode $ImdbIconSrc) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
@@ -5268,7 +5498,15 @@ function Get-StatsTvShowRowsHtml {
 
         $imdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
         $imdbHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            '<span style="color:#6f6f6f;">IMDb unavailable</span>'
+            $provider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+            $providerValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
+            $providerHtml = Get-DesignProviderRatingHtml -Provider $provider -Value $providerValue
+            if ([string]::IsNullOrWhiteSpace($providerHtml)) {
+                '<span style="color:#6f6f6f;">Rating unavailable</span>'
+            }
+            else {
+                $providerHtml
+            }
         } else {
             $imdbIconSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
             '<span style="display:inline-block;white-space:nowrap;">' +
@@ -5333,8 +5571,14 @@ function Get-TvEpisodeLinesHtml {
             $imdb = [string]$episode.ImdbRating
         }
 
+        $provider = Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+        $providerValue = Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
+
         $ratingHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
-            ""
+            Get-DesignProviderRatingHtml `
+                -Provider $provider `
+                -Value $providerValue `
+                -MarginLeft 8
         }
         else {
             $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
@@ -5458,8 +5702,13 @@ $genreHtml
             }
             else {
                 $showImdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
+                $showProvider = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingProvider"
+                $showProviderValue = Get-OptionalStringProperty -InputObject $item -Name "DesignRatingValue"
                 $showRatingHtml = if ([string]::IsNullOrWhiteSpace($showImdb)) {
-                    ""
+                    Get-DesignProviderRatingHtml `
+                        -Provider $showProvider `
+                        -Value $showProviderValue `
+                        -MarginLeft 8
                 }
                 else {
                     $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
@@ -7414,6 +7663,8 @@ function Get-PopulatedPreviewStats {
                 Season=Safe-Int $episode.Season
                 Episode=Safe-Int $episode.Episode
                 ImdbRating=[string]$episode.ImdbRating
+                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
             })
             if ($sampleEpisodes.Count -ge 3) { break }
         }

--- a/scripts/test-deleted-item-cache.ps1
+++ b/scripts/test-deleted-item-cache.ps1
@@ -66,6 +66,8 @@ function New-TestItem {
         DesignRtCritic        = '91'
         DesignRtAudience      = '87'
         DesignImdbRating      = '7.8'
+        DesignRatingProvider  = 'TMDB'
+        DesignRatingValue     = '7.4'
         DesignRtCriticImage   = 'certified_fresh'
         DesignRtAudienceImage = 'upright'
         PlexToken             = $Secret
@@ -113,6 +115,8 @@ try {
     Assert-True ($null -ne $entry) 'Exact cache lookup failed.'
     Assert-Equal $entry.Title 'Future Deleted Movie' 'Cached title was not retained.'
     Assert-Equal $entry.Summary 'A short presentation summary.' 'Cached summary was not retained.'
+    Assert-Equal $entry.Ratings.Provider 'TMDB' 'Selected rating provider was not retained.'
+    Assert-Equal $entry.Ratings.ProviderValue '7.4' 'Selected rating value was not retained.'
     Assert-True ($null -eq $entry.PSObject.Properties['PlexToken']) 'Unexpected private field reached cache entry.'
 
     $rawIndex = Get-Content -LiteralPath (Join-Path $cacheRoot 'index.json') -Raw

--- a/scripts/test-library-selection.ps1
+++ b/scripts/test-library-selection.ps1
@@ -95,6 +95,7 @@ foreach ($relative in @(
         'Safe-Int',
         'Safe-Int64',
         'Get-OptionalStringProperty',
+        'Get-DesignProviderRating',
         'Test-IncludedLibraryRow',
         'Get-IncludedLibraryQueryScopes',
         'Get-History',

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -249,9 +249,9 @@ foreach ($engine in $engines) {
             }
 
             if ($scenario -eq 'rating-export-fallback') {
-                Assert-True ($normalHtml.Contains('53%') -and $normalHtml.Contains('40%') -and $normalHtml.Contains('7.4')) "$($engine.Name)/$scenario did not render provider-labelled movie and show ratings from Tautulli's item exports."
+                Assert-True ($normalHtml.Contains('53%') -and $normalHtml.Contains('40%') -and $normalHtml.Contains('TMDB') -and $normalHtml.Contains('7.4')) "$($engine.Name)/$scenario did not render provider-labelled movie and show ratings from Tautulli's item exports."
                 Assert-True ($previewLog.Contains('Design rich export result: RT critic=53%, audience=40')) "$($engine.Name)/$scenario did not report the successful JSON rating fallback."
-                Assert-True ($previewLog.Contains('Design rich export result: RT critic=n/a, audience=n/a, IMDb=7.4')) "$($engine.Name)/$scenario did not report the successful show IMDb fallback."
+                Assert-True ($previewLog.Contains('Design rich export result: RT critic=n/a, audience=n/a, IMDb=n/a, selected=TMDB 7.4')) "$($engine.Name)/$scenario did not report the successful show selected-provider fallback."
                 Assert-True (-not $previewLog.Contains('selected-logo level 9')) "$($engine.Name)/$scenario mislabeled a rating-only item export as a logo export."
                 Assert-True (-not $previewLog.Contains('could not enumerate additional exporter fields')) "$($engine.Name)/$scenario did not use a compatible Tautulli field-discovery request."
             }
@@ -474,7 +474,7 @@ foreach ($engine in $engines) {
                 Assert-True ($sendLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario SendTest did not preserve the direct Plex 404 warning."
                 if ($scenario -eq 'rating-export-fallback') {
                     Assert-True ($sendLog.Contains('Design rich export result: RT critic=53%, audience=40')) "$($engine.Name)/$scenario SendTest did not recover both ratings through the explicit item export."
-                    Assert-True ($sendLog.Contains('Design rich export result: RT critic=n/a, audience=n/a, IMDb=7.4')) "$($engine.Name)/$scenario SendTest did not recover show IMDb through the explicit item export."
+                    Assert-True ($sendLog.Contains('Design rich export result: RT critic=n/a, audience=n/a, IMDb=n/a, selected=TMDB 7.4')) "$($engine.Name)/$scenario SendTest did not recover the show selected-provider rating through the explicit item export."
                     Assert-True (-not $sendLog.Contains('could not enumerate additional exporter fields')) "$($engine.Name)/$scenario SendTest did not use the compatible field-discovery request."
                 }
                 if ($scenario -in $providerRecoveryScenarios) {
@@ -495,7 +495,7 @@ foreach ($engine in $engines) {
                     $emailThemeArgs += @(
                         '--require-html', 'alt="Rotten Tomatoes critic"',
                         '--require-html', 'alt="Rotten Tomatoes audience"',
-                        '--require-html', 'alt="IMDb"',
+                        '--require-html', 'TMDB</span>',
                         '--require-html', '53%</span>',
                         '--require-html', '40%</span>',
                         '--require-html', '7.4</span>'

--- a/scripts/test-release-artifacts.ps1
+++ b/scripts/test-release-artifacts.ps1
@@ -48,8 +48,8 @@ function Assert-RendererContract([string]$PackageName, [string]$Renderer) {
     Assert-True ($Renderer.Contains('function Test-PlexHostedMetadataExactMatch')) "$PackageName lacks fail-closed hosted match validation."
     Assert-True ($Renderer.Contains('-Method Post')) "$PackageName lacks the provider-contract POST retry for empty exact-ID matches."
     Assert-True ($Renderer.Contains('matching hints only: require an exact modern GUID')) "$PackageName does not document the exact-identifier hosted POST boundary."
-    Assert-True ($Renderer.Contains('"User-Agent"      = "TautWeekly-for-Plex/0.9.3"')) "$PackageName does not identify the tokenless public Plex rating fallback."
-    Assert-True ($Renderer.Contains('"X-Plex-Version"           = "0.9.3"')) "$PackageName does not identify the authenticated hosted metadata fallback."
+    Assert-True ($Renderer.Contains('"User-Agent"      = "TautWeekly-for-Plex/0.9.4"')) "$PackageName does not identify the tokenless public Plex rating fallback."
+    Assert-True ($Renderer.Contains('"X-Plex-Version"           = "0.9.4"')) "$PackageName does not identify the authenticated hosted metadata fallback."
     Assert-True ($Renderer.Contains('<meta name="color-scheme" content="light dark">')) "$PackageName does not advertise Apple-compatible email color schemes."
     Assert-True ($Renderer.Contains(':root { color-scheme:light dark; supported-color-schemes:light dark; }')) "$PackageName lacks the Apple-compatible email scheme declaration."
     Assert-True (-not $Renderer.Contains('color-scheme:dark only')) "$PackageName retains the incompatible dark-only email declaration."
@@ -57,6 +57,8 @@ function Assert-RendererContract([string]$PackageName, [string]$Renderer) {
     Assert-True ($Renderer.Contains('metadata_level   = 1')) "$PackageName requests more Tautulli metadata than the rating fallback requires."
     Assert-True ($Renderer.Contains('sub_media_type = $MediaType')) "$PackageName omits Tautulli's compatible exporter-field subtype."
     Assert-True ($Renderer.Contains('@("rating", "ratingImage", "audienceRating", "audienceRatingImage")')) "$PackageName does not request provider-labelled rating fields explicitly."
+    Assert-True ($Renderer.Contains('function Get-DesignProviderRating')) "$PackageName cannot recognize selected Tautulli rating providers."
+    Assert-True ($Renderer.Contains('DesignRatingProvider')) "$PackageName does not retain selected provider-labelled ratings."
     Assert-True ($Renderer.Contains('"Accept-Language" = "en-US,en;q=0.9"')) "$PackageName does not request stable provider-labelled rating text."
     Assert-True ($Renderer.Contains('function Get-BingeChampionTitleBreakdown')) "$PackageName lacks the media-specific Binge Champion title breakdown."
     Assert-True ($Renderer.Contains('$bingeTimeLine = "$([string]$bingeDisplay.TotalTimeText) watched"')) "$PackageName has stale Binge Champion duration copy."
@@ -81,6 +83,7 @@ function Assert-DeletedItemCacheContract([string]$PackageName, [string]$CacheMod
     )) {
         Assert-True ($CacheModule.Contains($required)) "$PackageName cache module is missing: $required"
     }
+    Assert-True ($CacheModule.Contains('ProviderValue')) "$PackageName cache module does not retain the bounded selected rating value."
     foreach ($forbidden in @('PlexToken', 'ApiKey', 'SmtpPassword', 'RecipientEmail', 'play_duration', 'watched_status')) {
         Assert-True (-not $CacheModule.Contains($forbidden)) "$PackageName cache module accepts a forbidden private field: $forbidden"
     }

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -19,6 +19,7 @@ $rendererPaths = @(
 
 $requiredFunctions = @(
     'Get-OptionalStringProperty',
+    'Get-DesignProviderRating',
     'Convert-DesignRatingPercent',
     'Find-DesignProviderRatingsRecursive',
     'ConvertTo-DesignGenreList',
@@ -91,6 +92,8 @@ foreach ($relativePath in $rendererPaths) {
     $flatCritic = ''
     $flatAudience = ''
     $flatImdb = ''
+    $flatProvider = ''
+    $flatProviderValue = ''
     Find-DesignProviderRatingsRecursive `
         -Node ([PSCustomObject]@{
             rating = '5.3'
@@ -100,25 +103,34 @@ foreach ($relativePath in $rendererPaths) {
         }) `
         -Critic ([ref]$flatCritic) `
         -Audience ([ref]$flatAudience) `
-        -Imdb ([ref]$flatImdb)
-    Assert-True ($flatCritic -eq '53' -and $flatAudience -eq '40' -and [string]::IsNullOrWhiteSpace($flatImdb)) "$relativePath did not parse Tautulli's flattened low-score RT export"
+        -Imdb ([ref]$flatImdb) `
+        -Provider ([ref]$flatProvider) `
+        -ProviderValue ([ref]$flatProviderValue)
+    Assert-True ($flatCritic -eq '53' -and $flatAudience -eq '40' -and [string]::IsNullOrWhiteSpace($flatImdb) -and [string]::IsNullOrWhiteSpace($flatProvider)) "$relativePath did not parse Tautulli's flattened low-score RT export"
 
     $flatShowCritic = ''
     $flatShowAudience = ''
     $flatShowImdb = ''
+    $flatShowProvider = ''
+    $flatShowProviderValue = ''
     Find-DesignProviderRatingsRecursive `
         -Node ([PSCustomObject]@{
-            rating = '7.4'
-            ratingImage = 'imdb://image.rating'
+            rating = ''
+            audienceRating = '7.4'
+            audienceRatingImage = 'themoviedb://image.rating'
         }) `
         -Critic ([ref]$flatShowCritic) `
         -Audience ([ref]$flatShowAudience) `
-        -Imdb ([ref]$flatShowImdb)
-    Assert-True ($flatShowImdb -eq '7.4' -and [string]::IsNullOrWhiteSpace($flatShowCritic) -and [string]::IsNullOrWhiteSpace($flatShowAudience)) "$relativePath did not parse Tautulli's flattened IMDb export"
+        -Imdb ([ref]$flatShowImdb) `
+        -Provider ([ref]$flatShowProvider) `
+        -ProviderValue ([ref]$flatShowProviderValue)
+    Assert-True ($flatShowProvider -eq 'TMDB' -and $flatShowProviderValue -eq '7.4' -and [string]::IsNullOrWhiteSpace($flatShowImdb) -and [string]::IsNullOrWhiteSpace($flatShowCritic) -and [string]::IsNullOrWhiteSpace($flatShowAudience)) "$relativePath did not parse Tautulli's official TV selected-provider export shape"
 
     $nestedCritic = ''
     $nestedAudience = ''
     $nestedImdb = ''
+    $nestedProvider = ''
+    $nestedProviderValue = ''
     Find-DesignProviderRatingsRecursive `
         -Node ([PSCustomObject]@{
             Rating = @(
@@ -141,22 +153,37 @@ foreach ($relativePath in $rendererPaths) {
         }) `
         -Critic ([ref]$nestedCritic) `
         -Audience ([ref]$nestedAudience) `
-        -Imdb ([ref]$nestedImdb)
-    Assert-True ($nestedCritic -eq '53' -and $nestedAudience -eq '40' -and $nestedImdb -eq '7.4') "$relativePath did not parse nested provider-labelled entries"
+        -Imdb ([ref]$nestedImdb) `
+        -Provider ([ref]$nestedProvider) `
+        -ProviderValue ([ref]$nestedProviderValue)
+    Assert-True ($nestedCritic -eq '53' -and $nestedAudience -eq '40' -and $nestedImdb -eq '7.4' -and [string]::IsNullOrWhiteSpace($nestedProvider)) "$relativePath did not parse nested provider-labelled entries"
 
     $unlabelledCritic = ''
     $unlabelledAudience = ''
     $unlabelledImdb = ''
+    $unlabelledProvider = ''
+    $unlabelledProviderValue = ''
     Find-DesignProviderRatingsRecursive `
         -Node ([PSCustomObject]@{ rating = '9.9'; audienceRating = '9.8' }) `
         -Critic ([ref]$unlabelledCritic) `
         -Audience ([ref]$unlabelledAudience) `
-        -Imdb ([ref]$unlabelledImdb)
+        -Imdb ([ref]$unlabelledImdb) `
+        -Provider ([ref]$unlabelledProvider) `
+        -ProviderValue ([ref]$unlabelledProviderValue)
     Assert-True (
         [string]::IsNullOrWhiteSpace($unlabelledCritic) -and
         [string]::IsNullOrWhiteSpace($unlabelledAudience) -and
-        [string]::IsNullOrWhiteSpace($unlabelledImdb)
+        [string]::IsNullOrWhiteSpace($unlabelledImdb) -and
+        [string]::IsNullOrWhiteSpace($unlabelledProvider) -and
+        [string]::IsNullOrWhiteSpace($unlabelledProviderValue)
     ) "$relativePath mislabeled provider-free numeric ratings"
+
+    $tvdb = Get-DesignProviderRating -RatingImage 'thetvdb://image.rating' -RatingValue '8.2'
+    Assert-True ($tvdb.Provider -eq 'TVDB' -and $tvdb.Value -eq '8.2') "$relativePath did not recognize a provider-labelled TVDB rating"
+    $unknown = Get-DesignProviderRating -RatingImage 'unknown://image.rating' -RatingValue '9.9'
+    Assert-True ([string]::IsNullOrWhiteSpace($unknown.Provider)) "$relativePath accepted an unknown rating provider"
+    $invalid = Get-DesignProviderRating -RatingImage 'themoviedb://image.rating' -RatingValue '12.4'
+    Assert-True ([string]::IsNullOrWhiteSpace($invalid.Provider)) "$relativePath accepted an out-of-range provider rating"
 
     # Provider-only collection tests isolate the legacy best-effort path. The
     # persistent cache has its own exact-ID, privacy, and lifecycle suite.
@@ -427,10 +454,54 @@ foreach ($relativePath in $rendererPaths) {
     }
 
     function Write-Log { param([string]$Message, [string]$Level = 'INFO') }
+    $script:providerDirectCalls = 0
+    $script:providerExportCalls = 0
+    function Invoke-TautulliApi {
+        param([string]$Command, [hashtable]$Parameters = @{})
+        Assert-True ($Command -eq 'get_metadata') "$relativePath used an unexpected Tautulli request for selected-provider metadata"
+        if ([string]$Parameters.rating_key -eq 'selected-provider-movie') {
+            return [PSCustomObject]@{
+                rating = '8.1'
+                rating_image = 'imdb://image.rating'
+                audience_rating = ''
+                audience_rating_image = ''
+            }
+        }
+        Assert-True ([string]$Parameters.rating_key -eq 'selected-provider-show') "$relativePath requested an unexpected selected-provider rating key"
+        return [PSCustomObject]@{
+            rating = ''
+            rating_image = ''
+            audience_rating = '7.4'
+            audience_rating_image = 'themoviedb://image.rating'
+        }
+    }
+    function Get-DesignPlexMetadata { param([string]$RatingKey) $script:providerDirectCalls++; return $null }
+    function Get-DesignRichExport {
+        param([string]$RatingKey, [string]$MediaType, [switch]$NeedLogo)
+        $script:providerExportCalls++
+        return [PSCustomObject]@{ RtCritic = ''; RtAudience = ''; Imdb = ''; Provider = ''; ProviderValue = '' }
+    }
+    $selectedProviderShow = [PSCustomObject]@{
+        RatingKey = 'selected-provider-show'
+        Type = 'show'
+        Title = 'Selected Provider Show'
+    }
+    $selectedProviderMovie = [PSCustomObject]@{
+        RatingKey = 'selected-provider-movie'
+        Type = 'movie'
+        Title = 'Selected Provider Movie'
+    }
+    Add-DesignRatingMetadata -ReleaseData ([PSCustomObject]@{ Movies = @($selectedProviderMovie); TV = @($selectedProviderShow) })
+    Assert-True ($selectedProviderShow.DesignRatingProvider -eq 'TMDB' -and $selectedProviderShow.DesignRatingValue -eq '7.4') "$relativePath ignored Tautulli's selected TV audience-rating provider"
+    Assert-True ([string]::IsNullOrWhiteSpace($selectedProviderShow.DesignImdbRating)) "$relativePath mislabeled a selected TMDB score as IMDb"
+    Assert-True ($selectedProviderMovie.DesignImdbRating -eq '8.1') "$relativePath did not preserve a selected movie IMDb rating for its dedicated icon"
+    Assert-True ($script:providerDirectCalls -eq 0 -and $script:providerExportCalls -eq 0) "$relativePath performed unnecessary rating fallbacks after Tautulli returned a selected provider"
+
+    function Invoke-TautulliApi { param([string]$Command, [hashtable]$Parameters = @{}) throw 'Simulated deleted metadata' }
     function Get-DesignPlexMetadata { param([string]$RatingKey) return $null }
     function Get-DesignRichExport {
         param([string]$RatingKey, [string]$MediaType, [switch]$NeedLogo)
-        return [PSCustomObject]@{ RtCritic = ''; RtAudience = '' }
+        return [PSCustomObject]@{ RtCritic = ''; RtAudience = ''; Imdb = ''; Provider = ''; ProviderValue = '' }
     }
     function Get-PlexHostedMetadata {
         param([string]$MetadataGuid, [string]$MediaType, [string]$MatchTitle, [string]$MatchYear, [int]$ParentIndex, [int]$Index)

--- a/scripts/test-support/fake-tautulli.py
+++ b/scripts/test-support/fake-tautulli.py
@@ -559,7 +559,15 @@ class Handler(BaseHTTPRequestHandler):
         command = query.get("cmd", "")
         if command == "download_export" and self.current_scenario() == "rating-export-fallback":
             if query.get("export_id") == "59":
-                export_data = [{"rating": "7.4", "ratingImage": "imdb://image.rating"}]
+                # Current Tautulli show exports do not expose ratingImage, but
+                # they do expose the selected audience provider fields.
+                export_data = [
+                    {
+                        "rating": "",
+                        "audienceRating": "7.4",
+                        "audienceRatingImage": "themoviedb://image.rating",
+                    }
+                ]
             else:
                 export_data = [
                     {
@@ -715,15 +723,17 @@ class Handler(BaseHTTPRequestHandler):
                     }
                 )
                 return
+            metadata_fields = [
+                {"field": "rating", "level": 1},
+                {"field": "audienceRating", "level": 1},
+                {"field": "audienceRatingImage", "level": 1},
+                {"field": "contentRating", "level": 1},
+            ]
+            if media_type == "movie":
+                metadata_fields.insert(1, {"field": "ratingImage", "level": 1})
             self.api_success(
                 {
-                    "metadata_fields": [
-                        {"field": "rating", "level": 1},
-                        {"field": "ratingImage", "level": 1},
-                        {"field": "audienceRating", "level": 1},
-                        {"field": "audienceRatingImage", "level": 1},
-                        {"field": "contentRating", "level": 1},
-                    ],
+                    "metadata_fields": metadata_fields,
                     "media_info_fields": [],
                 }
             )
@@ -747,12 +757,9 @@ class Handler(BaseHTTPRequestHandler):
                     for field in query.get("custom_fields", "").split(",")
                     if field.strip()
                 }
-                required_fields = {
-                    "rating",
-                    "ratingImage",
-                    "audienceRating",
-                    "audienceRatingImage",
-                }
+                required_fields = {"rating", "audienceRating", "audienceRatingImage"}
+                if query.get("rating_key") != "selected-show":
+                    required_fields.add("ratingImage")
                 if not required_fields.issubset(requested_fields):
                     self.write_json(
                         {


### PR DESCRIPTION
## Diagnosis

TautWeekly v0.9.2 accepted movie Rotten Tomatoes and TV IMDb shapes, but its show regression modeled `ratingImage=imdb`. Current Tautulli TV metadata/export behavior can instead leave `ratingImage`/`rating_image` empty and return the selected TMDB value through `audienceRating`/`audience_rating` plus the matching provider image. The export completed, but TautWeekly ignored that valid provider-labelled value.

Relates to #58. The issue must remain open pending reporter confirmation.

## Correction

- recognize provider-labelled IMDb, TMDB, and TVDB values from both rating field pairs;
- preserve dedicated Rotten Tomatoes and IMDb icon rendering, with a text badge for recognized alternate selected providers;
- apply the behavior to release cards, episode rows, personal statistics, and all three maintained renderer sources;
- persist only the bounded provider/value pair in the existing exact-GUID deleted-item cache;
- replace the synthetic show fixture with Tautulli's maintained TV field shape;
- document the diagnosis, boundaries, and v0.9.4 candidate.

Unknown providers, unlabeled values, and scores outside 0-10 still fail closed. Export requests remain metadata level 1 with media information/file locations disabled.

## Validation

- renderer collection/parser regression: Windows, NAS/Docker, macOS
- sanitized PreviewAll and decoded SendTest regression with direct Plex returning 404: 8 Windows scenarios locally; PowerShell 7 container variants gated in hosted CI
- deleted-item cache privacy, schema, exact matching, bounds, recovery, and platform parity
- repository privacy/secret scan; docs/link/platform/PowerShell checks
- user exclusion, Binge Champion, library scoping, update, and scheduler regressions
- all nine release archives plus standalone `SHA256SUMS.txt`
- repeated v0.9.4 builds byte-identical

The supplied log and screenshots were used only as private diagnostic evidence and are not included in the repository.
