### PR TITLE
fix: keep release tests cross-platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Test rolling configuration-backup retention on PowerShell 7
         shell: pwsh
         run: ./scripts/test-config-backup-retention.ps1
+      - name: Test production recipient policy on PowerShell 7
+        shell: pwsh
+        run: ./scripts/test-sendall-recipient-policy.ps1 -PythonPath python3
       - name: Test SMTP authentication protocol on PowerShell 7
         run: python3 scripts/test-smtp-transport.py --helper platforms/nas-docker/app/Smtp-Transport.ps1
       - name: Validate NAS Compose configuration

--- a/scripts/test-sendall-recipient-policy.ps1
+++ b/scripts/test-sendall-recipient-policy.ps1
@@ -14,6 +14,10 @@ $fakeSmtp = Join-Path $Root 'scripts/test-support/fake-smtp.py'
 $headlessRunner = Join-Path $Root 'scripts/test-support/invoke-renderer-headless.ps1'
 $powerShell7 = Get-Command pwsh -ErrorAction SilentlyContinue
 $windowsHost = if ($env:SystemRoot) { Join-Path $env:SystemRoot 'System32/WindowsPowerShell/v1.0/powershell.exe' } else { '' }
+$processWindowArgs = @{}
+if ($PSVersionTable.PSEdition -eq 'Desktop' -or $env:OS -eq 'Windows_NT') {
+    $processWindowArgs.WindowStyle = 'Hidden'
+}
 
 function Assert-True([bool]$Condition, [string]$Message) {
     if (-not $Condition) { throw $Message }
@@ -331,7 +335,7 @@ foreach ($engine in $engines) {
             '-u', $fakeTautulli, '--port', [string]$tautulliPort, '--scenario', 'quiet',
             '--users-file', $usersFile, '--refresh-users-file', $refreshUsersFile,
             '--fail-refresh-file', $failRefreshFile, '--call-log', $tautulliLog, '--ready-file', $tautulliReady
-        ) -PassThru -WindowStyle Hidden -RedirectStandardOutput $tautulliStdout -RedirectStandardError $tautulliStderr
+        ) -PassThru @processWindowArgs -RedirectStandardOutput $tautulliStdout -RedirectStandardError $tautulliStderr
         for ($attempt = 0; $attempt -lt 100 -and -not (Test-Path $tautulliReady); $attempt++) {
             if ($tautulli.HasExited) { throw "Virtual Tautulli exited early: $(Get-Content $tautulliStderr -Raw -ErrorAction SilentlyContinue)" }
             Start-Sleep -Milliseconds 50
@@ -383,7 +387,7 @@ foreach ($engine in $engines) {
                 'reject-policy' { $smtpArguments += '--reject-policy' }
             }
             $smtp = $null
-            $smtp = Start-Process -FilePath $PythonPath -ArgumentList $smtpArguments -PassThru -WindowStyle Hidden -RedirectStandardOutput $smtpStdout -RedirectStandardError $smtpStderr
+            $smtp = Start-Process -FilePath $PythonPath -ArgumentList $smtpArguments -PassThru @processWindowArgs -RedirectStandardOutput $smtpStdout -RedirectStandardError $smtpStderr
             try {
                 for ($attempt = 0; $attempt -lt 100 -and -not (Test-Path $smtpReady); $attempt++) {
                     if ($smtp.HasExited) { throw "Virtual SMTP exited early: $(Get-Content $smtpStderr -Raw -ErrorAction SilentlyContinue)" }
@@ -439,7 +443,7 @@ foreach ($engine in $engines) {
                             '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $headlessRunner,
                             '-RendererPath', (Join-Path $appRoot 'TautWeekly.ps1'), '-ConfigPath', $configPath,
                             '-UserId', '1', '-Mode', 'SendAll', '-ResultPath', $unconfirmedResultPath, '-NoConfirmSendAll'
-                        ) -Wait -PassThru -WindowStyle Hidden -RedirectStandardOutput $unconfirmedStdout -RedirectStandardError $unconfirmedStderr
+                        ) -Wait -PassThru @processWindowArgs -RedirectStandardOutput $unconfirmedStdout -RedirectStandardError $unconfirmedStderr
                         Assert-True ($unconfirmedProcess.ExitCode -eq 1) "$($engine.Name) accepted an unconfirmed production SendAll."
                         $callsAfterUnconfirmed = @(Get-Content -LiteralPath $tautulliLog -ErrorAction SilentlyContinue | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }).Count
                         Assert-True ($callsAfterUnconfirmed -eq $callsBeforeUnconfirmed) "$($engine.Name) contacted Tautulli before production confirmation."
@@ -450,7 +454,7 @@ foreach ($engine in $engines) {
                         '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $headlessRunner,
                         '-RendererPath', (Join-Path $appRoot 'TautWeekly.ps1'), '-ConfigPath', $configPath,
                         '-UserId', '1', '-Mode', 'SendAll', '-ResultPath', $resultPath
-                    ) -Wait -PassThru -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+                    ) -Wait -PassThru @processWindowArgs -RedirectStandardOutput $stdout -RedirectStandardError $stderr
                 }
                 finally {
                     $env:TAUTWEEKLY_DATA_DIR = $oldDataRoot


### PR DESCRIPTION
## Summary

- omit the Windows-only `Start-Process -WindowStyle` option when the SendAll policy harness runs under Linux/macOS PowerShell
- preserve hidden child processes on Windows
- unblock the v0.19.1 tag release validator without changing Manager, renderer, SMTP, package, or delivery behavior

Immediate release-gate follow-up to #127.

## Validation

- all 78 PowerShell files parse
- SendAll recipient policy, privacy, package synchronization, SMTP fail-fast, spacing, refresh ordering, and manual/scheduled parity: 33/33 scenarios across all three renderer engines
- original failed release log confirms `-WindowStyle` was the only failing validator operation and no release/artifacts were published
