### PR TITLE
fix: finalize Windows Manager lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.5] - 2026-08-14
+
+### Changed
+
+- Summarized the guided Tautulli roster as **found ● excluded**, with the
+  effective exclusion count covering both configured user IDs and users matched
+  privately by retained legacy email rules.
+- Kept legacy email-rule matches visibly checked at the top of the delivery
+  roster while preserving the underlying email rule as the source of truth.
+
+### Fixed
+
+- Displayed Manual Welcome and all-recipient production sends only in the
+  dedicated **Current or latest manual send** card instead of duplicating the
+  same operation in the generic current-run card.
+- Started the installed Manager directly after Setup's completion dialog closes
+  and prevented hidden Windows child processes from inheriting Setup handles.
+  The completed installer now exits without retaining its downloaded EXE.
+- Added fictional loopback browser fixtures and regression coverage for 78
+  discovered users, two retained exclusions, the single manual-send status
+  surface, and the Windows handle-inheritance boundary.
+
 ## [0.12.4] - 2026-08-14
 
 ### Changed

--- a/docs/releases/v0.12.5.md
+++ b/docs/releases/v0.12.5.md
@@ -1,0 +1,63 @@
+# TautWeekly for Plex v0.12.5
+
+v0.12.5 is a focused Windows corrective release. It makes Setup's process
+lifecycle deterministic on completed installations, removes a duplicated
+manual-delivery status card, and makes every effective delivery exclusion
+visible in the guided configuration roster.
+
+## Release Setup completely
+
+After the completion dialog is dismissed, Setup now launches the installed
+Manager directly as a detached process and returns. Hidden Windows child
+processes are created without inheriting Setup's handles, so neither the
+Manager nor its launcher can keep the downloaded `TautWeekly-Setup.exe` open.
+
+The Windows installer acceptance test completes a real isolated installation,
+waits for the exact Setup process to terminate, moves the candidate EXE to prove
+its lock is released, verifies the installed Manager's TautWeekly icon and
+product identity, and then exercises update, portable migration, and uninstall.
+
+## Show one truthful manual-send status
+
+Manual Welcome and all-recipient production sends now appear only in the
+dedicated **Current or latest manual send** card. The generic current-run card
+is hidden for those operation types, eliminating the duplicate running or
+completed status while preserving the same sanitized operation evidence.
+
+## Count every retained delivery exclusion
+
+The guided Tautulli roster now reports **found ● excluded**. The exclusion
+count includes configured Tautulli user IDs and users matched by retained
+`ExcludedEmails` rules. Matching users remain checked, are grouped first, and
+are identified as excluded by the existing configuration.
+
+Legacy matching remains server-side. The browser receives only the user's
+already-sanitized display record and a Boolean match flag; email addresses are
+not returned, cached, logged, or written to generated output. A legacy match is
+read-only in the ID selector because clearing an ID cannot remove the separate
+email rule that still excludes the recipient.
+
+## Update from v0.12.4 or an older installation
+
+1. Download `TautWeekly-Setup.exe` and `SHA256SUMS.txt` from this release.
+2. Verify the EXE against `SHA256SUMS.txt`.
+3. Run Setup and confirm **Update** for the preselected installer-owned folder.
+4. Open **TautWeekly Manager** and run **Validate, save, and verify** once.
+
+For an older portable/BAT installation, select that exact installation folder
+in Setup and confirm **Migrate**. Configuration, credentials, exclusions,
+history, previews, diagnostics, backups, optional password-lock state, and an
+owned Windows Scheduled Task remain private and are preserved.
+
+## Validation and limitations
+
+Release gates cover Manager and installer unit tests and vetting, embedded
+JavaScript and accessibility checks, maintained Manager cross-builds,
+repository and privacy validation, reproducible archives, packaged runtime
+contracts, and isolated Windows fresh-install/update/portable-migration/
+uninstall lifecycle testing. Desktop and mobile browser QA used only fictional
+loopback fixtures and verified 78 discovered users, two retained exclusions,
+and one manual-send status card.
+
+The Setup executable remains unsigned. Windows SmartScreen may identify it as
+an unknown publisher; verify the download against `SHA256SUMS.txt`.

--- a/installer/cmd/tautweekly-setup/main.go
+++ b/installer/cmd/tautweekly-setup/main.go
@@ -107,7 +107,7 @@ func run(args []string) error {
 		logger.Printf("install failed: %v", err)
 		return fmt.Errorf("Installation stopped safely. Existing configuration and history were not removed.\n\nReview the installer log for details:\n%s", opts.logPath)
 	}
-	return finishInstallation(opts, showCompletion, queueManagerLaunchAfterExit)
+	return finishInstallation(opts, showCompletion, startDetached)
 }
 
 func finishInstallation(opts options, completion func(string, string, bool) error, queueLaunch func(string, string) error) error {
@@ -802,18 +802,6 @@ func startDetached(_ string, workingDirectory string) error {
 		return err
 	}
 	return command.Process.Release()
-}
-
-func queueManagerLaunchAfterExit(_ string, workingDirectory string) error {
-	if runtime.GOOS != "windows" {
-		return errors.New("installed Manager can be launched only on Windows")
-	}
-	dataDir, _ := installedDataDirectory(workingDirectory)
-	const script = `$parent=Get-Process -Id ([int]$env:TAUTWEEKLY_SETUP_PARENT) -ErrorAction SilentlyContinue;if($null-ne $parent){$parent.WaitForExit()};$arguments=@('-NoLogo','-NoProfile','-NonInteractive','-WindowStyle','Hidden','-ExecutionPolicy','Bypass','-File',$env:TAUTWEEKLY_MANAGER_SCRIPT);if(-not [string]::IsNullOrWhiteSpace($env:TAUTWEEKLY_MANAGER_DATA)){$arguments+=@('-DataRoot',$env:TAUTWEEKLY_MANAGER_DATA)};& powershell.exe @arguments;exit $LASTEXITCODE`
-	return queuePostExitHandoff(script, workingDirectory, []string{
-		"TAUTWEEKLY_MANAGER_SCRIPT=" + filepath.Join(workingDirectory, "START-MANAGER.ps1"),
-		"TAUTWEEKLY_MANAGER_DATA=" + dataDir,
-	})
 }
 
 func queueExitMarkerAfterExit(markerPath, workingDirectory string) error {

--- a/installer/cmd/tautweekly-setup/main_test.go
+++ b/installer/cmd/tautweekly-setup/main_test.go
@@ -152,7 +152,7 @@ func TestInstallationCompletionPointsToManagerShortcut(t *testing.T) {
 	}
 }
 
-func TestFinishInstallationDismissesCompletionBeforeQueueingManagerLaunch(t *testing.T) {
+func TestFinishInstallationDismissesCompletionBeforeLaunchingManager(t *testing.T) {
 	opts := options{installDir: filepath.Join(t.TempDir(), "TautWeekly")}
 	events := []string{}
 	err := finishInstallation(opts,
@@ -167,14 +167,14 @@ func TestFinishInstallationDismissesCompletionBeforeQueueingManagerLaunch(t *tes
 			if workingDirectory != opts.installDir {
 				t.Fatalf("Manager launch used %q instead of %q", workingDirectory, opts.installDir)
 			}
-			events = append(events, "manager-launch-queued")
+			events = append(events, "manager-launch-started")
 			return nil
 		},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := strings.Join(events, ","); got != "completion-dismissed,manager-launch-queued" {
+	if got := strings.Join(events, ","); got != "completion-dismissed,manager-launch-started" {
 		t.Fatalf("installer completion and launch order was %q", got)
 	}
 }

--- a/installer/cmd/tautweekly-setup/windows.go
+++ b/installer/cmd/tautweekly-setup/windows.go
@@ -212,7 +212,11 @@ func applyVerifiedUpdate(opts options, candidateRoot, targetVersion string) erro
 }
 
 func hideProcessWindow(command *exec.Cmd) {
-	command.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000}
+	command.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:       true,
+		CreationFlags:    0x08000000,
+		NoInheritHandles: true,
+	}
 }
 
 func confirmAction(title, message string, testMode bool) (bool, error) {

--- a/installer/cmd/tautweekly-setup/windows_test.go
+++ b/installer/cmd/tautweekly-setup/windows_test.go
@@ -7,10 +7,22 @@ import (
 	"errors"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestHiddenChildProcessesDoNotInheritSetupHandles(t *testing.T) {
+	command := exec.Command("cmd.exe", "/d", "/c", "exit 0")
+	hideProcessWindow(command)
+	if command.SysProcAttr == nil || !command.SysProcAttr.HideWindow {
+		t.Fatal("hidden child process does not retain the Windows hidden-window contract")
+	}
+	if !command.SysProcAttr.NoInheritHandles {
+		t.Fatal("detached child process may inherit and retain a handle to Setup")
+	}
+}
 
 func TestCreateShortcutAcceptsPathsWithSpaces(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "folder with spaces")

--- a/manager/internal/manager/web/app.css
+++ b/manager/internal/manager/web/app.css
@@ -58,4 +58,5 @@
 .user-combobox>input:focus{border-color:var(--gold);box-shadow:0 0 0 3px rgba(229,160,13,.12)}
 .manual-send-mode-field select{border-color:var(--line-strong);font:inherit}
 .choice-row.legacy-exclusion{cursor:default;border-color:rgba(229,160,13,.28);background:linear-gradient(110deg,rgba(229,160,13,.065),var(--surface) 48%)}
-.choice-row.legacy-exclusion input:disabled{cursor:not-allowed;opacity:.78}
+.choice-row.legacy-exclusion input:disabled{cursor:not-allowed;opacity:1}
+.discovery-excluded-count{color:rgba(255,122,114,.48);font-weight:750}

--- a/manager/internal/manager/web/app.js
+++ b/manager/internal/manager/web/app.js
@@ -722,11 +722,17 @@ function renderDiscoveredUsers() {
   const container = byId("discovery-users");
   container.replaceChildren();
   const users = state.discovery?.users || [];
-  const legacyRuleCount = Number(state.discovery?.legacyRuleCount || 0);
-  const matchedLegacyRuleCount = Number(state.discovery?.matchedLegacyRuleCount || 0);
-  const legacySummary = legacyRuleCount ? ` · ${matchedLegacyRuleCount}/${legacyRuleCount} legacy matched` : "";
-  setText("discovery-user-count", `${users.length} found${legacySummary}`);
   const configured = new Set(currentListField("ExcludedUserIds"));
+  const excludedCount = users.filter((item) => configured.has(item.id) || item.legacyRuleExcluded === true).length;
+  const count = byId("discovery-user-count");
+  count.replaceChildren(document.createTextNode(`${users.length} found`));
+  if (excludedCount > 0) {
+    count.append(document.createTextNode(" ● "));
+    const excluded = document.createElement("span");
+    excluded.className = "discovery-excluded-count";
+    excluded.textContent = `${excludedCount} excluded`;
+    count.append(excluded);
+  }
   const orderedUsers = [...users].sort((left, right) => {
     const leftExcluded = configured.has(left.id) || left.legacyRuleExcluded === true;
     const rightExcluded = configured.has(right.id) || right.legacyRuleExcluded === true;
@@ -1794,7 +1800,14 @@ function renderManualSendStatus(operation) {
 }
 
 function renderCurrentOperation(operation) {
+  const card = byId("current-operation");
   const cancel = byId("preview-cancel-button");
+  const manualSend = ["send-welcome", "send-all"].includes(operation?.type);
+  card.hidden = manualSend;
+  if (manualSend) {
+    cancel.hidden = true;
+    return;
+  }
   cancel.hidden = !operation?.cancellable || !operationIsActive(operation);
   cancel.disabled = state.operationCancelling;
   setSwappingButtonText("preview-cancel-button", state.operationCancelling ? "Cancelling..." : "Cancel preview generation");

--- a/manager/testdata/browser-qa/README.md
+++ b/manager/testdata/browser-qa/README.md
@@ -9,6 +9,12 @@ SMTP acceptances; and SendWelcome reports one fictional acceptance. None opens
 a connection. Each writes one sanitized structured result. The fixture contains
 no network, SMTP, browser-launch, or scheduler operation.
 
+`mock-tautulli.mjs` is an optional loopback-only companion for interactive
+browser QA. It exposes exactly the three read-only Tautulli discovery commands
+used by the Manager and returns three fictional libraries and 78 fictional
+users. Two users match the fixture's legacy email exclusions so the retained,
+checked exclusion presentation can be verified without exposing real addresses.
+
 Browser QA copies these files to an ignored temporary directory and renames
 `fixture-config.json` to `config.json`. The temporary root and Manager data are
 removed before repository validation.

--- a/manager/testdata/browser-qa/mock-tautulli.mjs
+++ b/manager/testdata/browser-qa/mock-tautulli.mjs
@@ -1,0 +1,57 @@
+import http from "node:http";
+
+const listenAddress = "127.0.0.1";
+const listenPort = 18181;
+const apiKey = "fictional-browser-qa-api-key";
+
+const users = Array.from({ length: 78 }, (_, index) => ({
+  user_id: String(index + 1),
+  friendly_name: index === 0 ? "Fictional Admin" : `Fictional Viewer ${String(index + 1).padStart(2, "0")}`,
+  email: index === 0
+    ? "viewer@example.com"
+    : index === 1
+      ? "unmatched-legacy@example.org"
+      : `viewer${index + 1}@example.org`,
+  is_active: 1,
+  do_notify: 1,
+  is_admin: index === 0 ? 1 : 0,
+}));
+
+const server = http.createServer((request, response) => {
+  const target = new URL(request.url || "/", `http://${listenAddress}:${listenPort}`);
+  if (target.pathname !== "/api/v2" || target.searchParams.get("apikey") !== apiKey) {
+    response.writeHead(401, { "content-type": "text/plain; charset=utf-8" });
+    response.end("unauthorized");
+    return;
+  }
+
+  let data;
+  switch (target.searchParams.get("cmd")) {
+    case "get_libraries":
+      data = [
+        { section_id: "1", section_name: "Fictional Movies", section_type: "movie", is_active: 1, count: 40 },
+        { section_id: "2", section_name: "Fictional Shows", section_type: "show", is_active: 1, count: 20 },
+        { section_id: "3", section_name: "Fictional Family", section_type: "movie", is_active: 1, count: 18 },
+      ];
+      break;
+    case "get_user_names":
+      data = users.map(({ user_id, friendly_name }) => ({ user_id, friendly_name }));
+      break;
+    case "get_users":
+      data = users;
+      break;
+    default:
+      response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+      response.end("unsupported fixture command");
+      return;
+  }
+
+  response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+  response.end(JSON.stringify({ response: { result: "success", data } }));
+});
+
+server.listen(listenPort, listenAddress);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/scripts/test-manager-accessibility.py
+++ b/scripts/test-manager-accessibility.py
@@ -250,6 +250,8 @@ def main() -> int:
         failures.append("legacy direct Plex omissions have no guided completion message")
     if "legacyRuleExcluded" not in javascript or "Excluded by existing config" not in javascript:
         failures.append("legacy email exclusions are not represented in guided delivery choices")
+    if 'excluded.className = "discovery-excluded-count"' not in javascript or "rgba(255,122,114,.48)" not in css:
+        failures.append("guided delivery choices do not show the requested effective exclusion count")
     if "const orderedUsers = [...users].sort" not in javascript or "leftExcluded ? -1 : 1" not in javascript:
         failures.append("configured delivery exclusions are not grouped visibly at the top of discovered users")
     if ".user-combobox>input" not in css or ".manual-send-mode-field select{border-color:var(--line-strong)" not in css:
@@ -258,6 +260,8 @@ def main() -> int:
         failures.append("guided user selectors do not open from the full input field for typing or mouse selection")
     if 'card.hidden = !manualSend;' not in javascript:
         failures.append("manual production status is visible before a manual send exists")
+    if 'card.hidden = manualSend;' not in javascript:
+        failures.append("manual production delivery is duplicated in the generic current-run card")
     for label in ("Index", "Manual Welcome", "New User - No History", "New User - With History", "Normal Newsletter", "Established Quiet", "Established Warnings"):
         if label not in javascript:
             failures.append(f"preview scenario label is missing: {label}")


### PR DESCRIPTION
## What changed

- Launch the installed Manager directly after the Setup completion dialog and prevent hidden Windows children from inheriting Setup handles.
- Show Manual Welcome and all-recipient production delivery only in the dedicated manual-send status card.
- Count effective delivery exclusions across configured Tautulli IDs and privacy-preserving legacy email matches, while keeping retained matches visibly checked.
- Add fictional loopback browser fixtures, regression checks, changelog entries, and v0.12.5 release notes.

## Root cause

The v0.12.4 post-exit PowerShell handoff could remain alive long enough to retain the downloaded Setup executable on some Windows hosts. Manual delivery was rendered by both the dedicated and generic operation surfaces. The guided roster exposed legacy-match state per user but summarized only legacy-rule aggregates instead of the effective excluded-recipient total.

## Validation

- Manager: full Go tests and vet
- Installer: affected lifecycle tests, installer/uninstaller vet, and isolated real Windows fresh-install/update/portable-migration/icon/uninstall acceptance
- UI: JavaScript syntax, accessibility regression suite, and fictional desktop/mobile browser QA (78 users, 2 exclusions, one manual-send status card)
- Packages: all 10 release deliverables, manifests, privacy contracts, SHA-256 checks, and byte-identical reproducibility
- Repository: structure, branding, platform, docs, links, PowerShell, scheduler, updater, deleted-item cache, cross-build, and Bash syntax/update-management checks

Local environment notes: ShellCheck and Docker Compose remain CI gates because those tools are not installed on this Windows host. The non-interactive Codex shell also cannot resolve the Windows Programs special folder; the dedicated real installer lifecycle acceptance passed.
