### PR TITLE
release: v0.17.1 purple update status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-08-18
+
+### Fixed
+
+- Changed the validated **Update available** status chip from the generic blue
+  checking state to the agreed violet/purple treatment with a subtle purple
+  pulse. The purple header update icon beside the Manager lock is unchanged,
+  and active update checks remain blue so discovery and availability are
+  visually distinct.
+
 ## [0.17.0] - 2026-08-18
 
 ### Added

--- a/docs/releases/v0.17.1.md
+++ b/docs/releases/v0.17.1.md
@@ -1,0 +1,32 @@
+# TautWeekly for Plex v0.17.1
+
+v0.17.1 corrects the Manager's update-available presentation. After a verified
+stable comparison finds a newer release, the status chip inside **Settings >
+Updates** now uses the agreed violet/purple color and a subtle purple pulse.
+The existing purple update icon beside the Manager lock remains the direct link
+to the same status card.
+
+An active **Checking** state remains blue. This keeps a check that is still in
+progress visually distinct from a completed, validated update result.
+
+The pulse respects reduced-motion preferences, and the status retains a
+high-contrast system-color treatment in forced-colors mode. The correction is
+shared by every Manager package and the static GUI preview. It does not change
+update discovery, package ownership, installation permissions, authentication,
+or the Windows password-lock behavior.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for the installed
+package. No configuration migration is required. Existing credentials,
+schedules, generated newsletters, backups, history, Tailscale settings, and
+Manager access settings remain unchanged.
+
+## Validation
+
+The hotfix passed the dedicated update-indicator package, routing, motion,
+mobile, preview, reduced-motion, and forced-colors contracts; production and
+preview JavaScript syntax; Manager accessibility validation; repository,
+branding, platform, documentation, link, reproducible-package, Windows
+installer, and amd64/arm64 container checks. A local rendered-browser audit
+confirmed the purple color, 2.9-second animation, and changing purple shadow.


### PR DESCRIPTION
## Summary

- prepare the v0.17.1 hotfix release for the purple, pulsing in-card **Update available** status
- retain the existing purple update icon beside the Manager lock and keep active checks blue
- document unchanged authentication, Windows password-lock, update, package, and migration behavior

## Included fix

- feature PR #113
- merged feature commit `eefdb53fa7c09ececa6b5fcd17daf73f48c196d1`
- release preparation commit `4206399`

## Validation

- full feature PR CI passed for Windows/Linux Manager matrices, PowerShell, repositories, Compose, reproducible archives, Windows installer lifecycle, and amd64/arm64 containers
- dedicated update-indicator, syntax, accessibility, repository, platform, branding, link, and documentation checks passed locally
- rendered browser validation confirmed the violet color, 2.9-second purple pulse, reduced-motion behavior, and retained purple header icon

## Risk

Low. This release changes update-status presentation and release documentation only. It does not change update discovery or installation, authentication, package ownership, Tailscale configuration, or Windows password-lock behavior.
