### PR TITLE
chore: release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-08-20
+
+### Changed
+
+- Clarified the capability-aware application and package status card by placing
+  **Latest stable** beside **Manager build**, renaming **Release layers** to
+  **Release alignment**, and removing the deprecated **Package baseline**
+  field from the production Manager and live synthetic GUI Preview.
+- Made **Host adapter** conditional on an applicable reported contract and
+  reflowed the status grid across desktop and mobile widths without changing
+  update classification, checks, caching, indicators, or installation
+  boundaries.
+
 ## [0.18.0] - 2026-08-20
 
 ### Added

--- a/docs/releases/v0.18.1.md
+++ b/docs/releases/v0.18.1.md
@@ -1,0 +1,52 @@
+# TautWeekly for Plex v0.18.1
+
+v0.18.1 clarifies the capability-aware **Application and package status** card
+in the production Manager and live synthetic GUI Preview. Its visible fields
+now use this order:
+
+1. **Manager build**
+2. **Latest stable**
+3. **Platform**
+4. **Edition**
+5. **Release alignment**
+6. **Host adapter**, only when the package reports an applicable contract
+7. **Update channel**
+8. **Last successful check**
+
+The deprecated **Package baseline** field is gone. **Release alignment** keeps
+the existing concise comparison of the running application, package, and image
+versions without repeating identical version values. Windows and any other
+edition that reports `not-applicable` no longer show a Host adapter row;
+packages with an adapter contract retain its actual API version and state.
+The grid fills the available desktop row and remains single-column without
+horizontal overflow on mobile.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for the installed
+package. No configuration migration is required. Existing credentials,
+schedules, generated newsletters, backups, history, Tailscale settings,
+Manager access settings, package ownership, and recovery behavior remain
+unchanged.
+
+## Security and behavior boundaries
+
+This is a status-presentation refinement. Update state classification, the
+24-hour authenticated-entry refresh, five-minute successful-result reuse,
+failure backoff, explicit **Check now**, cached and offline behavior, update
+indicators and glows, Windows confirmation and elevation, host-owned update
+flows, scheduling, backup, rollback, and recovery boundaries are unchanged.
+The Manager gains no new network, root, container-engine, host-helper, file, or
+installation authority.
+
+## Validation
+
+Production and preview JavaScript syntax, focused accessibility/static
+contracts, Manager and installer unit tests and vet, all eight maintained
+Manager cross-build targets, repository/platform/documentation/privacy suites,
+33 synthetic renderer integration scenarios, complete release payload and
+checksum contracts, the isolated Windows installer lifecycle, and byte-exact
+archive reproducibility passed. Synthetic browser QA at 1440x1000 and 390x844
+confirmed the approved order, conditional Host adapter behavior for applicable
+and not-applicable states, clean responsive reflow, no horizontal overflow,
+and no console errors.


### PR DESCRIPTION
## Summary

- publish the patch release notes for the capability-aware status-card clarity refinement
- document removal of Package baseline, the Release alignment rename, the approved field order, and conditional Host adapter visibility
- record unchanged update, security, privacy, installation, scheduling, backup, and recovery boundaries

## Release target

- version: `v0.18.1`
- feature merge: `d627f74797de8d42d5af9edbc1d41d3415ec7c4d`
- release commit: `6adb5867101721ac251f8993ceb424e17050825f`

## Validation

- feature PR #117 passed all CI, archive, installer, and multi-architecture container checks
- release documentation passes repository hygiene/privacy, links, documentation, JavaScript, and accessibility validation locally
- complete local 0.18.1 candidate artifacts, checksums, package contracts, Windows installer lifecycle, and byte-identical reproducibility passed
