### PR TITLE
chore: prepare v0.15.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-08-18
+
 ### Changed
 
 - Consolidated Manager build, package baseline, platform, edition, and release

--- a/docs/releases/v0.15.2.md
+++ b/docs/releases/v0.15.2.md
@@ -1,0 +1,37 @@
+# TautWeekly for Plex v0.15.2
+
+v0.15.2 fixes Manager update and configuration interactions across every
+maintained package. Windows verified updates now reconnect to the restarted
+Manager automatically, generated configuration switches respond across their
+full visible surface, and build/package identity is presented once in the
+application and package status card.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for your package.
+On Windows, open **Manager > Settings > Updates**, run **Check now**, confirm
+the verified stable update, and approve the Windows administrator prompt.
+
+An already-open pre-v0.15.2 Windows tab still contains the older browser code,
+so it may need one final refresh while moving to this release. Once v0.15.2 is
+loaded, later verified updates reconnect and advance the page automatically.
+
+No configuration migration is required. The Manager continues to preserve
+existing credentials, schedules, generated newsletters, private state, and
+package-owned lifecycle boundaries.
+
+## Scope and validation
+
+The click defect came from shared Manager markup, not Windows configuration
+storage: a non-label visual wrapper surrounded a checkbox whose pointer events
+were disabled. The API already preserved explicit boolean `false` values.
+Regression coverage now exercises the authenticated save path for Windows,
+macOS Docker Desktop, NAS/Compose, QNAP, Unraid, compatible Docker, native
+Linux, and FreeBSD package identities.
+
+Release gates test and vet the Manager and installer, validate accessibility
+and JavaScript, cross-build Windows/Linux/macOS/FreeBSD Manager binaries for
+amd64 and arm64, build and boot-test the shared container image, exercise the
+verified Windows updater with fixtures, and build reproducible release
+archives. Automated tests do not contact real Plex, Tautulli, SMTP, or user
+configuration.


### PR DESCRIPTION
## Summary

- promote the audited Manager update/toggle hotfix to v0.15.2
- publish Windows update guidance, the shared cross-package toggle diagnosis, and the one-time pre-v0.15.2 browser limitation
- retain the established changelog and release-note structure

Release follow-up to #107.

## Validation

- repository privacy and hygiene validation - pass
- documentation feature validation - pass
- relative link validation - pass
- git diff --check - pass

The feature head merged through #107 after the complete CI, Windows installer, reproducible archive, and multi-architecture container matrices passed.
