### PR TITLE
test: exercise rating fallback in SendTest

### DIFF
--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -36,6 +36,7 @@ $engines = @(
 $providerRecoveryScenarios = @('deleted-history-metadata', 'deleted-history-legacy-guid')
 $cacheScenario = 'cache-deleted'
 $deletedHistoryScenarios = @($providerRecoveryScenarios) + @($cacheScenario)
+$sendTestScenarios = @('optional-hero-metadata', 'rating-export-fallback') + @($deletedHistoryScenarios)
 
 $executed = 0
 foreach ($engine in $engines) {
@@ -93,7 +94,7 @@ foreach ($engine in $engines) {
             $baseUrl = (Get-Content $readyFile -Raw).Trim()
 
             $smtpPort = 0
-            if ($scenario -eq 'optional-hero-metadata' -or $scenario -in $deletedHistoryScenarios) {
+            if ($scenario -in $sendTestScenarios) {
                 $smtpPort = Get-FreeTcpPort
                 $smtpServer = Start-Process -FilePath $PythonPath -ArgumentList @(
                     '-u', $fakeSmtp, '--port', [string]$smtpPort,
@@ -125,7 +126,7 @@ foreach ($engine in $engines) {
                 MaxTv = 4
                 SendDelaySeconds = 0
             }
-            if ($scenario -eq 'optional-hero-metadata' -or $scenario -in $deletedHistoryScenarios) {
+            if ($scenario -in $sendTestScenarios) {
                 $configOverrides['SmtpHost'] = '127.0.0.1'
                 $configOverrides['SmtpPort'] = $smtpPort
                 $configOverrides['SmtpEnableSsl'] = $false
@@ -414,7 +415,7 @@ foreach ($engine in $engines) {
                 Assert-True (@($externalPosterCalls | Where-Object { $_.has_plex_token }).Count -eq 0) "$($engine.Name)/$scenario forwarded the Plex token to an external poster host."
             }
 
-            if ($scenario -eq 'optional-hero-metadata' -or $scenario -in $deletedHistoryScenarios) {
+            if ($scenario -in $sendTestScenarios) {
                 $previewLog = Get-Content $stdout -Raw
                 Assert-True ($previewLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario did not exercise the recoverable direct Plex 404 fallback."
                 Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the global-history title fallback for sparse hero metadata."
@@ -495,9 +496,14 @@ foreach ($engine in $engines) {
                 $emailThemeArgs = @($smtpDataFile)
                 if ($scenario -eq 'rating-export-fallback') {
                     $emailThemeArgs += @(
-                        '--require-html', 'alt="Rotten Tomatoes critic"',
-                        '--require-html', 'alt="Rotten Tomatoes audience"',
-                        '--require-html', 'alt="IMDb"',
+                        # Windows PowerShell 5.1 strips embedded quote
+                        # characters when forwarding native-process
+                        # arguments. Use the provider labels themselves so
+                        # the decoded-MIME assertions work identically under
+                        # Windows PowerShell and PowerShell 7.
+                        '--require-html', 'Rotten Tomatoes critic',
+                        '--require-html', 'Rotten Tomatoes audience',
+                        '--require-html', 'IMDb',
                         '--require-html', '53%</span>',
                         '--require-html', '40%</span>',
                         '--require-html', '8.7</span>',


### PR DESCRIPTION
## What changed

- include `rating-export-fallback` in the integration scenarios that start virtual SMTP and run `SendTest`;
- make decoded-MIME provider markers survive both Windows PowerShell 5.1 and PowerShell 7 native argument forwarding.

## Why

The issue #68 audit found that the existing rating-export SendTest assertions were unreachable: SMTP and SendTest only ran for the optional-metadata and deleted-history scenarios. Enabling the intended path initially exposed embedded-quote stripping in Windows PowerShell's native Python arguments; provider-label markers avoid that runtime-specific quoting ambiguity.

This is a validation-only correction. It does not alter production rating acquisition, provider priority, rendering, cache behavior, packages, or containers.

The reporter's sanitized rating evidence shows direct Plex metadata requests failing while Tautulli's normal metadata and item export expose only selected IMDb movie fields. Under that input, TautWeekly's labelled IMDb fallback is expected. When the virtual Tautulli export supplies RT, the newly executed decoded SendTest MIME assertions require RT critic/audience and exact-episode IMDb while forbidding the lower-priority movie IMDb and TV TMDB values.

The wider warning audit found no cache initialization, integrity, eviction, or restoration error. Exact-GUID cache hits were successful but contained no unavailable RT metadata.

Relates to #68; does not close it.

## Validation

- renderer collection/provider edges: Windows, NAS/Docker/Linux/FreeBSD, macOS renderer sources
- end-to-end virtual Tautulli + SMTP integration: 8 Windows scenarios, including the newly reachable rating-export SendTest MIME path
- 64 PowerShell files parsed
- repository/privacy/secret validation
- maintained platform contracts
- `git diff --check`
