### PR TITLE
fix: restore Mac Manager operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored macOS Docker Desktop Manager previews, test delivery, and manual
+  delivery by honoring the Manager's private operation snapshot and structured
+  result contract in the Mac runtime package.
+
 ## [0.15.0] - 2026-08-18
 
 ### Added

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -1,6 +1,10 @@
 TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 ================================
 
+v1.3.2 Portable
+---------------
+- restores Manager previews, test delivery, and manual delivery by honoring private operation snapshots and structured results
+
 v1.3.1 Portable
 ---------------
 - replaces image-only updates with verified host-package and image updates plus coordinated rollback

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -6,6 +6,10 @@
 
     [string]$ConfigPath = $(if (-not [string]::IsNullOrWhiteSpace([string]$env:TAUTWEEKLY_CONFIG)) { [string]$env:TAUTWEEKLY_CONFIG } else { "/data/config.json" }),
 
+    [switch]$NoOpen,
+
+    [string]$ResultPath = "",
+
     [switch]$ConfirmSendAll,
 
     [switch]$ConfirmWelcome
@@ -20,6 +24,86 @@ if ($PSVersionTable.PSVersion -lt [Version]"7.2") {
     throw "TautWeekly for Plex Mac Portable requires PowerShell 7.2 or newer. Found $($PSVersionTable.PSVersion)."
 }
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$script:TautWeeklyResultStartedAtUtc = [DateTime]::UtcNow
+$script:TautWeeklyResultWritten = $false
+$script:TautWeeklyResultWriting = $false
+$script:TautWeeklyResultSmtpAcceptedCount = 0
+$script:TautWeeklyResultSkippedCount = 0
+$script:TautWeeklyResultFailedCount = 0
+$script:TautWeeklyResultGeneratedPreviewFiles = New-Object System.Collections.Generic.List[string]
+$script:TautWeeklyResultDeliveryScope = switch ($Mode) {
+    "SendTest" { "test" }
+    "SendTestAll" { "test" }
+    "SendWelcome" { "welcome" }
+    "SendAll" { "production" }
+    default { "none" }
+}
+
+function Write-TautWeeklyStructuredResult {
+    param(
+        [ValidateSet("succeeded","partial","failed")]
+        [string]$Outcome
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ResultPath) -or
+        $script:TautWeeklyResultWritten -or
+        $script:TautWeeklyResultWriting) {
+        return
+    }
+
+    $script:TautWeeklyResultWriting = $true
+    $temporaryPath = ""
+    try {
+        $resolvedResultPath = [IO.Path]::GetFullPath($ResultPath)
+        $resultDirectory = [IO.Path]::GetDirectoryName($resolvedResultPath)
+        if ([string]::IsNullOrWhiteSpace($resultDirectory)) {
+            throw "Structured result directory is unavailable."
+        }
+        [IO.Directory]::CreateDirectory($resultDirectory) | Out-Null
+        $finishedAtUtc = [DateTime]::UtcNow
+        $durationMs = [Math]::Max(0, [int64]($finishedAtUtc - $script:TautWeeklyResultStartedAtUtc).TotalMilliseconds)
+        $safePreviewFiles = @(
+            $script:TautWeeklyResultGeneratedPreviewFiles |
+                ForEach-Object { [IO.Path]::GetFileName([string]$_) } |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                Sort-Object -Unique
+        )
+        $result = [ordered]@{
+            schemaVersion = 1
+            mode = [string]$Mode
+            outcome = $Outcome
+            deliveryScope = [string]$script:TautWeeklyResultDeliveryScope
+            startedAtUtc = $script:TautWeeklyResultStartedAtUtc.ToString("o")
+            finishedAtUtc = $finishedAtUtc.ToString("o")
+            durationMs = $durationMs
+            smtpAcceptedCount = [Math]::Max(0, [int]$script:TautWeeklyResultSmtpAcceptedCount)
+            skippedCount = [Math]::Max(0, [int]$script:TautWeeklyResultSkippedCount)
+            failedCount = [Math]::Max(0, [int]$script:TautWeeklyResultFailedCount)
+            generatedPreviewFiles = $safePreviewFiles
+        }
+        $temporaryPath = Join-Path $resultDirectory (".tautweekly-result-{0}.tmp" -f [Guid]::NewGuid().ToString("N"))
+        $json = $result | ConvertTo-Json -Depth 4 -Compress
+        [IO.File]::WriteAllText($temporaryPath, $json + [Environment]::NewLine, (New-Object Text.UTF8Encoding($false)))
+        Move-Item -LiteralPath $temporaryPath -Destination $resolvedResultPath -Force
+        $temporaryPath = ""
+        $script:TautWeeklyResultWritten = $true
+    }
+    catch {
+        Write-Warning "TautWeekly could not write the sanitized structured result."
+    }
+    finally {
+        if (-not [string]::IsNullOrWhiteSpace($temporaryPath) -and (Test-Path -LiteralPath $temporaryPath)) {
+            Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+        }
+        $script:TautWeeklyResultWriting = $false
+    }
+}
+
+trap {
+    Write-TautWeeklyStructuredResult -Outcome "failed"
+    exit 1
+}
 
 $ScriptRoot = $PSScriptRoot
 . (Join-Path $ScriptRoot "Smtp-Transport.ps1")
@@ -7732,8 +7816,10 @@ if ($Mode -eq "SendWelcome") {
         -PosterAssets $posterAssets `
         -HeroAssets $designHero
 
+    $script:TautWeeklyResultSmtpAcceptedCount = 1
     Mark-UserWelcomed -State $accessState -UserId $user.UserId
     Write-Log "Welcome email sent successfully to $($user.FriendlyName)."
+    Write-TautWeeklyStructuredResult -Outcome "succeeded"
     exit 0
 }
 
@@ -8301,6 +8387,7 @@ if ($Mode -eq "PreviewAll") {
 
     for ($i = 0; $i -lt $bundle.Variants.Count; $i++) {
         Set-Content -Path (Join-Path $previewDir $files[$i]) -Value $bundle.Variants[$i].Html -Encoding UTF8
+        $script:TautWeeklyResultGeneratedPreviewFiles.Add($files[$i])
     }
 
     $serverName = HtmlEncode (Get-ConfiguredServerName)
@@ -8339,6 +8426,7 @@ $($cards.ToString())
 
     $indexPath = Join-Path $previewDir "preview-all-00-INDEX.html"
     Set-Content -Path $indexPath -Value $indexHtml -Encoding UTF8
+    $script:TautWeeklyResultGeneratedPreviewFiles.Add("preview-all-00-INDEX.html")
 
     Write-Host ""
     Write-Host "Created all-email-type preview: $indexPath" -ForegroundColor Green
@@ -8347,6 +8435,7 @@ $($cards.ToString())
     if (-not [string]::IsNullOrWhiteSpace($publicUrl)) {
         Write-Host "Browser URL: $publicUrl" -ForegroundColor Cyan
     }
+    Write-TautWeeklyStructuredResult -Outcome "succeeded"
     exit 0
 }
 
@@ -8377,12 +8466,15 @@ if ($Mode -eq "SendTestAll") {
             -PosterAssets $variant.PosterAssets `
             -HeroAssets $variant.HeroAssets
 
+        $script:TautWeeklyResultSmtpAcceptedCount++
+
         if ($delaySeconds -gt 0 -and $i -lt ($bundle.Variants.Count - 1)) {
             Start-Sleep -Seconds $delaySeconds
         }
     }
 
     Write-Log "All six email-state tests were sent to TestEmail only."
+    Write-TautWeeklyStructuredResult -Outcome "succeeded"
     exit 0
 }
 
@@ -8398,6 +8490,7 @@ if ($Mode -eq "Preview") {
     $safeName = Get-SafeFilePart $result.User.FriendlyName
     $previewPath = Join-Path $OutputDir ("preview_{0}.html" -f $safeName)
     Set-Content -Path $previewPath -Value $result.Html -Encoding UTF8
+    $script:TautWeeklyResultGeneratedPreviewFiles.Add([IO.Path]::GetFileName($previewPath))
 
     Write-Host ""
     Write-Host "TAUTWEEKLY FOR PLEX PREVIEW"
@@ -8414,6 +8507,7 @@ if ($Mode -eq "Preview") {
     if (-not [string]::IsNullOrWhiteSpace($publicUrl)) {
         Write-Host "Browser URL: $publicUrl" -ForegroundColor Cyan
     }
+    Write-TautWeeklyStructuredResult -Outcome "succeeded"
     exit 0
 }
 
@@ -8438,7 +8532,9 @@ if ($Mode -eq "SendTest") {
         -PosterAssets $result.PosterAssets `
         -HeroAssets $activeDesignHero
 
+    $script:TautWeeklyResultSmtpAcceptedCount = 1
     Write-Log "Test email sent successfully."
+    Write-TautWeeklyStructuredResult -Outcome "succeeded"
     exit 0
 }
 
@@ -8462,6 +8558,7 @@ if ($Mode -eq "SendAll") {
             if (Should-SkipUser -User $user) {
                 Write-Log "Skipping $($user.FriendlyName) ($($user.UserId))."
                 $skipped++
+                $script:TautWeeklyResultSkippedCount = $skipped
                 continue
             }
 
@@ -8482,6 +8579,7 @@ if ($Mode -eq "SendAll") {
             }
 
             $sent++
+            $script:TautWeeklyResultSmtpAcceptedCount = $sent
             $sendDelay = 10
             if ($null -ne $Config.PSObject.Properties["SendDelaySeconds"]) {
                 $sendDelay = [Math]::Max(0, (Safe-Int $Config.SendDelaySeconds))
@@ -8493,6 +8591,7 @@ if ($Mode -eq "SendAll") {
         }
         catch {
             $failed++
+            $script:TautWeeklyResultFailedCount = $failed
             Write-Log "Send failed for user $($n.user_id): $($_.Exception.Message)" "ERROR"
         }
     }
@@ -8503,7 +8602,11 @@ if ($Mode -eq "SendAll") {
     Write-Host ("Skipped: {0}" -f $skipped)
     Write-Host ("Failed:  {0}" -f $failed)
 
-    if ($failed -gt 0) { exit 2 }
+    if ($failed -gt 0) {
+        Write-TautWeeklyStructuredResult -Outcome $(if ($sent -gt 0) { "partial" } else { "failed" })
+        exit 2
+    }
+    Write-TautWeeklyStructuredResult -Outcome "succeeded"
     exit 0
 }
 

--- a/platforms/mac-docker/app/bin/run-mode.sh
+++ b/platforms/mac-docker/app/bin/run-mode.sh
@@ -17,10 +17,24 @@ fi
 USER_ID=""
 CONFIRM_SEND_ALL=""
 CONFIRM_WELCOME=""
+NO_OPEN=""
+MANAGER_CONFIG=""
+MANAGER_RESULT=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --confirm-send-all) CONFIRM_SEND_ALL="-ConfirmSendAll" ;;
     --confirm-welcome) CONFIRM_WELCOME="-ConfirmWelcome" ;;
+    --no-open) NO_OPEN="-NoOpen" ;;
+    --manager-config)
+      [[ $# -ge 2 ]] || { echo "--manager-config requires a path." >&2; exit 64; }
+      MANAGER_CONFIG="$2"
+      shift
+      ;;
+    --manager-result)
+      [[ $# -ge 2 ]] || { echo "--manager-result requires a path." >&2; exit 64; }
+      MANAGER_RESULT="$2"
+      shift
+      ;;
     *)
       if [[ -z "$USER_ID" ]]; then USER_ID="$1"; else echo "Unexpected argument: $1" >&2; exit 64; fi
       ;;
@@ -28,6 +42,34 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 mkdir -p "$data_root/logs" "$data_root/output" "$data_root/assets"
+
+if [[ -n "$MANAGER_CONFIG" || -n "$MANAGER_RESULT" ]]; then
+  manager_root="$data_root/manager"
+  manager_config_name="${MANAGER_CONFIG#"$manager_root"/}"
+  manager_result_name="${MANAGER_RESULT#"$manager_root"/}"
+  manager_config_id=""
+  manager_result_id=""
+  if [[ "$MANAGER_CONFIG" == "$manager_root"/* &&
+        "$manager_config_name" =~ ^operation-([A-Za-z0-9_-]{16})\.config\.json$ ]]; then
+    manager_config_id="${BASH_REMATCH[1]}"
+  fi
+  if [[ "$MANAGER_RESULT" == "$manager_root"/* &&
+        "$manager_result_name" =~ ^operation-([A-Za-z0-9_-]{16})\.result\.json$ ]]; then
+    manager_result_id="${BASH_REMATCH[1]}"
+  fi
+  if [[ -z "$manager_config_id" || "$manager_config_id" != "$manager_result_id" ||
+        ! -f "$MANAGER_CONFIG" || -L "$MANAGER_CONFIG" ||
+        -e "$MANAGER_RESULT" || -L "$MANAGER_RESULT" ||
+        ! -d "$manager_root" || -L "$manager_root" ]]; then
+    echo "Manager operation paths are invalid." >&2
+    exit 64
+  fi
+  config_path="$MANAGER_CONFIG"
+elif [[ -n "$NO_OPEN" ]]; then
+  echo "--no-open is reserved for Manager operations." >&2
+  exit 64
+fi
+
 exec 9>"$data_root/.tautweekly-operation.lock"
 if ! flock -w 30 9; then
   echo "Another TautWeekly for Plex operation is already running. Try again after it finishes." >&2
@@ -35,6 +77,9 @@ if ! flock -w 30 9; then
 fi
 ARGS=( -NoLogo -NoProfile -NonInteractive -File "$app_root/TautWeekly.ps1" -Mode "$MODE" -ConfigPath "$config_path" )
 if [[ -n "$USER_ID" ]]; then ARGS+=( -UserId "$USER_ID" ); fi
+if [[ -n "$MANAGER_RESULT" ]]; then ARGS+=( -ResultPath "$MANAGER_RESULT" ); fi
+if [[ -z "$MANAGER_RESULT" && "$MODE" == "SendAll" ]]; then ARGS+=( -ResultPath "$data_root/last-run.json" ); fi
+if [[ -n "$NO_OPEN" ]]; then ARGS+=( "$NO_OPEN" ); fi
 if [[ -n "$CONFIRM_SEND_ALL" ]]; then ARGS+=( "$CONFIRM_SEND_ALL" ); fi
 if [[ -n "$CONFIRM_WELCOME" ]]; then ARGS+=( "$CONFIRM_WELCOME" ); fi
 exec pwsh "${ARGS[@]}"

--- a/scripts/test-platform-command-routing.sh
+++ b/scripts/test-platform-command-routing.sh
@@ -167,13 +167,18 @@ if command -v flock >/dev/null 2>&1; then
   manager_config="$test_root/data/manager/operation-$manager_id.config.json"
   manager_result="$test_root/data/manager/operation-$manager_id.result.json"
   printf '%s\n' '{}' >"$manager_config"
-  reset_calls
-  TAUTWEEKLY_APP_DIR=/virtual/app \
-  TAUTWEEKLY_DATA_DIR="$test_root/data" \
-  TAUTWEEKLY_CONFIG="$test_root/data/config.json" \
-    bash "$repo_root/platforms/nas-docker/app/bin/run-mode.sh" PreviewAll 17 \
-      --manager-config "$manager_config" --manager-result "$manager_result" --no-open
-  assert_call "pwsh -NoLogo -NoProfile -NonInteractive -File /virtual/app/TautWeekly.ps1 -Mode PreviewAll -ConfigPath $manager_config -UserId 17 -ResultPath $manager_result -NoOpen"
+  for manager_runtime_wrapper in \
+      "$repo_root/platforms/nas-docker/app/bin/run-mode.sh" \
+      "$repo_root/platforms/mac-docker/app/bin/run-mode.sh"; do
+    reset_calls
+    rm -f "$manager_result"
+    TAUTWEEKLY_APP_DIR=/virtual/app \
+    TAUTWEEKLY_DATA_DIR="$test_root/data" \
+    TAUTWEEKLY_CONFIG="$test_root/data/config.json" \
+      bash "$manager_runtime_wrapper" PreviewAll 17 \
+        --manager-config "$manager_config" --manager-result "$manager_result" --no-open
+    assert_call "pwsh -NoLogo -NoProfile -NonInteractive -File /virtual/app/TautWeekly.ps1 -Mode PreviewAll -ConfigPath $manager_config -UserId 17 -ResultPath $manager_result -NoOpen"
+  done
 
   if TAUTWEEKLY_APP_DIR=/virtual/app TAUTWEEKLY_DATA_DIR="$test_root/data" \
       bash "$repo_root/platforms/nas-docker/app/bin/run-mode.sh" PreviewAll 17 \

--- a/scripts/test-release-artifacts.ps1
+++ b/scripts/test-release-artifacts.ps1
@@ -40,6 +40,9 @@ function Get-ZipEntrySha256([IO.Compression.ZipArchiveEntry]$Entry) {
 }
 
 function Assert-RendererContract([string]$PackageName, [string]$Renderer) {
+    Assert-True ($Renderer.Contains('[string]$ResultPath = ""')) "$PackageName lacks the Manager structured-result path."
+    Assert-True ($Renderer.Contains('function Write-TautWeeklyStructuredResult')) "$PackageName lacks the Manager structured-result writer."
+    Assert-True ($Renderer.Contains('generatedPreviewFiles = $safePreviewFiles')) "$PackageName lacks sanitized Manager preview results."
     Assert-True ($Renderer.Contains('Get-OptionalStringProperty -InputObject $Row -Name "section_id"')) "$PackageName lacks the executable library predicate fix."
     Assert-True ($Renderer.Contains('$params.section_id = $sectionId')) "$PackageName lacks server-side selected-library scoping."
     Assert-True ($Renderer.Contains('$expectedSectionId = ([string]$ExpectedSectionId).Trim()')) "$PackageName lacks scoped recently-added row handling."
@@ -148,6 +151,7 @@ $expected = [ordered]@{
         'TautWeekly-nas-docker/app/Schedule-Time.ps1',
         'TautWeekly-nas-docker/app/healthcheck.sh',
         'TautWeekly-nas-docker/app/bin/run-as-user.sh',
+        'TautWeekly-nas-docker/app/bin/run-mode.sh',
         'TautWeekly-nas-docker/app/bin/run-script.sh',
         'TautWeekly-nas-docker/app/product-branding/favicon.ico',
         'TautWeekly-nas-docker/app/product-branding/tautweekly-app-icon-128.png',
@@ -164,6 +168,7 @@ $expected = [ordered]@{
         'TautWeekly-mac-docker/app/Smtp-Transport.ps1',
         'TautWeekly-mac-docker/app/Schedule-Time.ps1',
         'TautWeekly-mac-docker/app/bin/run-as-user.sh',
+        'TautWeekly-mac-docker/app/bin/run-mode.sh',
         'TautWeekly-mac-docker/app/bin/run-script.sh',
         'TautWeekly-mac-docker/manager/tautweekly-manager-linux-amd64',
         'TautWeekly-mac-docker/manager/tautweekly-manager-linux-arm64',
@@ -183,6 +188,7 @@ $expected = [ordered]@{
         'TautWeekly-linux/app/Smtp-Transport.ps1',
         'TautWeekly-linux/app/Schedule-Time.ps1',
         'TautWeekly-linux/app/bin/run-as-user.sh',
+        'TautWeekly-linux/app/bin/run-mode.sh',
         'TautWeekly-linux/app/bin/run-script.sh',
         'TautWeekly-linux/app/product-branding/favicon.ico',
         'TautWeekly-linux/app/product-branding/tautweekly-app-icon-128.png',
@@ -203,6 +209,7 @@ $expected = [ordered]@{
         'TautWeekly-freebsd-podman/app/Smtp-Transport.ps1',
         'TautWeekly-freebsd-podman/app/Schedule-Time.ps1',
         'TautWeekly-freebsd-podman/app/bin/run-as-user.sh',
+        'TautWeekly-freebsd-podman/app/bin/run-mode.sh',
         'TautWeekly-freebsd-podman/app/bin/run-script.sh',
         'TautWeekly-freebsd-podman/app/product-branding/favicon.ico',
         'TautWeekly-freebsd-podman/app/product-branding/tautweekly-app-icon-128.png',


### PR DESCRIPTION
## Summary

- accept and validate the Manager's private operation snapshot/result arguments in the macOS Docker runtime wrapper
- emit the same sanitized structured operation results as the maintained NAS/Linux renderer
- exercise the exact Manager command against both Mac and NAS wrappers and require the contract in release archives

Addresses #103.

## Validation

- scripts/test-platform-command-routing.sh - pass with mocks only
- scripts/validate-platforms.ps1 - pass
- scripts/validate-powershell.ps1 - 71 files pass
- git diff --check - pass

No real Tautulli, Plex, SMTP, or user configuration was contacted. Local archive compilation is deferred to CI because Go and ShellCheck are not installed in this workspace.