### PR TITLE
chore: prepare v0.12.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-08-14
+
 ### Changed
 
 - Styled the production-newsletter selector with the same bounded chevron and

--- a/docs/releases/v0.12.2.md
+++ b/docs/releases/v0.12.2.md
@@ -1,0 +1,56 @@
+# TautWeekly for Plex v0.12.2
+
+v0.12.2 keeps the Windows Manager's validation results synchronized across
+Config, Dashboard, and Verify, including after the Manager restarts.
+
+## Validate once, diagnose only when needed
+
+**Validate, save, and verify** remains the primary setup action. It attempts
+all four safe setup steps:
+
+1. load the saved Tautulli libraries and users;
+2. verify Tautulli and, when configured, direct Plex;
+3. run the non-sending SMTP reachability and STARTTLS preflight; and
+4. generate the six local newsletter preview states.
+
+The Manager now retains the sanitized Tautulli, direct Plex, and SMTP outcomes
+for the current saved configuration. Dashboard's Manager runtime, Config
+status, and Integrations cards refresh together when validation finishes, and
+Verify displays the same retained component results. The controls on Verify
+remain optional targeted reruns for diagnosing a particular failure; users do
+not need to repeat them after a successful validation.
+
+Retained evidence is bound to the exact configuration revision. Saving changed
+settings or restoring a backup clears the prior evidence before the new checks
+run, so a result from one configuration cannot appear against another.
+
+## Consistent production-send selector
+
+The **Newsletter to send** selector now uses the same bounded chevron treatment
+as the Manager's Tautulli user selectors. Its All Recipients and Manual Welcome
+state transitions are unchanged.
+
+## Update from v0.12.1 or an older verified installation
+
+1. Download `TautWeekly-Setup.exe` and `SHA256SUMS.txt` from this release.
+2. Verify the EXE against `SHA256SUMS.txt`.
+3. Run Setup and confirm **Update** for the preselected installer-owned folder.
+4. Open **TautWeekly Manager** and run **Validate, save, and verify** once.
+
+For an older portable/BAT installation, select that exact installation folder
+in Setup and confirm **Migrate**. Configuration, credentials, choices, history,
+previews, diagnostics, backups, password-lock state, and an owned Windows
+Scheduled Task remain private and are preserved.
+
+## Validation and limitations
+
+Release gates cover Manager unit tests and vetting on Windows and Ubuntu,
+installer tests, JavaScript and accessibility checks, eight maintained Manager
+cross-builds, repository/privacy validation, reproducible archives, renderer
+fixtures, and Windows install/update/migration/uninstall lifecycle testing.
+Desktop and mobile browser QA used only the repository's fictional no-network
+fixture. No live Plex, Tautulli, SMTP, recipient, delivery, or schedule action
+was run for this patch.
+
+The Setup executable remains unsigned. Windows SmartScreen may identify it as
+an unknown publisher; verify the download against `SHA256SUMS.txt`.


### PR DESCRIPTION
## Summary

- publish the v0.12.2 release notes for synchronized Manager validation status
- document that Validate and save runs every safe non-sending setup check
- clarify that Verify actions are optional targeted reruns for diagnosing individual failures
- document the consistent production-delivery selector styling and update path

## Validation

- `powershell -NoProfile -File scripts/validate-docs.ps1`
- `powershell -NoProfile -File scripts/check-links.ps1`
- relative links checked across 56 Markdown and HTML files
- `git diff --check`

## Release scope

This is the release-preparation follow-up to merged PR #86. The implementation in #86 passed the complete Manager, installer, cross-platform build, accessibility, browser, and GitHub Actions test matrix. No live Plex, Tautulli, SMTP delivery, recipient, or Task Scheduler operation was performed for this release-preparation commit.
