### PR TITLE
fix: restore Manager update and toggle interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Consolidated Manager build, package baseline, platform, edition, and release
+  layer health into the existing application and package status surface without
+  repeating identical release versions.
+
+### Fixed
+
+- Made the Windows verified-update view reconnect to the restarted Manager and
+  advance to current automatically instead of waiting for a manual refresh.
+- Made generated configuration switches fully clickable and preserved explicit
+  `false` values through the shared Manager API on every shipped package type.
+
 ## [0.15.1] - 2026-08-18
 
 ### Fixed

--- a/docs/gui-preview/app.css
+++ b/docs/gui-preview/app.css
@@ -60,6 +60,9 @@
 .choice-row.legacy-exclusion{cursor:default;border-color:rgba(229,160,13,.28);background:linear-gradient(110deg,rgba(229,160,13,.065),var(--surface) 48%)}
 .choice-row.legacy-exclusion input:disabled{cursor:not-allowed;opacity:.78}
 
+/* Generated boolean switches use a real label so their full visible surface is clickable. */
+.config-control-boolean .config-toggle{width:max-content;cursor:pointer;user-select:none}
+
 /* Capability-aware update preview mirrors the embedded Manager card. */
 .update-settings-panel{margin-bottom:1rem;padding:1.4rem;border:1px solid rgba(173,140,255,.36);border-radius:var(--radius);background:linear-gradient(145deg,rgba(173,140,255,.075),var(--surface))}
 .update-settings-panel .eyebrow{color:#c7b3ff}.update-settings-heading{display:flex;align-items:flex-start;justify-content:space-between;gap:1.5rem}.update-settings-heading>div{min-width:0}.update-settings-heading h2{margin:.45rem 0;font-size:1.25rem}.update-settings-heading p{margin:0;max-width:760px;color:var(--muted);font-size:.76rem;line-height:1.55}

--- a/docs/gui-preview/app.js
+++ b/docs/gui-preview/app.js
@@ -36,6 +36,7 @@ const guidedConfigFields = new Set(["IncludedLibraryIds", "ExcludedUserIds"]);
 const activeSecretReveals = new Map();
 let pendingSecretReveal = null;
 let sessionRecoveryPromise = null;
+let updateInstallPollTimer;
 
 function materializeMaterialIcon(svg) {
   const use = svg?.querySelector("use");
@@ -378,7 +379,7 @@ function renderStatus() {
   setText("next-run-utc", snapshot.schedule.nextRunUtc ? `Fictional UTC: ${formatDate(snapshot.schedule.nextRunUtc)}` : "The synthetic scheduler has no upcoming run.");
   setText("preview-count", snapshot.previewSummary);
   setText("sidebar-platform", `${titleCase(snapshot.platform)} · static preview`);
-  setText("about-platform", titleCase(snapshot.platform));
+  setText("update-platform", titleCase(snapshot.platform));
 }
 
 function renderDashboardGreeting(observedAtUtc) {
@@ -928,8 +929,9 @@ function createConfigControl(field) {
     input = document.createElement("input");
     input.type = "checkbox";
     input.checked = Boolean(field.value);
-    const toggle = document.createElement("span");
+    const toggle = document.createElement("label");
     toggle.className = "config-toggle";
+    toggle.htmlFor = id;
     toggle.append(input, document.createElement("span"));
     const stateLabel = document.createElement("em");
     stateLabel.textContent = input.checked ? "Enabled" : "Disabled";
@@ -2317,17 +2319,37 @@ function displayUpdateVersion(value, unavailable = "Not reported") {
   return value ? `v${value}` : unavailable;
 }
 
+function readableList(values) {
+  if (values.length < 2) return values[0] || "";
+  if (values.length === 2) return `${values[0]} and ${values[1]}`;
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+}
+
+function releaseLayerSummary(update) {
+  const managerVersion = update.managerVersion || "";
+  const layers = [
+    ["Application", update.applicationVersion],
+    ...(update.imageVersion ? [["Container image", update.imageVersion]] : []),
+    [update.packageLabel || "Host package", update.packageVersion],
+  ];
+  const matching = layers.filter(([, version]) => managerVersion && version === managerVersion).map(([label]) => label);
+  const different = layers.filter(([, version]) => version && version !== managerVersion).map(([label, version]) => `${label} ${displayUpdateVersion(version)}`);
+  const missing = layers.filter(([, version]) => !version).map(([label]) => `${label} not reported`);
+  const parts = [];
+  if (matching.length) parts.push(`${readableList(matching)} ${matching.length === 1 ? "matches" : "match"} Manager build`);
+  parts.push(...different, ...missing);
+  return parts.join(" · ") || "No release layers reported";
+}
+
 function renderUpdates() {
   const update = state.updates || {};
   const presentation = updateStatePresentation(update);
   setChip("update-settings-chip", state.updateChecking ? "Checking" : presentation.label, state.updateChecking ? "pending" : presentation.tone);
   setText("update-settings-summary", presentation.summary);
   setText("update-manager-version", displayUpdateVersion(update.managerVersion));
-  setText("update-application-version", displayUpdateVersion(update.applicationVersion));
-  setText("update-package-label", update.packageLabel || "Host package");
-  setText("update-package-version", displayUpdateVersion(update.packageVersion));
-  byId("update-image-version-row").hidden = !update.imageVersion;
-  setText("update-image-version", displayUpdateVersion(update.imageVersion, "Not applicable"));
+  setText("update-package-baseline", state.about?.packageVersion || "Synthetic baseline unavailable");
+  setText("update-platform", titleCase(state.status?.platform));
+  setText("update-release-layers", releaseLayerSummary(update));
   setText("update-host-adapter", update.hostAdapterState === "not-applicable" ? "Not applicable" : `${update.hostAdapterVersion ? `API ${update.hostAdapterVersion}` : "Not reported"} - ${titleCase(update.hostAdapterState)}`);
   setText("update-channel", titleCase(update.updateChannel || "stable"));
   setText("update-latest-version", displayUpdateVersion(update.latestStableVersion, "Not checked"));
@@ -2363,10 +2385,12 @@ function renderUpdates() {
   byId("update-install-confirm-row").hidden = !installAvailable;
   const installButton = byId("update-install-button");
   installButton.hidden = !installAvailable;
-  installButton.disabled = !installAvailable || !byId("update-install-confirm").checked || state.updateInstalling || update.installState === "running";
-  setSwappingButtonText("update-install-button", state.updateInstalling || update.installState === "running" ? "Simulated updater running" : "Simulate install");
-  byId("update-settings-message").textContent = update.installState === "running"
-    ? "The in-memory demo reports a running updater. No process, elevation prompt, or file change occurred. Reload to reset."
+  installButton.disabled = !installAvailable || !byId("update-install-confirm").checked || state.updateInstalling || ["starting", "running"].includes(update.installState);
+  setSwappingButtonText("update-install-button", state.updateInstalling || ["starting", "running"].includes(update.installState) ? "Simulated updater running" : "Simulate install");
+  byId("update-settings-message").textContent = ["starting", "running"].includes(update.installState)
+    ? "The in-memory demo is transitioning to the updated Manager automatically. No process, elevation prompt, or file change occurs."
+    : update.installState === "completed"
+      ? "The simulated Manager update completed and the combined package status refreshed automatically."
     : state.updateChecking
       ? "Refreshing bundled fictional release metadata. No network request is made."
       : "This static preview uses bundled fictional release metadata. Production normal health also performs no update-network request.";
@@ -2394,12 +2418,25 @@ async function installUpdate() {
   try {
     state.updates = await request("/api/v1/updates/install", { method: "POST", body: "{}" });
     setGlobalStatus("Verified updater simulation started.", true);
+    clearTimeout(updateInstallPollTimer);
+    updateInstallPollTimer = setTimeout(pollUpdateInstall, 250);
   } catch (error) {
     byId("update-settings-message").textContent = error.message;
   } finally {
     state.updateInstalling = false;
     renderUpdates();
   }
+}
+
+async function pollUpdateInstall() {
+  state.updates = await request("/api/v1/updates");
+  renderUpdates();
+  if (["starting", "running"].includes(state.updates.installState)) {
+    updateInstallPollTimer = setTimeout(pollUpdateInstall, 250);
+    return;
+  }
+  byId("update-install-confirm").checked = false;
+  setGlobalStatus("Simulated Manager update completed automatically.", true);
 }
 
 async function copyUpdateCommand() {
@@ -2411,8 +2448,6 @@ async function copyUpdateCommand() {
 }
 
 function renderAbout() {
-  setText("about-version", state.about.version || "Version unavailable");
-  setText("about-package", state.about.packageVersion || "Package version unavailable");
   const events = state.diagnostics?.events || [];
   setText("diagnostics-count", events.length ? `${events.length} fictional` : "No events");
   setText("diagnostics-retention", "Bundled demo events; reset on reload.");

--- a/docs/gui-preview/index.html
+++ b/docs/gui-preview/index.html
@@ -273,10 +273,11 @@
         <section class="update-settings-panel" id="update-settings-panel" aria-labelledby="update-settings-heading">
           <div class="update-settings-heading"><div><span class="eyebrow">Capability-aware update preview</span><h2 id="update-settings-heading">Application and package status</h2><p id="update-settings-summary">Reading a fictional local update result. This static preview never contacts a release service.</p></div><span class="state-chip pending" id="update-settings-chip">Unknown</span></div>
           <dl class="update-version-grid">
-            <div><dt>Running Manager</dt><dd id="update-manager-version">Not reported</dd></div>
-            <div><dt>Application</dt><dd id="update-application-version">Not reported</dd></div>
-            <div><dt id="update-package-label">Host package</dt><dd id="update-package-version">Not reported</dd></div>
-            <div id="update-image-version-row"><dt>Container image application</dt><dd id="update-image-version">Not applicable</dd></div>
+            <div><dt>Manager build</dt><dd id="update-manager-version">Not reported</dd></div>
+            <div><dt>Package baseline</dt><dd id="update-package-baseline">Not reported</dd></div>
+            <div><dt>Platform</dt><dd id="update-platform">Not reported</dd></div>
+            <div><dt>Edition</dt><dd id="update-edition">Package-neutral GUI Preview</dd></div>
+            <div><dt>Release layers</dt><dd id="update-release-layers">Not reported</dd></div>
             <div><dt>Host adapter</dt><dd id="update-host-adapter">Not applicable</dd></div>
             <div><dt>Update channel</dt><dd id="update-channel">Stable</dd></div>
             <div><dt>Latest stable</dt><dd id="update-latest-version">Not checked</dd></div>
@@ -295,7 +296,6 @@
           <article><span class="about-number">03</span><h2>Fictional secret controls</h2><p>Secret fields expose only a fixed demo placeholder. Values typed into password controls are discarded and never persisted.</p></article>
           <article><span class="about-number">04</span><h2>Delivery truthfulness</h2><p>Every check and operation is labeled synthetic or simulated; no SMTP acceptance or inbox delivery is asserted.</p></article>
         </div>
-        <dl class="build-details"><div><dt>Manager build</dt><dd id="about-version">Checking...</dd></div><div><dt>Package baseline</dt><dd id="about-package">Checking...</dd></div><div><dt>Platform</dt><dd id="about-platform">Checking...</dd></div><div><dt>Edition</dt><dd>Package-neutral GUI Preview</dd></div></dl>
         <div class="section-heading"><div><span class="eyebrow">Synthetic diagnostics</span><h2>Configuration diagnostics</h2></div><p>Fixed fictional events demonstrate the production layout and disappear when the page reloads.</p></div>
         <section class="diagnostics-panel" aria-labelledby="diagnostics-heading">
           <div class="panel-heading"><h2 id="diagnostics-heading">Setup and verification events</h2><small id="diagnostics-count">Checking</small></div>

--- a/docs/gui-preview/mock-api.js
+++ b/docs/gui-preview/mock-api.js
@@ -143,6 +143,7 @@
     scheduleOperation: null,
     scheduleStartedMS: 0,
     lockEnabled: false,
+    updateStartedMS: 0,
     update: {
       schemaVersion: 1,
       observedAtUtc: now(),
@@ -279,6 +280,22 @@
     return model.scheduleOperation;
   }
 
+  function finishUpdateIfReady() {
+    if (!model.updateStartedMS || model.update.installState !== "running") return;
+    if (Date.now() - model.updateStartedMS < 900) return;
+    const version = model.update.latestStableVersion;
+    Object.assign(model.update, {
+      observedAtUtc: now(),
+      state: "current",
+      managerVersion: version,
+      applicationVersion: version,
+      packageVersion: version,
+      updateAvailable: false,
+      installSupported: false,
+      installState: "completed",
+    });
+  }
+
   function json(payload, statusCode = 200) {
     return Promise.resolve(new Response(JSON.stringify(payload), { status: statusCode, headers: { "Content-Type": "application/json", "Cache-Control": "no-store" } }));
   }
@@ -296,6 +313,7 @@
     const body = bodyOf(init);
     finishOperationIfReady();
     finishScheduleIfReady();
+    finishUpdateIfReady();
 
     if (path === "/api/v1/setup") return json({ paired: true, authenticationRequired: false, pairingRequired: false });
     if (path === "/api/v1/auth/session" || path === "/api/v1/auth/login" || path === "/api/v1/auth/pair") return json({ authenticated: true, csrfToken: "synthetic-demo-token", expiresAtUtc: new Date(Date.now() + 86400000).toISOString() });
@@ -342,6 +360,7 @@
       return json(model.update);
     }
     if (path === "/api/v1/updates/install" && method === "POST") {
+      model.updateStartedMS = Date.now();
       model.update.installState = "running";
       model.update.observedAtUtc = now();
       return json(model.update, 202);

--- a/manager/internal/manager/server_test.go
+++ b/manager/internal/manager/server_test.go
@@ -91,6 +91,63 @@ func TestStaticRootServesIndexWithoutRedirect(t *testing.T) {
 	}
 }
 
+func TestBooleanConfigurationTogglesPersistAcrossPackageVariants(t *testing.T) {
+	tests := []struct {
+		kind string
+		mode string
+	}{
+		{packageKindWindows, runtimeModeWindows},
+		{packageKindMac, runtimeModeMac},
+		{packageKindNAS, runtimeModeNAS},
+		{packageKindQNAP, runtimeModeNAS},
+		{packageKindUnraid, runtimeModeNAS},
+		{packageKindCompatibleDocker, runtimeModeNAS},
+		{packageKindLinux, runtimeModeLinux},
+		{packageKindFreeBSD, runtimeModeNAS},
+	}
+	for _, test := range tests {
+		t.Run(test.kind, func(t *testing.T) {
+			root := integrationConfigRoot(t, "http://127.0.0.1:8181", "fictional-api-key", "", "")
+			server, err := New(Options{
+				DataDir:        t.TempDir(),
+				TautWeeklyRoot: root,
+				RuntimeRoot:    root,
+				Version:        "test",
+				RuntimeMode:    test.mode,
+				PackageKind:    test.kind,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, err := server.auth.newSession()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cookie := &http.Cookie{Name: sessionCookieName, Value: session.Token}
+			mutation := validConfigSaveRequest(t, ReadConfigEditor(root))
+			for _, name := range []string{"SmtpEnableSsl", "SmtpUseAuthentication", "DeletedItemCacheEnabled"} {
+				mutation.Values[name] = json.RawMessage(`false`)
+			}
+			body, err := json.Marshal(mutation)
+			if err != nil {
+				t.Fatal(err)
+			}
+			saved := mutationRequestForTest(server, http.MethodPut, "/api/v1/config", body, cookie, session.CSRFToken)
+			if saved.Code != http.StatusOK {
+				t.Fatalf("configuration save: got %d, body %s", saved.Code, saved.Body.String())
+			}
+			persisted := ReadConfigEditor(root)
+			for _, name := range []string{"SmtpEnableSsl", "SmtpUseAuthentication", "DeletedItemCacheEnabled"} {
+				field := editorField(t, persisted, name)
+				value, ok := field.Value.(bool)
+				if !ok || value {
+					t.Fatalf("%s did not persist false for %s: %#v", name, test.kind, field.Value)
+				}
+			}
+		})
+	}
+}
+
 func TestServerNormalizesRelativeRuntimePaths(t *testing.T) {
 	base := t.TempDir()
 	t.Chdir(base)

--- a/manager/internal/manager/updates_test.go
+++ b/manager/internal/manager/updates_test.go
@@ -386,11 +386,13 @@ func TestUpdateEndpointsRequireAuthenticationCSRFOriginAndAllowedHost(t *testing
 func TestWindowsInstallActionUsesOnlyInjectedVerifiedUpdaterWhenReady(t *testing.T) {
 	now := time.Date(2031, 4, 18, 16, 30, 0, 0, time.UTC)
 	currentNow := now
+	data := t.TempDir()
+	root := t.TempDir()
 	checker := &fixtureUpdateChecker{release: updateRelease{Version: "1.1.0", ReleaseNotesURL: stableReleaseBaseURL + "1.1.0"}}
 	installer := &fixtureUpdateInstaller{supported: true, result: make(chan error, 1)}
 	server, err := New(Options{
-		DataDir:                 t.TempDir(),
-		TautWeeklyRoot:          t.TempDir(),
+		DataDir:                 data,
+		TautWeeklyRoot:          root,
 		Version:                 "1.0.0",
 		RuntimeMode:             runtimeModeWindows,
 		PackageKind:             packageKindWindows,
@@ -425,6 +427,28 @@ func TestWindowsInstallActionUsesOnlyInjectedVerifiedUpdaterWhenReady(t *testing
 	}
 	installer.result <- nil
 	close(installer.result)
+	deadline := time.Now().Add(time.Second)
+	for server.updates.Status().InstallState != "completed" && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if state := server.updates.Status().InstallState; state != "completed" {
+		t.Fatalf("completed installer state: got %q", state)
+	}
+
+	restarted := newUpdateCoordinator(Options{
+		DataDir:        data,
+		TautWeeklyRoot: root,
+		Version:        "1.1.0",
+		RuntimeMode:    runtimeModeWindows,
+		PackageKind:    packageKindWindows,
+		PackageVersion: "1.1.0",
+		Now:            func() time.Time { return currentNow },
+		updateChecker:  checker,
+	})
+	afterRestart := restarted.Status()
+	if afterRestart.State != "current" || afterRestart.InstallState != "idle" || afterRestart.UpdateAvailable {
+		t.Fatalf("post-update restart status: %+v", afterRestart)
+	}
 }
 
 func TestUpdateCacheRejectsTamperedPrivateContent(t *testing.T) {

--- a/manager/internal/manager/web/app.css
+++ b/manager/internal/manager/web/app.css
@@ -63,6 +63,9 @@
 .choice-row.legacy-exclusion input:disabled{cursor:not-allowed;opacity:1}
 .discovery-selected-count{color:var(--gold-bright);font-weight:750}.discovery-excluded-count{color:rgba(255,122,114,.48);font-weight:750}
 
+/* Generated boolean switches use a real label so their full visible surface is clickable. */
+.config-control-boolean .config-toggle{width:max-content;cursor:pointer;user-select:none}
+
 /* Capability-aware update status keeps Internet checks explicit and host ownership visible. */
 .update-settings-panel{margin-bottom:1rem;padding:1.4rem;border:1px solid rgba(173,140,255,.36);border-radius:var(--radius);background:linear-gradient(145deg,rgba(173,140,255,.075),var(--surface))}
 .update-settings-panel .eyebrow{color:#c7b3ff}.update-settings-heading{display:flex;align-items:flex-start;justify-content:space-between;gap:1.5rem}.update-settings-heading>div{min-width:0}.update-settings-heading h2{margin:.45rem 0;font-size:1.25rem}.update-settings-heading p{margin:0;max-width:760px;color:var(--muted);font-size:.76rem;line-height:1.55}

--- a/manager/internal/manager/web/app.js
+++ b/manager/internal/manager/web/app.js
@@ -42,6 +42,10 @@ const guidedConfigFields = new Set(["IncludedLibraryIds", "ExcludedUserIds"]);
 const activeSecretReveals = new Map();
 let pendingSecretReveal = null;
 let sessionRecoveryPromise = null;
+let updateInstallPollTimer;
+let updateInstallExpectedVersion = "";
+let updateInstallSawDisconnect = false;
+let updateInstallPollDeadline = 0;
 
 function materializeMaterialIcon(svg) {
   const use = svg?.querySelector("use");
@@ -367,7 +371,7 @@ function renderCapabilities() {
     : mac
       ? "Docker Desktop publishes the Manager on 127.0.0.1 by default. Changing the bind address for trusted-LAN access still requires authentication; DNS hostnames must be allowlisted and TLS is expected beyond a trusted local network."
     : "The Manager accepts browser connections only from this computer and rejects unrecognized hostnames.");
-  setText("about-edition", nas ? "NAS / Container Manager" : linux ? "Native Linux Manager" : mac ? "macOS Docker Desktop Manager" : "Windows Manager");
+  setText("update-edition", nas ? "NAS / Container Manager" : linux ? "Native Linux Manager" : mac ? "macOS Docker Desktop Manager" : "Windows Manager");
   setText("about-secret-copy", service
     ? "Secrets stay hidden during normal reads. Revealing returns only the selected credential, requires administrator password re-authentication, and automatically clears from the page."
     : "Secrets stay hidden during normal reads. Revealing returns only the selected credential, uses password re-authentication when the optional lock is enabled, and automatically clears from the page.");
@@ -546,7 +550,7 @@ function renderStatus() {
   setText("next-run-utc", snapshot.schedule.nextRunUtc ? `UTC: ${formatDate(snapshot.schedule.nextRunUtc)}` : embeddedSchedule ? "The embedded scheduler has not reported a valid upcoming run." : "Task Scheduler has not reported an upcoming run.");
   setText("preview-count", snapshot.previewSummary);
   setText("sidebar-platform", `${titleCase(snapshot.platform)} · ${isNAS() ? "trusted LAN" : isLinuxService() ? "host loopback" : isMacDocker() ? "Mac loopback" : "local only"}`);
-  setText("about-platform", titleCase(snapshot.platform));
+  setText("update-platform", titleCase(snapshot.platform));
 }
 
 function renderDashboardGreeting(observedAtUtc) {
@@ -1127,8 +1131,9 @@ function createConfigControl(field) {
     input = document.createElement("input");
     input.type = "checkbox";
     input.checked = Boolean(field.value);
-    const toggle = document.createElement("span");
+    const toggle = document.createElement("label");
     toggle.className = "config-toggle";
+    toggle.htmlFor = id;
     toggle.append(input, document.createElement("span"));
     const stateLabel = document.createElement("em");
     stateLabel.textContent = input.checked ? "Enabled" : "Disabled";
@@ -2588,18 +2593,37 @@ function displayUpdateVersion(value, unavailable = "Not reported") {
   return value ? `v${value}` : unavailable;
 }
 
+function readableList(values) {
+  if (values.length < 2) return values[0] || "";
+  if (values.length === 2) return `${values[0]} and ${values[1]}`;
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+}
+
+function releaseLayerSummary(update) {
+  const managerVersion = update.managerVersion || state.about?.version || "";
+  const layers = [
+    ["Application", update.applicationVersion],
+    ...(update.imageVersion ? [["Container image", update.imageVersion]] : []),
+    [update.packageLabel || "Host package", update.packageVersion],
+  ];
+  const matching = layers.filter(([, version]) => managerVersion && version === managerVersion).map(([label]) => label);
+  const different = layers.filter(([, version]) => version && version !== managerVersion).map(([label, version]) => `${label} ${displayUpdateVersion(version)}`);
+  const missing = layers.filter(([, version]) => !version).map(([label]) => `${label} not reported`);
+  const parts = [];
+  if (matching.length) parts.push(`${readableList(matching)} ${matching.length === 1 ? "matches" : "match"} Manager build`);
+  parts.push(...different, ...missing);
+  return parts.join(" · ") || "No release layers reported";
+}
+
 function renderUpdates() {
   const update = state.updates || {};
   const presentation = updateStatePresentation(update);
   setChip("update-settings-chip", state.updateChecking || update.checkInProgress ? "Checking" : presentation.label, state.updateChecking || update.checkInProgress ? "pending" : presentation.tone);
   setText("update-settings-summary", presentation.summary);
-  setText("update-manager-version", displayUpdateVersion(update.managerVersion));
-  setText("update-application-version", displayUpdateVersion(update.applicationVersion));
-  setText("update-package-label", update.packageLabel || "Host package");
-  setText("update-package-version", displayUpdateVersion(update.packageVersion, "Not reported by this host package"));
-  const imageRow = byId("update-image-version-row");
-  imageRow.hidden = !update.imageVersion;
-  setText("update-image-version", displayUpdateVersion(update.imageVersion, "Not applicable"));
+  setText("update-manager-version", displayUpdateVersion(update.managerVersion || state.about?.version));
+  setText("update-package-baseline", state.about?.packageVersion || "Package baseline unavailable");
+  setText("update-platform", titleCase(state.status?.platform));
+  setText("update-release-layers", releaseLayerSummary(update));
   setText("update-host-adapter", update.hostAdapterState === "not-applicable"
     ? "Not applicable"
     : `${update.hostAdapterVersion ? `API ${update.hostAdapterVersion}` : "Not reported"} · ${titleCase(update.hostAdapterState)}`);
@@ -2647,11 +2671,14 @@ function renderUpdates() {
   installRow.hidden = !installAvailable;
   installButton.hidden = !installAvailable;
   installButton.disabled = !installAvailable || !byId("update-install-confirm").checked || state.updateInstalling || ["starting", "running"].includes(update.installState);
-  setSwappingButtonText("update-install-button", state.updateInstalling || ["starting", "running"].includes(update.installState) ? "Starting verified updater..." : "Install update");
+  setSwappingButtonText("update-install-button", state.updateInstalling ? "Starting verified updater..." : ["starting", "running"].includes(update.installState) ? "Verified updater running..." : "Install update");
 
   const message = byId("update-settings-message");
   if (state.updateChecking) message.textContent = "Contacting the fixed stable-release endpoint with an eight-second deadline. No application or package file is being changed.";
-  else if (state.updateInstalling || ["starting", "running"].includes(update.installState)) message.textContent = "The existing verified Windows updater is running. Approve the Windows administrator prompt if it appears; the Manager may restart after verification.";
+  else if (state.updateInstalling) message.textContent = "Starting the existing verified Windows updater. Approve the Windows administrator prompt if it appears.";
+  else if (["starting", "running"].includes(update.installState)) message.textContent = "The verified Windows updater is running. This page will reconnect and refresh automatically after the Manager restarts.";
+  else if (update.installState === "failed") message.textContent = "The verified Windows updater stopped before completing. Review the sanitized failure above, then check again before retrying.";
+  else if (update.installState === "completed") message.textContent = "The verified Windows updater completed. Refreshing local package status.";
   else if (backoffActive) message.textContent = `The next manual check is available after ${formatDate(update.nextCheckAllowedAtUtc)}. This bounded delay prevents repeated upstream requests.`;
   else if (update.lastFailure?.action === "check") message.textContent = "The last check failed safely. Cached local status remains available, and newsletter delivery is unaffected.";
   else message.textContent = "Normal Manager and dashboard health never depend on Internet availability. Only Check now contacts the stable release service.";
@@ -2680,6 +2707,7 @@ async function installUpdate() {
   try {
     state.updates = await request("/api/v1/updates/install", { method: "POST", body: "{}" });
     setGlobalStatus("Verified Windows updater started.", true);
+    beginUpdateInstallPolling(state.updates.latestStableVersion);
   } catch (error) {
     byId("update-settings-message").textContent = error.message;
     setGlobalStatus(error.message, true);
@@ -2687,6 +2715,57 @@ async function installUpdate() {
     state.updateInstalling = false;
     renderUpdates();
   }
+}
+
+function stopUpdateInstallPolling() {
+  clearTimeout(updateInstallPollTimer);
+  updateInstallPollTimer = undefined;
+  updateInstallExpectedVersion = "";
+  updateInstallSawDisconnect = false;
+  updateInstallPollDeadline = 0;
+}
+
+function beginUpdateInstallPolling(expectedVersion) {
+  stopUpdateInstallPolling();
+  updateInstallExpectedVersion = expectedVersion || "";
+  updateInstallPollDeadline = Date.now() + 15 * 60 * 1000;
+  updateInstallPollTimer = setTimeout(pollUpdateInstall, 1000);
+}
+
+async function pollUpdateInstall() {
+  if (!updateInstallExpectedVersion) return;
+  try {
+    const update = await request("/api/v1/updates");
+    state.updates = update;
+    const active = ["starting", "running"].includes(update.installState);
+    if (update.managerVersion === updateInstallExpectedVersion || (updateInstallSawDisconnect && !active)) {
+      stopUpdateInstallPolling();
+      setGlobalStatus("Manager update finished. Loading the updated application...");
+      window.location.reload();
+      return;
+    }
+    renderUpdates();
+    if (!active) {
+      stopUpdateInstallPolling();
+      setGlobalStatus(update.installState === "failed" ? "Verified updater did not complete." : "Verified updater finished without a Manager restart.", true);
+      return;
+    }
+  } catch (error) {
+    if (error.status === 401) {
+      stopUpdateInstallPolling();
+      window.location.reload();
+      return;
+    }
+    updateInstallSawDisconnect = true;
+    byId("update-settings-message").textContent = "The Manager is restarting for the verified update. Reconnecting automatically...";
+    setGlobalStatus("Reconnecting to the updated Manager...");
+  }
+  if (Date.now() >= updateInstallPollDeadline) {
+    stopUpdateInstallPolling();
+    byId("update-settings-message").textContent = "Automatic reconnection timed out. The updater may still be awaiting Windows approval; review the prompt, then use Refresh if needed.";
+    return;
+  }
+  updateInstallPollTimer = setTimeout(pollUpdateInstall, 1500);
 }
 
 async function copyUpdateCommand() {
@@ -2715,8 +2794,6 @@ async function copyUpdateCommand() {
 }
 
 function renderAbout() {
-  setText("about-version", state.about.version || "Version unavailable");
-  setText("about-package", state.about.packageVersion || "Package version unavailable");
   const events = state.diagnostics?.events || [];
   setText("diagnostics-count", events.length ? `${events.length} retained` : "No events");
   setText("diagnostics-retention", `Up to ${state.diagnostics?.maximumEntries || 200} events for ${state.diagnostics?.retentionDays || 30} days.`);
@@ -2844,6 +2921,7 @@ async function logout() {
 }
 
 function showAuthentication() {
+  stopUpdateInstallPolling();
   clearAllRevealedSecrets();
   closeSecretRevealDialog();
   concealMaskedInputs(byId("auth-shell"));

--- a/manager/internal/manager/web/index.html
+++ b/manager/internal/manager/web/index.html
@@ -275,10 +275,11 @@
         <section class="update-settings-panel" id="update-settings-panel" aria-labelledby="update-settings-heading">
           <div class="update-settings-heading"><div><span class="eyebrow">Capability-aware updates</span><h2 id="update-settings-heading">Application and package status</h2><p id="update-settings-summary">Reading the last local update result. No Internet request is made during normal refresh.</p></div><span class="state-chip pending" id="update-settings-chip">Unknown</span></div>
           <dl class="update-version-grid">
-            <div><dt>Running Manager</dt><dd id="update-manager-version">Not reported</dd></div>
-            <div><dt>Application</dt><dd id="update-application-version">Not reported</dd></div>
-            <div><dt id="update-package-label">Host package</dt><dd id="update-package-version">Not reported</dd></div>
-            <div id="update-image-version-row"><dt>Container image application</dt><dd id="update-image-version">Not applicable</dd></div>
+            <div><dt>Manager build</dt><dd id="update-manager-version">Not reported</dd></div>
+            <div><dt>Package baseline</dt><dd id="update-package-baseline">Not reported</dd></div>
+            <div><dt>Platform</dt><dd id="update-platform">Not reported</dd></div>
+            <div><dt>Edition</dt><dd id="update-edition">Manager</dd></div>
+            <div><dt>Release layers</dt><dd id="update-release-layers">Not reported</dd></div>
             <div><dt>Host adapter</dt><dd id="update-host-adapter">Not applicable</dd></div>
             <div><dt>Update channel</dt><dd id="update-channel">Stable</dd></div>
             <div><dt>Latest stable</dt><dd id="update-latest-version">Not checked</dd></div>
@@ -303,7 +304,6 @@
           <article><span class="about-number">04</span><h2>Delivery truthfulness</h2><p id="about-delivery-copy">Task execution, SMTP acceptance, and inbox delivery remain distinct states in both API copy and interface labels.</p></article>
           <article><span class="about-number">05</span><h2>Package lifecycle</h2><p id="about-lifecycle-copy">Updates and rollback follow the package boundary reported by this Manager.</p></article>
         </div>
-        <dl class="build-details"><div><dt>Manager build</dt><dd id="about-version">Checking...</dd></div><div><dt>Package baseline</dt><dd id="about-package">Checking...</dd></div><div><dt>Platform</dt><dd id="about-platform">Checking...</dd></div><div><dt>Edition</dt><dd id="about-edition">Manager</dd></div></dl>
         <div class="section-heading"><div><span class="eyebrow">Private local record</span><h2>Configuration diagnostics</h2></div><p>Useful setup evidence is retained without storing configuration values or raw service responses.</p></div>
         <section class="diagnostics-panel" aria-labelledby="diagnostics-heading">
           <div class="panel-heading"><h2 id="diagnostics-heading">Setup and verification events</h2><small id="diagnostics-count">Checking</small></div>

--- a/scripts/test-manager-accessibility.py
+++ b/scripts/test-manager-accessibility.py
@@ -279,6 +279,11 @@ def main() -> int:
     for control in (
         "update-settings-panel",
         "update-settings-chip",
+        "update-manager-version",
+        "update-package-baseline",
+        "update-platform",
+        "update-edition",
+        "update-release-layers",
         "update-check-button",
         "update-guidance-summary",
         "update-copy-command",
@@ -288,6 +293,10 @@ def main() -> int:
     ):
         if f'id="{control}"' not in combined:
             failures.append(f"Settings update card omits accessible control: {control}")
+    if 'class="build-details"' in combined or 'id="update-application-version"' in combined or 'id="update-package-version"' in combined:
+        failures.append("Manager and package identity is still duplicated outside the consolidated update status surface")
+    if "function releaseLayerSummary(" not in javascript or 'matching.length === 1 ? "matches" : "match"' not in javascript:
+        failures.append("application and package release layers are not summarized without duplicate version values")
     for marker in (
         'request("/api/v1/updates")',
         'request("/api/v1/updates/check", { method: "POST", body: "{}" })',
@@ -297,8 +306,14 @@ def main() -> int:
     ):
         if marker not in javascript:
             failures.append(f"Settings update interaction contract is missing: {marker}")
+    if "function pollUpdateInstall()" not in javascript or "updateInstallPollTimer = setTimeout(pollUpdateInstall" not in javascript:
+        failures.append("verified update installation has no automatic status transition")
     if '.update-settings-panel' not in css or '.update-command' not in css or '.update-install-confirm' not in css:
         failures.append("Settings update card lacks its responsive and accessible visual treatment")
+    if 'const toggle = document.createElement("label");' not in javascript or "toggle.htmlFor = id;" not in javascript:
+        failures.append("generated boolean switches do not associate their full visible surface with the checkbox")
+    if ".config-control-boolean .config-toggle{width:max-content;cursor:pointer" not in css:
+        failures.append("generated boolean switches do not expose a full clickable pointer surface")
     if 'value="send-all"' not in combined or 'value="send-welcome"' not in combined:
         failures.append("manual production delivery does not expose both all-recipient and Manual Welcome scopes")
     if 'type === "send-welcome"' not in javascript or "confirmProductionSend: true" not in javascript:


### PR DESCRIPTION
## Summary

- reconnect and reload the Windows Manager automatically after the verified updater restarts it
- consolidate Manager build, package baseline, platform, edition, and release-layer health into one status surface
- make generated configuration switches fully clickable and preserve explicit `false` values through the shared API
- mirror the behavior in the network-blocked GUI preview and cover every shipped package kind

## Root cause

The initiating Windows page retained its old in-memory `running` snapshot and never polled the replacement Manager. Generated boolean controls used a non-label wrapper while the transparent checkbox disabled pointer events, so their visible surface could not toggle the control. Build/package identity was also rendered in both Settings and About.

## Validation

- independent coordinating-task audit of the exact 11-file diff
- `go test ./...` and `go vet ./...` in `manager`
- focused Windows update transition and eight-package configuration persistence regressions
- production/preview JavaScript syntax checks
- Manager accessibility structure test
- repository, platform, and documentation validators
- Windows verified-updater fixture suite
- fixture-only cross-platform update-management suite
- Windows/Linux/macOS/FreeBSD amd64 and arm64 Manager cross-builds
- local synthetic browser interaction for toggle clicking/persistence and automatic update transition

No real Plex, Tautulli, SMTP, user configuration, or host updater was contacted.
