### PR TITLE
chore: prepare v0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-18
+
+### Added
+
+- Added an accessible, passive update-available indicator beside the Manager
+  access lock across every supported package. It appears only after a validated
+  stable release is unequivocally newer than the running application and links
+  directly to **Settings > Application and package status**.
+
+### Changed
+
+- Authenticated Manager entry now renders cached update state immediately and
+  performs one non-blocking refresh only when the cache is absent or at least
+  24 hours stale and the existing retry backoff permits it. Login, health,
+  ordinary navigation, and offline operation remain independent of release
+  checks.
+
 ## [0.15.2] - 2026-08-18
 
 ### Changed

--- a/docs/releases/v0.16.0.md
+++ b/docs/releases/v0.16.0.md
@@ -1,0 +1,48 @@
+# TautWeekly for Plex v0.16.0
+
+v0.16.0 adds a passive update notification to the authenticated Manager. When
+TautWeekly has validated that a newer stable application release is available,
+a purple update icon appears beside the access lock. Its accessible label names
+the available version, and activating it opens **Settings > Application and
+package status** for package-specific status and guidance.
+
+The indicator is shared by Windows, native Linux, macOS Docker Desktop,
+FreeBSD Podman, NAS/Compose, QNAP Container Station, Unraid, and compatible
+Docker hosts. It does not change update ownership: Windows retains its existing
+verified updater, while host-managed packages continue to use their documented
+package or image workflow.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for your package.
+After v0.16.0 is running, the Manager can render a validated cached update state
+on authenticated entry and refresh an absent or stale result once in the
+background when retry backoff permits. The notification is guidance, not an
+automatic installation control.
+
+No configuration migration is required. Existing credentials, schedules,
+generated newsletters, private state, backups, and package lifecycle boundaries
+remain unchanged.
+
+## Privacy, offline behavior, and validation
+
+The background refresh reuses the authenticated, CSRF-protected update endpoint
+and its bounded timeout, metadata validation, persistent cache, concurrency
+suppression, and sanitized retry backoff. It is not called from the login page,
+health checks, every API request, or ordinary navigation. Dashboard rendering
+and offline operation do not wait for a release check.
+
+The icon stays absent for current, checking without a validated result, unknown,
+offline/error-only, invalid metadata, rollback/downgrade, mismatched-only,
+unsupported, and legacy-wrapper-only states. A package or image mismatch alone
+does not produce an application-update notification.
+
+Release gates test and vet the Manager and installer, validate JavaScript and
+accessibility behavior, exercise cached/stale/fresh checks and package/version
+matrices, cross-build every maintained Manager target, boot-test the shared
+container and native Linux package, exercise the Windows installer lifecycle,
+and build reproducible release archives. Browser QA covered desktop and narrow
+mobile layouts, asynchronous appearance and disappearance, focus routing,
+history navigation, reduced-motion/forced-colors contracts, and console health.
+Automated tests use synthetic metadata and do not contact real Plex, Tautulli,
+SMTP, user configuration, or updater services.


### PR DESCRIPTION
## Summary

- publish the v0.16.0 changelog entry for the cross-package Manager update-available header indicator
- add release notes covering authenticated background cadence, strict visibility, package ownership, privacy, offline behavior, and validation

## Validation

- repository, Unraid template, platform, documentation, and relative-link validators
- release-shaped v0.16.0 build with all ten distributables and SHA-256 checksums
- packaged runtime contracts and checksum verification
- repeated v0.16.0 build produced byte-identical archives and checksums
- feature PR #109 and merged-main CI, Pages, Container, native Linux package, and Windows installer lifecycle gates are green

## Release boundary

This PR contains release metadata only. After it merges and main remains green, an annotated `v0.16.0` tag will trigger the repository's verified GitHub release and multi-architecture container workflows.
