### PR TITLE
chore: prepare v0.12.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   hidden legacy rule.
 - Restored consistent sizing, borders, typography, and responsive containment
   across the production newsletter and Tautulli user selectors.
+- Kept the Windows Setup completion dialog in the foreground and delayed the
+  Manager/browser launch until that dialog is dismissed, preventing a hidden
+  Setup process from retaining the downloaded EXE after installation.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-08-14
+
 ### Changed
 
 - Styled the production Manual Welcome user selector with the same bounded

--- a/docs/releases/v0.12.3.md
+++ b/docs/releases/v0.12.3.md
@@ -33,6 +33,18 @@ The production Manual Welcome user selector now uses the same height, border,
 type, focus, menu containment, and responsive behavior as the preview and
 TestEmail user selectors.
 
+## Let Windows Setup finish cleanly
+
+Setup previously started the local Manager and browser before displaying its
+final confirmation. On some Windows 10 desktops the browser could cover that
+ownerless confirmation, leaving `TautWeekly-Setup.exe` waiting invisibly and
+therefore locked against deletion or another update.
+
+The completion dialog is now explicitly foregrounded. The Manager/browser
+handoff occurs only after that dialog is dismissed, after which Setup exits
+normally. A failed installation still retains the existing best-effort Manager
+restart behavior, and `--no-launch` installations remain non-launching.
+
 ## Update from v0.12.2 or an older verified installation
 
 1. Download `TautWeekly-Setup.exe` and `SHA256SUMS.txt` from this release.

--- a/docs/releases/v0.12.3.md
+++ b/docs/releases/v0.12.3.md
@@ -1,0 +1,59 @@
+# TautWeekly for Plex v0.12.3
+
+v0.12.3 keeps older email-based delivery exclusions visible and truthful in
+the Windows Manager while tightening the synchronization and styling completed
+in v0.12.2.
+
+## Preserve legacy exclusions without exposing addresses
+
+Older Windows configurations can contain `ExcludedEmails` even when
+`ExcludedUserIds` is empty. TautWeekly still enforces those email rules, but
+the guided Tautulli choices previously showed only ID-based exclusions.
+
+The Manager now matches legacy email rules to the saved Tautulli roster on the
+server. A matching user appears checked and labelled **Legacy email
+exclusion**. That row is protected from ID-only editing because unchecking it
+would not remove the underlying email rule. The header also reports matched
+and total legacy-rule counts, making a stale or unmatched rule visible.
+
+Raw email addresses never cross the Manager API and are never written to its
+discovery cache. The browser receives only a match flag for the applicable
+user and bounded aggregate counts. Existing `ExcludedEmails` values remain
+unchanged in `config.json`.
+
+## Keep validation evidence synchronized
+
+Dashboard's Integrations card and the Verify page now use the retained safe
+setup result whenever a more detailed manual diagnostic result is not
+available. **Validate, save, and verify** therefore remains the primary setup
+and revalidation action. Manual Verify controls remain targeted reruns for
+diagnosing an individual failure.
+
+The production Manual Welcome user selector now uses the same height, border,
+type, focus, menu containment, and responsive behavior as the preview and
+TestEmail user selectors.
+
+## Update from v0.12.2 or an older verified installation
+
+1. Download `TautWeekly-Setup.exe` and `SHA256SUMS.txt` from this release.
+2. Verify the EXE against `SHA256SUMS.txt`.
+3. Run Setup and confirm **Update** for the preselected installer-owned folder.
+4. Open **TautWeekly Manager** and run **Validate, save, and verify** once.
+
+For an older portable/BAT installation, select that exact installation folder
+in Setup and confirm **Migrate**. Configuration, credentials, legacy email and
+ID exclusions, history, previews, diagnostics, backups, password-lock state,
+and an owned Windows Scheduled Task remain private and are preserved.
+
+## Validation and limitations
+
+Release gates cover Manager and installer unit tests and vetting, JavaScript
+and accessibility checks, eight maintained Manager cross-builds, repository
+and privacy validation, reproducible archives, package contracts, and Windows
+fresh-install/update/portable-migration/uninstall lifecycle testing. Desktop
+and mobile browser QA used only fictional local fixtures. The real email values
+shown in the user report were not copied into source, tests, logs, or release
+artifacts.
+
+The Setup executable remains unsigned. Windows SmartScreen may identify it as
+an unknown publisher; verify the download against `SHA256SUMS.txt`.

--- a/installer/cmd/tautweekly-setup/main.go
+++ b/installer/cmd/tautweekly-setup/main.go
@@ -102,7 +102,17 @@ func run(args []string) error {
 		logger.Printf("install failed: %v", err)
 		return fmt.Errorf("Installation stopped safely. Existing configuration and history were not removed.\n\nReview the installer log for details:\n%s", opts.logPath)
 	}
-	return showCompletion("TautWeekly is ready", installationCompletionMessage(opts.noLaunch), opts.testMode)
+	return finishInstallation(opts, showCompletion, startDetached)
+}
+
+func finishInstallation(opts options, completion func(string, string, bool) error, launch func(string, string) error) error {
+	completionErr := completion("TautWeekly is ready", installationCompletionMessage(opts.noLaunch), opts.testMode)
+	if !opts.noLaunch && !opts.testMode {
+		if err := launch(filepath.Join(opts.installDir, "Open-TautWeekly.cmd"), opts.installDir); err != nil {
+			return fmt.Errorf("open installed Manager: %w", err)
+		}
+	}
+	return completionErr
 }
 
 func installationCompletionMessage(noLaunch bool) string {
@@ -273,6 +283,7 @@ func install(opts options, logger *log.Logger) error {
 	}
 	managerWasRunning := false
 	managerRestarted := false
+	installSucceeded := false
 	if updatingExisting {
 		if err := migrateLegacyManagerData(opts.installDir, opts.dataDir); err != nil {
 			return err
@@ -305,7 +316,7 @@ func install(opts options, logger *log.Logger) error {
 			return err
 		}
 		defer func() {
-			if managerWasRunning && !managerRestarted {
+			if managerWasRunning && !managerRestarted && !installSucceeded {
 				_ = startDetached(filepath.Join(opts.installDir, "Open-TautWeekly.cmd"), opts.installDir)
 			}
 		}()
@@ -323,12 +334,13 @@ func install(opts options, logger *log.Logger) error {
 		}
 	}
 	logger.Printf("install complete version=%s", version)
-	if (!opts.noLaunch || managerWasRunning) && !opts.testMode {
+	if managerWasRunning && opts.noLaunch && !opts.testMode {
 		if err := startDetached(filepath.Join(opts.installDir, "Open-TautWeekly.cmd"), opts.installDir); err != nil {
 			return fmt.Errorf("open installed Manager: %w", err)
 		}
-		managerRestarted = managerWasRunning
+		managerRestarted = true
 	}
+	installSucceeded = true
 	return nil
 }
 

--- a/installer/cmd/tautweekly-setup/main_test.go
+++ b/installer/cmd/tautweekly-setup/main_test.go
@@ -152,6 +152,56 @@ func TestInstallationCompletionPointsToManagerShortcut(t *testing.T) {
 	}
 }
 
+func TestFinishInstallationDismissesCompletionBeforeLaunchingManager(t *testing.T) {
+	opts := options{installDir: filepath.Join(t.TempDir(), "TautWeekly")}
+	events := []string{}
+	err := finishInstallation(opts,
+		func(_, message string, suppressed bool) error {
+			if suppressed || !strings.Contains(message, "will now open in your browser") {
+				t.Fatalf("unexpected completion state: suppressed=%t message=%q", suppressed, message)
+			}
+			events = append(events, "completion-dismissed")
+			return nil
+		},
+		func(_, workingDirectory string) error {
+			if workingDirectory != opts.installDir {
+				t.Fatalf("Manager launch used %q instead of %q", workingDirectory, opts.installDir)
+			}
+			events = append(events, "manager-launched")
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(events, ","); got != "completion-dismissed,manager-launched" {
+		t.Fatalf("installer completion and launch order was %q", got)
+	}
+}
+
+func TestFinishInstallationNoLaunchClosesWithoutStartingManager(t *testing.T) {
+	opts := options{installDir: t.TempDir(), noLaunch: true}
+	launchCalled := false
+	err := finishInstallation(opts,
+		func(_, message string, suppressed bool) error {
+			if suppressed || strings.Contains(message, "will now open in your browser") {
+				t.Fatalf("unexpected no-launch completion state: suppressed=%t message=%q", suppressed, message)
+			}
+			return nil
+		},
+		func(_, _ string) error {
+			launchCalled = true
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if launchCalled {
+		t.Fatal("no-launch installation started the Manager")
+	}
+}
+
 func TestMigrateLegacyManagerDataRejectsConflictingExternalState(t *testing.T) {
 	existing := t.TempDir()
 	data := t.TempDir()

--- a/installer/cmd/tautweekly-setup/windows.go
+++ b/installer/cmd/tautweekly-setup/windows.go
@@ -35,23 +35,24 @@ type verifiedUpdateResult struct {
 }
 
 var (
-	user32          = syscall.NewLazyDLL("user32.dll")
-	messageBox      = user32.NewProc("MessageBoxW")
-	sendMessage     = user32.NewProc("SendMessageW")
-	showWindow      = user32.NewProc("ShowWindow")
-	setForeground   = user32.NewProc("SetForegroundWindow")
-	setWindowPos    = user32.NewProc("SetWindowPos")
-	shell32         = syscall.NewLazyDLL("shell32.dll")
-	browseForFolder = shell32.NewProc("SHBrowseForFolderW")
-	getFolderPath   = shell32.NewProc("SHGetPathFromIDListW")
-	ole32           = syscall.NewLazyDLL("ole32.dll")
-	coTaskMemFree   = ole32.NewProc("CoTaskMemFree")
-	buttonYesNo     = uintptr(0x00000004)
-	iconQuestion    = uintptr(0x00000020)
-	iconInformation = uintptr(0x00000040)
-	iconError       = uintptr(0x00000010)
-	buttonOK        = uintptr(0x00000000)
-	resultYes       = uintptr(6)
+	user32            = syscall.NewLazyDLL("user32.dll")
+	messageBox        = user32.NewProc("MessageBoxW")
+	sendMessage       = user32.NewProc("SendMessageW")
+	showWindow        = user32.NewProc("ShowWindow")
+	setForeground     = user32.NewProc("SetForegroundWindow")
+	setWindowPos      = user32.NewProc("SetWindowPos")
+	shell32           = syscall.NewLazyDLL("shell32.dll")
+	browseForFolder   = shell32.NewProc("SHBrowseForFolderW")
+	getFolderPath     = shell32.NewProc("SHGetPathFromIDListW")
+	ole32             = syscall.NewLazyDLL("ole32.dll")
+	coTaskMemFree     = ole32.NewProc("CoTaskMemFree")
+	buttonYesNo       = uintptr(0x00000004)
+	iconQuestion      = uintptr(0x00000020)
+	iconInformation   = uintptr(0x00000040)
+	iconError         = uintptr(0x00000010)
+	messageForeground = uintptr(0x00010000)
+	buttonOK          = uintptr(0x00000000)
+	resultYes         = uintptr(6)
 )
 
 type browseInfo struct {
@@ -218,7 +219,7 @@ func confirmAction(title, message string, testMode bool) (bool, error) {
 	if testMode {
 		return true, nil
 	}
-	result, err := showMessage(title, message, buttonYesNo|iconQuestion)
+	result, err := showMessage(title, message, buttonYesNo|iconQuestion|messageForeground)
 	return result == resultYes, err
 }
 
@@ -226,7 +227,7 @@ func showCompletion(title, message string, suppressed bool) error {
 	if suppressed {
 		return nil
 	}
-	_, err := showMessage(title, message, buttonOK|iconInformation)
+	_, err := showMessage(title, message, buttonOK|iconInformation|messageForeground)
 	return err
 }
 
@@ -234,7 +235,7 @@ func showFailure(title, message string, suppressed bool) error {
 	if suppressed {
 		return nil
 	}
-	_, err := showMessage(title, message, buttonOK|iconError)
+	_, err := showMessage(title, message, buttonOK|iconError|messageForeground)
 	return err
 }
 

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -56,6 +56,18 @@ function Invoke-TestInstallerAt([string]$ApplicationRoot, [string]$PrivateRoot, 
 try {
     New-Item -ItemType Directory -Path $testRoot | Out-Null
     Invoke-TestInstaller
+    $lockProbe = [IO.Path]::GetFullPath((Join-Path $DistPath 'TautWeekly-Setup.lock-probe.exe'))
+    Assert-True ([string]::Equals([IO.Path]::GetDirectoryName($lockProbe), $DistPath, [StringComparison]::OrdinalIgnoreCase)) 'Unsafe Setup lock-probe path.'
+    try {
+        Move-Item -LiteralPath $setup -Destination $lockProbe -ErrorAction Stop
+        Move-Item -LiteralPath $lockProbe -Destination $setup -ErrorAction Stop
+    }
+    finally {
+        if ((Test-Path -LiteralPath $lockProbe -PathType Leaf) -and -not (Test-Path -LiteralPath $setup)) {
+            Move-Item -LiteralPath $lockProbe -Destination $setup -ErrorAction SilentlyContinue
+        }
+    }
+    Assert-True (Test-Path -LiteralPath $setup -PathType Leaf) 'Setup remained locked or was not restored after its process exited.'
     foreach ($relative in @(
         'tautweekly-manager.exe', 'TautWeekly.ps1', 'START-MANAGER.ps1', 'RESET-MANAGER-ACCESS.ps1',
         'Open-TautWeekly.cmd', 'Reset-TautWeekly-Access.cmd', 'Uninstall-TautWeekly.cmd', 'TautWeekly-Uninstall.exe',
@@ -187,7 +199,7 @@ try {
         if ($null -ne $embeddedIcon) { $embeddedIcon.Dispose() }
     }
 
-    Write-Host '[PASS] Windows installer fresh install, verified upgrade, portable migration, icon, and privacy-preserving uninstall lifecycle.' -ForegroundColor Green
+    Write-Host '[PASS] Windows installer fresh install, process-lock release, verified upgrade, portable migration, icon, and privacy-preserving uninstall lifecycle.' -ForegroundColor Green
 }
 finally {
     if (Test-Path -LiteralPath $testRoot) {


### PR DESCRIPTION
## Release

Prepare v0.12.3 after merged PR #88, including the Windows 10 Setup process-lifetime correction found during final host acceptance.

## Included corrections

- surface legacy `ExcludedEmails` rules in guided Tautulli delivery exclusions without returning addresses to the browser
- preserve unmatched-rule visibility and protect matched legacy exclusions during ID-based edits
- keep Dashboard and Verify synchronized with the retained safe-validation result
- align the Manual Welcome and other guided selectors
- foreground the Setup completion dialog and launch the Manager/browser only after it is dismissed, so Setup exits and releases its downloaded EXE

## Release validation

The Manager patch passed duplicate push and pull-request CI runs: Windows and Ubuntu Manager suites, PowerShell renderer/protocol regressions, ShellCheck/repository/JSON/Compose checks, reproducible release archives, and Windows one-click installer lifecycle tests.

The Setup lifetime correction additionally passed installer/uninstaller tests and vet, sequencing tests, complete release rebuild and artifact contracts, a direct post-exit EXE lock-release probe, Windows fresh install/update/portable migration/launch/icon/uninstall lifecycle, repository/privacy/docs/link validation, and byte-for-byte reproducibility. PR checks must rerun from the new exact head before merge.
