### PR TITLE
docs: keep homepage spotlight on feature releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,10 @@ These instructions apply to the entire repository.
 - Create and modify public project files only in the local `TautWeekly` Git repository or one of its Git worktrees.
 - Preserve unrelated user changes and use a clean branch or worktree when the primary checkout is dirty.
 - Never commit runtime configuration, credentials, tokens, personal identifiers, generated newsletters, logs, state files, or private infrastructure details.
+
+## Primary Quickstart feature spotlight
+
+- Keep the featured release box in `docs/index.html` focused on the newest published release that adds substantial user-facing functionality.
+- A release qualifies when its changelog has an `Added` section describing a new end-user capability. Maintenance-only fixes, hardening, documentation, internal tooling, minor visual polish, and other tweaks do not replace the featured release.
+- When a qualifying feature release is published, update the spotlight's `data-feature-release` value, version label, explanation, capability summary, configuration link, and release-notes link together.
+- Keep repository validation aligned with this policy so a later maintenance release cannot silently displace the latest feature release.

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,17 +69,17 @@
       </div>
     </section>
 
-    <section class="section searchable" data-search="deleted items metadata artwork cache retention future retroactive limitation">
+    <section class="section searchable" id="feature-spotlight" data-feature-release="v0.18.0" data-search="feature release custom text card newsletter message title subheading body border opacity preview welcome packages">
       <div class="section-heading">
-        <div><div class="eyebrow">v0.9.0 storage boundary</div><h2>Future deletion protection, not retroactive reconstruction</h2></div>
-        <p>The v0.8.3 Plex hosted-provider recovery is best-effort. Tautulli history can retain identifiers and descriptive fields, but not durable artwork bytes after Plex/Tautulli discards them.</p>
+        <div><div class="eyebrow">v0.18.0 newsletter customization</div><h2>Add your own message without redesigning the newsletter</h2></div>
+        <p>The latest feature release brings a configurable custom text card to every maintained package, with consistent HTML, plain-text, preview, and welcome-state output.</p>
       </div>
       <article class="card featured">
-        <span class="tag">Exact stable GUID only</span>
-        <h3>A bounded cache is populated while media is still live</h3>
-        <p>v0.9.0 stores the minimum newsletter presentation metadata and one poster under private platform storage, then reuses it after a future deletion. It never title-matches ambiguous old history and cannot repair assets deleted before the cache was populated.</p>
-        <ul><li>365 days by default</li><li>1,000 items</li><li>256 MiB total</li><li>No tokens, recipients, or viewing metrics</li></ul>
-        <div class="card-actions"><a href="CONFIGURATION.md#persistent-deleted-item-cache">Cache configuration and migration</a><a href="releases/v0.9.0.md">v0.9.0 release notes</a></div>
+        <span class="tag">Every maintained package</span>
+        <h3>One optional card, shaped in Manager Config</h3>
+        <p>v0.18.0 places a custom message before the newsletter release-count and date block. Existing newsletters stay unchanged until the card is enabled, and the Manager requires a body before validation can continue.</p>
+        <ul><li>Optional gold title</li><li>Optional larger white subheading</li><li>Required plain-text body when enabled</li><li>Configurable border color and opacity</li></ul>
+        <div class="card-actions"><a href="CONFIGURATION.md#optional-custom-text-card">Custom text card configuration</a><a href="releases/v0.18.0.md">v0.18.0 release notes</a></div>
       </article>
     </section>
 

--- a/scripts/validate-docs.ps1
+++ b/scripts/validate-docs.ps1
@@ -124,6 +124,48 @@ foreach ($relative in $pages) {
     Write-Host "[PASS] Documentation features: $relative"
 }
 
+$homeQuickstart = [IO.File]::ReadAllText((Join-Path $docs 'index.html'))
+$changelog = [IO.File]::ReadAllText((Join-Path $Root 'CHANGELOG.md'))
+$releaseBlocks = [regex]::Matches(
+    $changelog,
+    '(?ms)^## \[(?<version>\d+\.\d+\.\d+)\][^\r\n]*\r?\n(?<body>.*?)(?=^## \[|\z)'
+)
+$latestFeatureBlock = @($releaseBlocks | Where-Object {
+    $_.Groups['body'].Value -match '(?m)^### Added\s*$'
+} | Select-Object -First 1)
+if ($latestFeatureBlock.Count -ne 1) {
+    throw 'CHANGELOG.md does not contain a published feature release with an Added section'
+}
+$latestFeatureRelease = 'v' + $latestFeatureBlock[0].Groups['version'].Value
+$spotlightSection = [regex]::Match(
+    $homeQuickstart,
+    '(?is)<section\b(?=[^>]*\bid=["'']feature-spotlight["''])[^>]*>(?<content>.*?)</section>'
+)
+if (-not $spotlightSection.Success) {
+    throw 'Primary Quickstart feature spotlight section is missing'
+}
+$spotlightOpeningTag = $spotlightSection.Value.Substring(0, $spotlightSection.Value.IndexOf('>') + 1)
+$featureReleaseMatch = [regex]::Match(
+    $spotlightOpeningTag,
+    '(?i)\bdata-feature-release=["''](?<version>v\d+\.\d+\.\d+)["'']'
+)
+if (-not $featureReleaseMatch.Success) {
+    throw 'Primary Quickstart feature spotlight is missing data-feature-release'
+}
+$spotlightRelease = $featureReleaseMatch.Groups['version'].Value
+if ($spotlightRelease -ne $latestFeatureRelease) {
+    throw "Primary Quickstart spotlights $spotlightRelease; latest feature release is $latestFeatureRelease"
+}
+$releaseNotesRelative = "releases/$latestFeatureRelease.md"
+if (-not [IO.File]::Exists((Join-Path $docs $releaseNotesRelative))) {
+    throw "Feature spotlight release notes are missing: $releaseNotesRelative"
+}
+$escapedReleaseLink = [regex]::Escape('href="' + $releaseNotesRelative + '"')
+if ($spotlightSection.Groups['content'].Value -notmatch $escapedReleaseLink) {
+    throw "Primary Quickstart feature spotlight does not link to $releaseNotesRelative"
+}
+Write-Host "[PASS] Primary Quickstart spotlights latest feature release: $latestFeatureRelease"
+
 $quickstartCss = [IO.File]::ReadAllText((Join-Path $docs 'assets/quickstart.css'))
 $quickstartJs = [IO.File]::ReadAllText((Join-Path $docs 'assets/quickstart.js'))
 foreach ($pattern in @(


### PR DESCRIPTION
## Summary

- Update the primary Quickstart feature spotlight from v0.9.0 to the latest substantive feature release, v0.18.0.
- Define the repository rule that maintenance-only releases do not displace the spotlight.
- Validate the spotlight against the newest published changelog release with an Added section and its release-notes link.

## Validation

- scripts/validate-docs.ps1
- scripts/check-links.ps1
- scripts/validate-branding.ps1
- scripts/validate-repository.ps1
- node --check docs/assets/site.js
- Desktop and mobile browser QA, including search and both spotlight links.

No version, tag, or release is needed for this Pages-only update.