### PR TITLE
fix: restore guided delivery exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.6] - 2026-08-15
+
+### Changed
+
+- Distinguished unsaved delivery choices from persisted exclusions in the
+  guided Tautulli roster. Checkbox changes now show a gold **selected** count;
+  after validation and save, the same count is reported as soft-red
+  **excluded** state.
+
+### Fixed
+
+- Recovered legacy `ExcludedEmails` matches when a Tautulli installation omits
+  email fields from `get_users`. The Manager now uses a bounded
+  `get_users_table` compatibility lookup only when legacy rules remain
+  unmatched, then keeps matched users visible, checked, and grouped first.
+- Prevented upgraded Manager pages from retaining stale embedded JavaScript or
+  styles by serving the local application shell and assets with `no-store`.
+
+### Security
+
+- Kept legacy email matching entirely server-side during the compatibility
+  lookup. Email addresses, API keys, and raw Tautulli responses are not returned
+  to the browser, cached in discovery state, or written to diagnostics.
+
 ## [0.12.5] - 2026-08-14
 
 ### Changed

--- a/docs/releases/v0.12.6.md
+++ b/docs/releases/v0.12.6.md
@@ -1,0 +1,63 @@
+# TautWeekly for Plex v0.12.6
+
+v0.12.6 is a focused Manager corrective release for guided delivery
+exclusions. It makes legacy email-based exclusions visible across more
+Tautulli response variants, distinguishes unsaved selections from saved
+configuration, and prevents an upgraded local Manager from serving stale UI
+assets.
+
+## Recover retained exclusions from Tautulli
+
+Some Tautulli installations do not include email fields in the primary
+`get_users` response. When retained `ExcludedEmails` rules cannot be matched
+from that response, the Manager now performs one bounded, read-only
+`get_users_table` compatibility lookup and merges only the missing user details
+by numeric Tautulli user ID.
+
+Matching remains private and server-side. The browser receives only the
+sanitized user ID, display name, eligibility, role, and a Boolean indication
+that the existing configuration excludes that user. Email addresses, API keys,
+and raw service responses are never returned to the browser or stored in the
+discovery cache.
+
+## Show selected state before save
+
+The guided roster now updates its summary as soon as a checkbox changes:
+
+- unsaved choices appear as **found ● selected** in gold;
+- saved choices appear as **found ● excluded** in soft red.
+
+After **Validate, save, and verify** completes, selected users remain checked
+and the summary changes to persisted exclusion state. Existing legacy matches
+remain visible, checked, and grouped at the top of the roster.
+
+## Load the current Manager UI after an update
+
+The embedded local application shell, JavaScript, and styles are now served
+with `Cache-Control: no-store`. Opening or refreshing the Manager after an
+upgrade therefore loads the UI shipped by the installed version instead of a
+stale browser copy.
+
+## Update from v0.12.5 or an older installation
+
+1. Download `TautWeekly-Setup.exe` and `SHA256SUMS.txt` from this release.
+2. Verify the EXE against `SHA256SUMS.txt`.
+3. Run Setup and confirm **Update** for the preselected installer-owned folder.
+4. Open **Config** and run **Validate, save, and verify** once.
+
+For an older portable/BAT installation, select that exact installation folder
+in Setup and confirm **Migrate**. Existing private configuration, credentials,
+delivery exclusions, history, previews, diagnostics, backups, optional
+password-lock state, and an owned Windows Scheduled Task are preserved.
+
+## Validation and limitations
+
+Release validation covers Manager unit tests and vetting, embedded JavaScript
+and accessibility checks, repository privacy validation, and maintained
+Manager cross-builds for Windows, Linux, macOS, and FreeBSD on amd64 and arm64.
+Desktop and 390-pixel mobile browser QA used only fictional loopback data and
+verified both the unsaved selected state and the saved excluded state with no
+horizontal overflow.
+
+The Setup executable remains unsigned. Windows SmartScreen may identify it as
+an unknown publisher; verify the download against `SHA256SUMS.txt`.

--- a/manager/internal/manager/integration.go
+++ b/manager/internal/manager/integration.go
@@ -94,6 +94,10 @@ type tautulliEnvelope struct {
 	} `json:"response"`
 }
 
+type tautulliUsersTable struct {
+	Data []map[string]any `json:"data"`
+}
+
 func RunRealIntegrationCheck(ctx context.Context, root string, request RealIntegrationCheckRequest, now func() time.Time) (IntegrationCheckResult, error) {
 	if !request.ConfirmRealNetwork {
 		return IntegrationCheckResult{}, ErrRealCheckConfirmation
@@ -182,9 +186,20 @@ func DiscoverTautulliChoices(ctx context.Context, root string, request TautulliD
 		return TautulliDiscoveryResult{}, errIntegrationResponse
 	}
 
-	libraries := normalizeDiscoveredLibraries(rawLibraries)
 	legacyRules := normalizedLegacyExclusionRules(values["ExcludedEmails"])
 	users, matchedLegacyRules := normalizeDiscoveredUsers(rawNames, rawUsers, legacyRules)
+	if matchedLegacyRules < len(legacyRules) {
+		var table tautulliUsersTable
+		params := url.Values{
+			"start":  {"0"},
+			"length": {strconv.Itoa(maximumDiscoveryChoices)},
+		}
+		if err := tautulliCommandWithParams(checkContext, client, base, apiKey, "get_users_table", params, &table); err == nil {
+			rawUsers = mergeDiscoveredUserDetails(rawUsers, table.Data)
+			users, matchedLegacyRules = normalizeDiscoveredUsers(rawNames, rawUsers, legacyRules)
+		}
+	}
+	libraries := normalizeDiscoveredLibraries(rawLibraries)
 	if len(libraries) == 0 {
 		return TautulliDiscoveryResult{}, fmt.Errorf("%w: no active movie or TV libraries", errIntegrationResponse)
 	}
@@ -280,7 +295,7 @@ func normalizeDiscoveredUsers(names, details []map[string]any, legacyRules map[s
 		legacyRuleExcluded := false
 		if hasDetails {
 			eligibility = "skipped"
-			email := strings.ToLower(strings.TrimSpace(fmt.Sprint(detail["email"])))
+			email := discoveredUserEmail(detail)
 			if integrationTruthy(detail["is_active"]) && integrationTruthy(detail["do_notify"]) && email != "" && email != "<nil>" {
 				eligibility = "eligible"
 			}
@@ -296,6 +311,64 @@ func normalizeDiscoveredUsers(names, details []map[string]any, legacyRules map[s
 	}
 	sort.Slice(result, func(i, j int) bool { return strings.ToLower(result[i].Name) < strings.ToLower(result[j].Name) })
 	return result, len(matchedLegacyRules)
+}
+
+func mergeDiscoveredUserDetails(primary, fallback []map[string]any) []map[string]any {
+	result := make([]map[string]any, 0, len(primary)+len(fallback))
+	byID := make(map[string]map[string]any, len(primary)+len(fallback))
+	for _, source := range primary {
+		copyOfSource := make(map[string]any, len(source))
+		for key, value := range source {
+			copyOfSource[key] = value
+		}
+		id := discoveryID(copyOfSource["user_id"])
+		if id != "" {
+			byID[id] = copyOfSource
+		}
+		result = append(result, copyOfSource)
+	}
+	for _, source := range fallback {
+		id := discoveryID(source["user_id"])
+		if id == "" {
+			continue
+		}
+		if existing, ok := byID[id]; ok {
+			for key, value := range source {
+				if discoveryValueMissing(existing[key]) && !discoveryValueMissing(value) {
+					existing[key] = value
+				}
+			}
+			continue
+		}
+		copyOfSource := make(map[string]any, len(source))
+		for key, value := range source {
+			copyOfSource[key] = value
+		}
+		byID[id] = copyOfSource
+		result = append(result, copyOfSource)
+	}
+	return result
+}
+
+func discoveredUserEmail(detail map[string]any) string {
+	for _, key := range []string{"email", "user_email"} {
+		value := strings.ToLower(strings.TrimSpace(fmt.Sprint(detail[key])))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func discoveryValueMissing(value any) bool {
+	if value == nil {
+		return true
+	}
+	if text, ok := value.(string); ok {
+		text = strings.TrimSpace(text)
+		return text == "" || text == "<nil>"
+	}
+	return false
 }
 
 func normalizedLegacyExclusionRules(value any) map[string]struct{} {
@@ -461,10 +534,20 @@ func verifyPlex(ctx context.Context, client *http.Client, values map[string]any,
 }
 
 func tautulliCommand(ctx context.Context, client *http.Client, base *url.URL, apiKey, command string, target any) error {
+	return tautulliCommandWithParams(ctx, client, base, apiKey, command, nil, target)
+}
+
+func tautulliCommandWithParams(ctx context.Context, client *http.Client, base *url.URL, apiKey, command string, params url.Values, target any) error {
 	endpoint := integrationEndpoint(base, "api/v2")
 	query := endpoint.Query()
 	query.Set("apikey", apiKey)
 	query.Set("cmd", command)
+	for key, values := range params {
+		query.Del(key)
+		for _, value := range values {
+			query.Add(key, value)
+		}
+	}
 	endpoint.RawQuery = query.Encode()
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {

--- a/manager/internal/manager/integration_test.go
+++ b/manager/internal/manager/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -466,9 +467,17 @@ func TestTautulliDiscoveryReturnsSanitizedChoicesWithoutEmailOrSecrets(t *testin
 			}
 		case "get_users":
 			data = []any{
-				map[string]any{"user_id": "1", "friendly_name": "Fictional Admin", "email": "private-admin@example.org", "is_active": 1, "do_notify": 1, "is_admin": 1},
+				map[string]any{"user_id": "1", "friendly_name": "Fictional Admin", "is_active": 1, "do_notify": 1, "is_admin": 1},
 				map[string]any{"user_id": "2", "username": "viewer", "email": "private-viewer@example.org", "is_active": 0, "do_notify": 1},
 			}
+		case "get_users_table":
+			if r.URL.Query().Get("start") != "0" || r.URL.Query().Get("length") != strconv.Itoa(maximumDiscoveryChoices) {
+				http.Error(w, "invalid table window", http.StatusBadRequest)
+				return
+			}
+			data = map[string]any{"data": []any{
+				map[string]any{"user_id": "1", "friendly_name": "Fictional Admin", "email": "private-admin@example.org", "is_active": 1, "do_notify": 1},
+			}}
 		default:
 			http.Error(w, "unsupported", http.StatusBadRequest)
 			return

--- a/manager/internal/manager/server.go
+++ b/manager/internal/manager/server.go
@@ -230,7 +230,7 @@ func (s *Server) staticHandler() http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Cache-Control", "no-store")
 		files.ServeHTTP(w, r)
 	})
 }

--- a/manager/internal/manager/server_test.go
+++ b/manager/internal/manager/server_test.go
@@ -85,6 +85,9 @@ func TestStaticRootServesIndexWithoutRedirect(t *testing.T) {
 	if !strings.Contains(response.Body.String(), "TautWeekly Manager") {
 		t.Fatal("static root did not serve the embedded application shell")
 	}
+	if cache := response.Header().Get("Cache-Control"); cache != "no-store" {
+		t.Fatalf("static application cache policy: got %q, want no-store", cache)
+	}
 }
 
 func TestServerNormalizesRelativeRuntimePaths(t *testing.T) {

--- a/manager/internal/manager/web/app.css
+++ b/manager/internal/manager/web/app.css
@@ -59,4 +59,4 @@
 .manual-send-mode-field select{border-color:var(--line-strong);font:inherit}
 .choice-row.legacy-exclusion{cursor:default;border-color:rgba(229,160,13,.28);background:linear-gradient(110deg,rgba(229,160,13,.065),var(--surface) 48%)}
 .choice-row.legacy-exclusion input:disabled{cursor:not-allowed;opacity:1}
-.discovery-excluded-count{color:rgba(255,122,114,.48);font-weight:750}
+.discovery-selected-count{color:var(--gold-bright);font-weight:750}.discovery-excluded-count{color:rgba(255,122,114,.48);font-weight:750}

--- a/manager/internal/manager/web/app.js
+++ b/manager/internal/manager/web/app.js
@@ -688,6 +688,11 @@ function setListField(name, values) {
   if (input) input.value = [...new Set(values)].join(", ");
 }
 
+function savedListField(name) {
+  const field = (state.editor?.fields || []).find((candidate) => candidate.name === name);
+  return Array.isArray(field?.value) ? field.value.map((value) => String(value).trim()).filter(Boolean) : [];
+}
+
 function renderDiscoveredLibraries() {
   const container = byId("discovery-libraries");
   container.replaceChildren();
@@ -723,16 +728,7 @@ function renderDiscoveredUsers() {
   container.replaceChildren();
   const users = state.discovery?.users || [];
   const configured = new Set(currentListField("ExcludedUserIds"));
-  const excludedCount = users.filter((item) => configured.has(item.id) || item.legacyRuleExcluded === true).length;
-  const count = byId("discovery-user-count");
-  count.replaceChildren(document.createTextNode(`${users.length} found`));
-  if (excludedCount > 0) {
-    count.append(document.createTextNode(" ● "));
-    const excluded = document.createElement("span");
-    excluded.className = "discovery-excluded-count";
-    excluded.textContent = `${excludedCount} excluded`;
-    count.append(excluded);
-  }
+  renderDiscoveryUserCount(users);
   const orderedUsers = [...users].sort((left, right) => {
     const leftExcluded = configured.has(left.id) || left.legacyRuleExcluded === true;
     const rightExcluded = configured.has(right.id) || right.legacyRuleExcluded === true;
@@ -763,10 +759,26 @@ function renderDiscoveredUsers() {
         .filter((choice) => !choice.disabled || choice.dataset.configuredId === "true")
         .map((choice) => choice.dataset.choiceId);
       setListField("ExcludedUserIds", [...unknown, ...known]);
+      renderDiscoveryUserCount(users);
     });
     label.append(input, copy);
     container.append(label);
   }
+}
+
+function renderDiscoveryUserCount(users = state.discovery?.users || []) {
+  const current = new Set(currentListField("ExcludedUserIds"));
+  const saved = new Set(savedListField("ExcludedUserIds"));
+  const changed = users.some((item) => current.has(item.id) !== saved.has(item.id));
+  const effective = users.filter((item) => current.has(item.id) || item.legacyRuleExcluded === true).length;
+  const count = byId("discovery-user-count");
+  count.replaceChildren(document.createTextNode(`${users.length} found`));
+  if (effective === 0) return;
+  count.append(document.createTextNode(" ● "));
+  const status = document.createElement("span");
+  status.className = changed ? "discovery-selected-count" : "discovery-excluded-count";
+  status.textContent = `${effective} ${changed ? "selected" : "excluded"}`;
+  count.append(status);
 }
 
 function renderUserDatalist() {

--- a/manager/testdata/browser-qa/README.md
+++ b/manager/testdata/browser-qa/README.md
@@ -10,10 +10,12 @@ a connection. Each writes one sanitized structured result. The fixture contains
 no network, SMTP, browser-launch, or scheduler operation.
 
 `mock-tautulli.mjs` is an optional loopback-only companion for interactive
-browser QA. It exposes exactly the three read-only Tautulli discovery commands
+browser QA. It exposes exactly the four read-only Tautulli discovery commands
 used by the Manager and returns three fictional libraries and 78 fictional
-users. Two users match the fixture's legacy email exclusions so the retained,
-checked exclusion presentation can be verified without exposing real addresses.
+users. Its primary user response omits two addresses so the bounded
+`get_users_table` compatibility fallback is exercised. Those two users match
+the fixture's legacy email exclusions, allowing the retained, checked exclusion
+presentation to be verified without exposing real addresses.
 
 Browser QA copies these files to an ignored temporary directory and renames
 `fixture-config.json` to `config.json`. The temporary root and Manager data are

--- a/manager/testdata/browser-qa/mock-tautulli.mjs
+++ b/manager/testdata/browser-qa/mock-tautulli.mjs
@@ -38,7 +38,19 @@ const server = http.createServer((request, response) => {
       data = users.map(({ user_id, friendly_name }) => ({ user_id, friendly_name }));
       break;
     case "get_users":
-      data = users;
+      data = users.map((user, index) => {
+        if (index > 1) return user;
+        const { email: _email, ...withoutEmail } = user;
+        return withoutEmail;
+      });
+      break;
+    case "get_users_table":
+      if (target.searchParams.get("start") !== "0" || target.searchParams.get("length") !== "2000") {
+        response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+        response.end("invalid fixture table window");
+        return;
+      }
+      data = { data: users };
       break;
     default:
       response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });

--- a/scripts/test-manager-accessibility.py
+++ b/scripts/test-manager-accessibility.py
@@ -250,8 +250,10 @@ def main() -> int:
         failures.append("legacy direct Plex omissions have no guided completion message")
     if "legacyRuleExcluded" not in javascript or "Excluded by existing config" not in javascript:
         failures.append("legacy email exclusions are not represented in guided delivery choices")
-    if 'excluded.className = "discovery-excluded-count"' not in javascript or "rgba(255,122,114,.48)" not in css:
+    if 'status.className = changed ? "discovery-selected-count" : "discovery-excluded-count"' not in javascript or "rgba(255,122,114,.48)" not in css:
         failures.append("guided delivery choices do not show the requested effective exclusion count")
+    if 'status.textContent = `${effective} ${changed ? "selected" : "excluded"}`' not in javascript or ".discovery-selected-count{color:var(--gold-bright)" not in css:
+        failures.append("guided delivery choices do not distinguish unsaved selections from saved exclusions")
     if "const orderedUsers = [...users].sort" not in javascript or "leftExcluded ? -1 : 1" not in javascript:
         failures.append("configured delivery exclusions are not grouped visibly at the top of discovered users")
     if ".user-combobox>input" not in css or ".manual-send-mode-field select{border-color:var(--line-strong)" not in css:


### PR DESCRIPTION
## What changed

- recover legacy `ExcludedEmails` matches through a bounded
  `get_users_table` fallback when Tautulli omits addresses from `get_users`
- keep matching users visible, checked, grouped first, and privacy-sanitized
- show unsaved checkbox state as a gold **selected** count and saved state as a
  soft-red **excluded** count
- serve embedded Manager assets with `Cache-Control: no-store` so upgrades
  cannot retain stale UI code
- add v0.12.6 changelog and release notes

## Root cause

The primary Tautulli user response is not consistent across maintained
installations. When it omitted email fields, the Manager could not privately
reconcile older email-based exclusions with the guided ID roster. The frontend
also described the effective checked total only as persisted exclusions, so it
did not distinguish an unsaved selection.

## User impact

Previously excluded recipients remain visibly checked after an update, without
exposing addresses to the browser. New checkbox choices update the roster
summary immediately and become persisted exclusions after validation and save.

## Validation

- `go test ./...` and `go vet ./...` in `manager/`
- installer tests/vet (all runnable tests; the local Codex shell-folder
  assertion is unavailable in this desktop account and is delegated to the
  Windows CI runner)
- Manager cross-builds: Windows, Linux, macOS, FreeBSD on amd64/arm64
- repository, documentation, accessibility, and embedded JavaScript validation
- desktop browser QA with 78 fictional users
- 390x844 mobile QA with no horizontal overflow
- verified selected gold and excluded `rgba(255, 122, 114, 0.48)` states
