### PR TITLE
fix: recover Windows Start menu paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.7] - 2026-08-15
+
+### Fixed
+
+- Resolved the per-user Windows Start-menu folder through the native Shell API
+  instead of a PowerShell COM lookup. If Windows does not return a usable
+  known-folder path, Setup now uses a bounded per-user `APPDATA`/`USERPROFILE`
+  fallback so an otherwise valid update can finish without touching private
+  configuration or history.
+
 ## [0.12.6] - 2026-08-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   known-folder path, Setup now uses a bounded per-user `APPDATA`/`USERPROFILE`
   fallback so an otherwise valid update can finish without touching private
   configuration or history.
+- Recovered an existing installer-owned application folder from its registered
+  uninstaller or icon when the primary Windows `InstallLocation` value is
+  missing or stale, so updates preselect the current folder without scanning
+  arbitrary user directories.
 
 ## [0.12.6] - 2026-08-15
 

--- a/docs/releases/v0.12.7.md
+++ b/docs/releases/v0.12.7.md
@@ -1,0 +1,39 @@
+# TautWeekly for Plex v0.12.7
+
+v0.12.7 is a focused Windows Setup hotfix for profiles where Windows returns an
+empty or invalid per-user **Programs** shell-folder path. In affected v0.12.5
+and v0.12.6 updates, Setup stopped before creating Start-menu shortcuts while
+preserving the existing installation, configuration, and history.
+
+## Finish updates on affected Windows profiles
+
+Setup now resolves the current user's Start-menu Programs folder through the
+native Windows Shell API instead of a PowerShell COM lookup. If Windows still
+does not provide a usable path, Setup uses a bounded fallback derived from the
+current user's absolute `APPDATA` or `USERPROFILE` path.
+
+The fallback is limited to the current user's standard Start-menu hierarchy.
+It does not inspect another account, use a public Desktop, or change the
+selected application and private-data directories.
+
+## Update from v0.12.6 or the interrupted update
+
+1. Download `TautWeekly-Setup.exe` and `SHA256SUMS.txt` from this release.
+2. Verify the EXE against `SHA256SUMS.txt`.
+3. Run Setup again and confirm **Update** for the preselected installation.
+4. Open the Manager and confirm the existing configuration, history, and
+   schedule state are present.
+
+No manual cleanup or reconfiguration is required after the reported
+`resolve Windows Start menu` failure. The failed attempt stopped safely before
+removing private state.
+
+## Validation and limitations
+
+Release validation covers the native and fallback shell-folder paths, Manager
+and installer unit tests and vetting, an isolated Windows install/update/icon/
+uninstall lifecycle, release archive reproducibility, and maintained Manager
+cross-builds for Windows, Linux, macOS, and FreeBSD on amd64 and arm64.
+
+The Setup executable remains unsigned. Windows SmartScreen may identify it as
+an unknown publisher; verify the download against `SHA256SUMS.txt`.

--- a/docs/releases/v0.12.7.md
+++ b/docs/releases/v0.12.7.md
@@ -16,6 +16,14 @@ The fallback is limited to the current user's standard Start-menu hierarchy.
 It does not inspect another account, use a public Desktop, or change the
 selected application and private-data directories.
 
+Setup also preselects an existing installer-owned application folder more
+reliably. If the primary `InstallLocation` registry value is missing or stale,
+it can recover the same validated folder from the registered uninstaller or
+application icon. Arbitrary folders are never accepted from registry data: the
+candidate must contain TautWeekly installer metadata or a verified portable
+release manifest. Legacy BAT-only folders that have never been migrated still
+require one explicit selection.
+
 ## Update from v0.12.6 or the interrupted update
 
 1. Download `TautWeekly-Setup.exe` and `SHA256SUMS.txt` from this release.

--- a/installer/cmd/tautweekly-setup/windows.go
+++ b/installer/cmd/tautweekly-setup/windows.go
@@ -44,6 +44,7 @@ var (
 	shell32           = syscall.NewLazyDLL("shell32.dll")
 	browseForFolder   = shell32.NewProc("SHBrowseForFolderW")
 	getFolderPath     = shell32.NewProc("SHGetPathFromIDListW")
+	getSpecialFolder  = shell32.NewProc("SHGetFolderPathW")
 	ole32             = syscall.NewLazyDLL("ole32.dll")
 	coTaskMemFree     = ole32.NewProc("CoTaskMemFree")
 	buttonYesNo       = uintptr(0x00000004)
@@ -290,6 +291,7 @@ func unregisterUninstaller() error {
 
 var (
 	resolveWindowsSpecialFolder = windowsSpecialFolder
+	queryWindowsSpecialFolder   = nativeWindowsSpecialFolder
 	writeWindowsShortcut        = createShortcut
 )
 
@@ -337,18 +339,69 @@ func createShortcuts(opts options, logger *log.Logger) error {
 }
 
 func windowsSpecialFolder(name string) (string, error) {
-	script := `$folder=(New-Object -ComObject WScript.Shell).SpecialFolders.Item($env:TAUTWEEKLY_SPECIAL_FOLDER);if([string]::IsNullOrWhiteSpace($folder)){exit 2};[Console]::Out.Write($folder)`
-	command := hiddenCommand("powershell.exe", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script)
-	command.Env = append(os.Environ(), "TAUTWEEKLY_SPECIAL_FOLDER="+name)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("resolve %s shell folder: %w: %s", name, err, strings.TrimSpace(string(output)))
+	path, nativeErr := queryWindowsSpecialFolder(name)
+	if cleaned, ok := cleanAbsoluteWindowsPath(path); ok {
+		return cleaned, nil
 	}
-	path := strings.TrimSpace(string(output))
+	if fallback, ok := fallbackWindowsSpecialFolder(name); ok {
+		return fallback, nil
+	}
+	if nativeErr != nil {
+		return "", fmt.Errorf("resolve %s shell folder: %w", name, nativeErr)
+	}
+	return "", fmt.Errorf("resolve %s shell folder: Windows returned an invalid path", name)
+}
+
+func nativeWindowsSpecialFolder(name string) (string, error) {
+	var folderID uintptr
+	switch name {
+	case "Programs":
+		folderID = 0x0002 // CSIDL_PROGRAMS
+	case "Desktop":
+		folderID = 0x0010 // CSIDL_DESKTOPDIRECTORY
+	default:
+		return "", fmt.Errorf("unsupported Windows shell folder %q", name)
+	}
+	if err := getSpecialFolder.Find(); err != nil {
+		return "", fmt.Errorf("load SHGetFolderPathW: %w", err)
+	}
+	buffer := make([]uint16, 260) // SHGetFolderPathW is defined for MAX_PATH.
+	result, _, callErr := getSpecialFolder.Call(
+		0,
+		folderID,
+		0,
+		0, // SHGFP_TYPE_CURRENT
+		uintptr(unsafe.Pointer(&buffer[0])),
+	)
+	if result != 0 {
+		return "", fmt.Errorf("SHGetFolderPathW returned HRESULT 0x%08x: %v", uint32(result), callErr)
+	}
+	return syscall.UTF16ToString(buffer), nil
+}
+
+func fallbackWindowsSpecialFolder(name string) (string, bool) {
+	switch name {
+	case "Programs":
+		if appData, ok := cleanAbsoluteWindowsPath(os.Getenv("APPDATA")); ok {
+			return filepath.Join(appData, "Microsoft", "Windows", "Start Menu", "Programs"), true
+		}
+		if profile, ok := cleanAbsoluteWindowsPath(os.Getenv("USERPROFILE")); ok {
+			return filepath.Join(profile, "AppData", "Roaming", "Microsoft", "Windows", "Start Menu", "Programs"), true
+		}
+	case "Desktop":
+		if profile, ok := cleanAbsoluteWindowsPath(os.Getenv("USERPROFILE")); ok {
+			return filepath.Join(profile, "Desktop"), true
+		}
+	}
+	return "", false
+}
+
+func cleanAbsoluteWindowsPath(path string) (string, bool) {
+	path = strings.TrimSpace(path)
 	if path == "" || !filepath.IsAbs(path) {
-		return "", fmt.Errorf("resolve %s shell folder: Windows returned an invalid path", name)
+		return "", false
 	}
-	return filepath.Clean(path), nil
+	return filepath.Clean(path), true
 }
 
 func createShortcut(destination, target, arguments, workingDirectory, icon string) error {

--- a/installer/cmd/tautweekly-setup/windows.go
+++ b/installer/cmd/tautweekly-setup/windows.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -116,19 +117,77 @@ func chooseInstallDirectory(initial string) (string, bool, error) {
 }
 
 func preferredInstallDirectory(fallback string) string {
-	command := hiddenCommand("reg.exe", "query", `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\TautWeekly`, "/v", "InstallLocation")
-	output, err := command.CombinedOutput()
+	for _, registered := range []struct {
+		name      string
+		directory func(string) string
+	}{
+		{name: "InstallLocation", directory: registeredInstallLocation},
+		{name: "UninstallString", directory: registeredExecutableDirectory},
+		{name: "DisplayIcon", directory: registeredDisplayIconDirectory},
+	} {
+		value, err := readWindowsUninstallValue(registered.name)
+		if err != nil {
+			continue
+		}
+		candidate := registered.directory(value)
+		if filepath.IsAbs(candidate) && (installedApplication(candidate) || verifiedPortableApplication(candidate)) {
+			return filepath.Clean(candidate)
+		}
+	}
+	return fallback
+}
+
+const windowsUninstallRegistryKey = `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\TautWeekly`
+
+var readWindowsUninstallValue = windowsUninstallValue
+
+func windowsUninstallValue(name string) (string, error) {
+	output, err := hiddenCommand("reg.exe", "query", windowsUninstallRegistryKey, "/v", name).CombinedOutput()
 	if err != nil {
-		return fallback
+		return "", err
 	}
 	for _, line := range strings.Split(string(output), "\n") {
 		if index := strings.Index(line, "REG_SZ"); index >= 0 {
 			if value := strings.TrimSpace(line[index+len("REG_SZ"):]); value != "" {
-				return value
+				return value, nil
 			}
 		}
 	}
-	return fallback
+	return "", fmt.Errorf("Windows uninstall value %s is unavailable", name)
+}
+
+func registeredInstallLocation(value string) string {
+	return strings.Trim(strings.TrimSpace(value), `"`)
+}
+
+func registeredExecutableDirectory(value string) string {
+	executable := strings.TrimSpace(value)
+	if strings.HasPrefix(executable, `"`) {
+		executable = strings.TrimPrefix(executable, `"`)
+		if closing := strings.Index(executable, `"`); closing >= 0 {
+			executable = executable[:closing]
+		}
+	} else if separator := strings.IndexAny(executable, " \t"); separator >= 0 {
+		executable = executable[:separator]
+	}
+	if executable == "" {
+		return ""
+	}
+	return filepath.Dir(executable)
+}
+
+func registeredDisplayIconDirectory(value string) string {
+	icon := strings.TrimSpace(value)
+	if comma := strings.LastIndex(icon, ","); comma >= 0 {
+		if _, err := strconv.Atoi(strings.TrimSpace(icon[comma+1:])); err == nil {
+			icon = icon[:comma]
+		}
+	}
+	icon = strings.Trim(strings.TrimSpace(icon), `"`)
+	if icon == "" {
+		return ""
+	}
+	return filepath.Dir(icon)
 }
 
 func hiddenCommand(name string, args ...string) *exec.Cmd {
@@ -262,7 +321,7 @@ func showMessage(title, message string, style uintptr) (uintptr, error) {
 
 func registerUninstaller(opts options) error {
 	uninstaller := filepath.Join(opts.installDir, "TautWeekly-Uninstall.exe")
-	key := `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\TautWeekly`
+	key := windowsUninstallRegistryKey
 	values := [][]string{
 		{"add", key, "/v", "DisplayName", "/t", "REG_SZ", "/d", productName, "/f"},
 		{"add", key, "/v", "DisplayVersion", "/t", "REG_SZ", "/d", version, "/f"},
@@ -282,7 +341,7 @@ func registerUninstaller(opts options) error {
 }
 
 func unregisterUninstaller() error {
-	output, err := hiddenCommand("reg.exe", "delete", `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\TautWeekly`, "/f").CombinedOutput()
+	output, err := hiddenCommand("reg.exe", "delete", windowsUninstallRegistryKey, "/f").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("unregister uninstaller: %w: %s", err, output)
 	}

--- a/installer/cmd/tautweekly-setup/windows_test.go
+++ b/installer/cmd/tautweekly-setup/windows_test.go
@@ -53,6 +53,46 @@ func TestWindowsSpecialFolderReturnsAbsolutePaths(t *testing.T) {
 	}
 }
 
+func TestWindowsSpecialFolderFallsBackToPerUserPaths(t *testing.T) {
+	root := t.TempDir()
+	appData := filepath.Join(root, "AppData", "Roaming")
+	profile := filepath.Join(root, "Profile")
+	originalQuery := queryWindowsSpecialFolder
+	t.Cleanup(func() { queryWindowsSpecialFolder = originalQuery })
+	queryWindowsSpecialFolder = func(string) (string, error) {
+		return "", errors.New("shell folder unavailable")
+	}
+	t.Setenv("APPDATA", appData)
+	t.Setenv("USERPROFILE", profile)
+
+	tests := map[string]string{
+		"Programs": filepath.Join(appData, "Microsoft", "Windows", "Start Menu", "Programs"),
+		"Desktop":  filepath.Join(profile, "Desktop"),
+	}
+	for name, want := range tests {
+		got, err := windowsSpecialFolder(name)
+		if err != nil {
+			t.Fatalf("resolve %s through fallback: %v", name, err)
+		}
+		if !samePath(got, want) {
+			t.Fatalf("%s fallback = %s, want %s", name, got, want)
+		}
+	}
+}
+
+func TestWindowsSpecialFolderRejectsInvalidNativeAndFallbackPaths(t *testing.T) {
+	originalQuery := queryWindowsSpecialFolder
+	t.Cleanup(func() { queryWindowsSpecialFolder = originalQuery })
+	queryWindowsSpecialFolder = func(string) (string, error) {
+		return "relative", nil
+	}
+	t.Setenv("APPDATA", "")
+	t.Setenv("USERPROFILE", "")
+	if _, err := windowsSpecialFolder("Programs"); err == nil {
+		t.Fatal("invalid native and fallback paths were accepted")
+	}
+}
+
 func TestCreateShortcutsUsesRedirectedDesktop(t *testing.T) {
 	root := t.TempDir()
 	programs := filepath.Join(root, "Programs")

--- a/installer/cmd/tautweekly-setup/windows_test.go
+++ b/installer/cmd/tautweekly-setup/windows_test.go
@@ -93,6 +93,77 @@ func TestWindowsSpecialFolderRejectsInvalidNativeAndFallbackPaths(t *testing.T) 
 	}
 }
 
+func TestPreferredInstallDirectoryUsesValidatedInstallLocation(t *testing.T) {
+	installed := filepath.Join(t.TempDir(), "Custom TautWeekly")
+	writeInstallerMarker(t, installed)
+	stubWindowsUninstallValues(t, map[string]string{"InstallLocation": installed})
+
+	if got := preferredInstallDirectory(filepath.Join(t.TempDir(), "fallback")); !samePath(got, installed) {
+		t.Fatalf("preferred install directory = %s, want %s", got, installed)
+	}
+}
+
+func TestPreferredInstallDirectoryRecoversFromRegisteredUninstaller(t *testing.T) {
+	installed := filepath.Join(t.TempDir(), "Custom TautWeekly With Spaces")
+	writeInstallerMarker(t, installed)
+	stubWindowsUninstallValues(t, map[string]string{
+		"InstallLocation": filepath.Join(t.TempDir(), "missing"),
+		"UninstallString": windowsQuote(filepath.Join(installed, "TautWeekly-Uninstall.exe")) + " --uninstall",
+	})
+
+	if got := preferredInstallDirectory(filepath.Join(t.TempDir(), "fallback")); !samePath(got, installed) {
+		t.Fatalf("recovered install directory = %s, want %s", got, installed)
+	}
+}
+
+func TestPreferredInstallDirectoryRecoversFromRegisteredIcon(t *testing.T) {
+	installed := filepath.Join(t.TempDir(), "Custom TautWeekly")
+	writeInstallerMarker(t, installed)
+	stubWindowsUninstallValues(t, map[string]string{
+		"DisplayIcon": windowsQuote(filepath.Join(installed, "tautweekly.ico")) + ",0",
+	})
+
+	if got := preferredInstallDirectory(filepath.Join(t.TempDir(), "fallback")); !samePath(got, installed) {
+		t.Fatalf("icon-derived install directory = %s, want %s", got, installed)
+	}
+}
+
+func TestPreferredInstallDirectoryRejectsUnownedRegistryPaths(t *testing.T) {
+	fallback := filepath.Join(t.TempDir(), "Programs", "TautWeekly")
+	stubWindowsUninstallValues(t, map[string]string{
+		"InstallLocation": t.TempDir(),
+		"UninstallString": windowsQuote(filepath.Join(t.TempDir(), "TautWeekly-Uninstall.exe")),
+		"DisplayIcon":     filepath.Join(t.TempDir(), "tautweekly.ico"),
+	})
+
+	if got := preferredInstallDirectory(fallback); !samePath(got, fallback) {
+		t.Fatalf("unowned registry path was accepted: got %s, want %s", got, fallback)
+	}
+}
+
+func stubWindowsUninstallValues(t *testing.T, values map[string]string) {
+	t.Helper()
+	original := readWindowsUninstallValue
+	t.Cleanup(func() { readWindowsUninstallValue = original })
+	readWindowsUninstallValue = func(name string) (string, error) {
+		value, ok := values[name]
+		if !ok {
+			return "", errors.New("registry value unavailable")
+		}
+		return value, nil
+	}
+}
+
+func writeInstallerMarker(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "INSTALL-METADATA.txt"), []byte("Version=test\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCreateShortcutsUsesRedirectedDesktop(t *testing.T) {
 	root := t.TempDir()
 	programs := filepath.Join(root, "Programs")

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -5,6 +5,7 @@ v1.9.0 Windows
 --------------
 - makes TautWeekly-Setup.exe and the loopback-only Manager the supported primary Windows install, configuration, verification, preview, test, schedule, update, and removal workflow
 - installs per Windows account into a selectable application directory with Desktop and Start Menu shortcuts, an installed uninstaller, and an external private Manager data directory
+- resolves the Start Menu through the native Windows Shell API with a bounded per-user fallback for profiles whose shell-folder lookup returns an invalid path
 - recognizes an installer-owned application as Update and a release-manifest-verified older portable folder as Migrate while refusing arbitrary non-empty directories
 - preserves config, credentials, delivery state, previews, logs, caches, custom assets, and Manager access/history across verified replacement and automatic rollback
 - opens trusted-local Windows sessions without a pairing token and provides an optional eight-character password lock, guarded secret reveal, sign-out, and local recovery shortcut

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -6,6 +6,7 @@ v1.9.0 Windows
 - makes TautWeekly-Setup.exe and the loopback-only Manager the supported primary Windows install, configuration, verification, preview, test, schedule, update, and removal workflow
 - installs per Windows account into a selectable application directory with Desktop and Start Menu shortcuts, an installed uninstaller, and an external private Manager data directory
 - resolves the Start Menu through the native Windows Shell API with a bounded per-user fallback for profiles whose shell-folder lookup returns an invalid path
+- preselects an existing installer-owned folder from validated Windows uninstall registration fields when the primary InstallLocation entry is missing or stale
 - recognizes an installer-owned application as Update and a release-manifest-verified older portable folder as Migrate while refusing arbitrary non-empty directories
 - preserves config, credentials, delivery state, previews, logs, caches, custom assets, and Manager access/history across verified replacement and automatic rollback
 - opens trusted-local Windows sessions without a pairing token and provides an optional eight-character password lock, guarded secret reveal, sign-out, and local recovery shortcut


### PR DESCRIPTION
## What changed

- resolve the current user's Programs and Desktop folders with the native Windows Shell API instead of PowerShell/WScript COM
- fall back only to bounded absolute per-user APPDATA or USERPROFILE paths when Windows returns an unusable known-folder path
- add regression coverage for empty/invalid native shell-folder results
- document the interrupted-update recovery path for v0.12.7

## Root cause

The v0.12.5/v0.12.6 installer made Start-menu shortcut creation mandatory but obtained the Programs folder through a PowerShell COM lookup. Some Windows 10 profiles return an empty value from that lookup, causing Setup to abort with `resolve Programs shell folder: Windows returned an invalid path` even though the installation and private data were otherwise valid.

## Validation

- installer `go test ./...` and `go test -tags uninstaller ./...`
- installer `go vet ./...` and `go vet -tags uninstaller ./...`
- Manager tests and vetting
- Windows/ Linux/ macOS/ FreeBSD Manager cross-builds on amd64 and arm64
- repository, branding, platform, link, docs, PowerShell, JavaScript, and accessibility validation
- reproducible v0.12.7 release archives and package contract/checksum validation
- Windows PowerShell 5.1 install/update/migration/icon/process-lock/uninstall lifecycle

## User impact

Users whose v0.12.5 or v0.12.6 update stopped at Start-menu resolution can rerun v0.12.7 Setup. Existing configuration, credentials, history, previews, diagnostics, schedule state, and Manager data remain preserved.
