### PR TITLE
chore: prepare v0.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-08-18
+
 ### Fixed
 
 - Restored macOS Docker Desktop Manager previews, test delivery, and manual

--- a/docs/releases/v0.15.1.md
+++ b/docs/releases/v0.15.1.md
@@ -1,0 +1,30 @@
+# TautWeekly for Plex v0.15.1
+
+v0.15.1 restores Manager previews, TestEmail delivery, and manual delivery in
+the macOS Docker Desktop package. The Mac runtime now accepts the Manager's
+private operation snapshot and emits the same sanitized structured result used
+by the maintained NAS/Linux runtime.
+
+## Update existing Mac installations
+
+Back up private data, then run this from the extracted Mac package:
+
+```sh
+./tautweekly.sh update
+```
+
+Sign back in to the Manager and retry **Previews** and the controlled
+**TestEmail** check. No Docker Desktop or .NET reinstall, Plex/Tautulli
+metadata refresh, configuration replacement, or manual file patch is needed.
+
+## Scope and validation
+
+The defect was limited to the Mac package's operation wrapper and renderer.
+Windows, NAS/Compose, QNAP, Unraid, compatible Docker, native Linux, and
+FreeBSD packages already carried the required Manager operation contract.
+
+Release gates exercise the exact Manager command with mock paths against both
+Mac and NAS wrappers, boot-test the Mac image, validate PowerShell and shell
+source, build reproducible ZIP/TAR archives, and require the structured-result
+contract in every packaged renderer. Automated tests do not contact real Plex,
+Tautulli, SMTP, or user configuration.


### PR DESCRIPTION
## Summary

- promote the Mac Manager operations fix to v0.15.1
- add concise Mac update and verification guidance
- document that other maintained platform packages already have the required operation contract

Release follow-up to #105; addresses #103.

## Validation

- repository privacy and hygiene validation - pass
- documentation feature validation - pass
- relative link validation - pass
- git diff --check - pass