### PR TITLE
chore: prepare v0.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-21
+
 ### Added
 
 - Added uncapped personal movie and TV statistics so every qualifying unique

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,17 +69,17 @@
       </div>
     </section>
 
-    <section class="section searchable" id="feature-spotlight" data-feature-release="v0.19.0" data-search="feature release custom text card title gif selector celebrate construction rocket tickets warning alert retention backups history diagnostics packages">
+    <section class="section searchable" id="feature-spotlight" data-feature-release="v0.20.0" data-search="feature release personal statistics uncapped movies television tv ratings posters watch time binge champion responsive desktop mobile packages">
       <div class="section-heading">
-        <div><div class="eyebrow">v0.19.0 title GIFs and rolling retention</div><h2>Give a custom title one carefully packaged reaction</h2></div>
-        <p>The newest feature release adds a six-choice local GIF selector to the optional custom-card title and keeps Manager recovery/history surfaces predictably bounded.</p>
+        <div><div class="eyebrow">v0.20.0 uncapped personal statistics</div><h2>See every qualifying title from your week</h2></div>
+        <p>The newest feature release removes the four-title ceiling from personal movie and TV statistics while keeping every row's eligible artwork, metadata, and ratings.</p>
       </div>
       <article class="card featured">
         <span class="tag">Every maintained package</span>
-        <h3>Six local choices, one deterministic email asset</h3>
-        <p>v0.19.0 places Celebrate, Construction, Rocket, Tickets, Warning, or Alert immediately after a non-empty uppercase custom title. The Manager previews the selection in-field; delivered mail attaches only the selected allowlisted GIF.</p>
-        <ul><li>Accessible keyboard and mobile selector</li><li>Exact 18×18 newsletter placement</li><li>Newest 10 configuration backups</li><li>Newest 20 operations and diagnostics</li></ul>
-        <div class="card-actions"><a href="CONFIGURATION.md#optional-custom-text-card">Title GIF configuration</a><a href="releases/v0.19.0.md">v0.19.0 release notes</a></div>
+        <h3>Full-width sections that grow with your viewing</h3>
+        <p>v0.20.0 gives Movies watched and TV shows watched their own full-width cards. Titles pair into two columns on desktop and stack into one column on mobile, with compact personal-time and Binge Champion cards kept independent of the list length.</p>
+        <ul><li>Every qualifying unique movie and TV show</li><li>Posters, metadata, and eligible ratings beyond row four</li><li>Responsive two-column and single-column title grids</li><li>Unchanged privacy, ranking, and watch-time semantics</li></ul>
+        <div class="card-actions"><a href="CONFIGURATION.md#content-and-eligibility">Content and eligibility</a><a href="releases/v0.20.0.md">v0.20.0 release notes</a></div>
       </article>
     </section>
 

--- a/docs/releases/v0.20.0.md
+++ b/docs/releases/v0.20.0.md
@@ -1,0 +1,64 @@
+# TautWeekly for Plex v0.20.0
+
+v0.20.0 removes the visible four-title ceiling from personal movie and TV
+statistics and gives long, uneven viewing lists a responsive layout across
+every maintained package.
+
+## Every qualifying title
+
+Personal statistics now render every qualifying unique movie and every
+qualifying unique TV show from the reporting window. The established
+aggregation, deduplication, watch-time-then-plays ranking, rating eligibility,
+privacy, and watch-time rules are unchanged. Rows after the former fourth-row
+boundary receive the same metadata enrichment, poster preparation, eligible
+Rotten Tomatoes or IMDb treatment, HTML rendering, and plain-text output as
+earlier rows.
+
+Movies watched and TV shows watched are separate full-width cards. Each card
+pairs two titles per row on desktop and stacks one title per row on mobile, so
+uneven sets such as five movies and one TV show remain balanced. One-sided and
+empty reporting windows retain their existing sensible states.
+
+## Compact weekly summary
+
+Personal total watch time and Binge Champion remain side by side on desktop
+and stack on mobile, but they are now equal-height compact cards whose height
+does not depend on the number of personal titles. The personal card adds the
+`YOU CLOCKED` eyebrow and uses the visible label `total watch time`.
+
+These values intentionally remain different metrics. Personal total watch
+time includes all movie and episode playback in the reporting window, while
+Binge Champion displays the qualifying duration used for the privacy-preserving
+weekly ranking. Winner and non-winner states, anonymity, unique-title
+breakdowns, and ranking behavior are unchanged.
+
+## Preview parity
+
+The network-blocked Manager preview now uses synthetic fixtures with more than
+ten movie and TV rows, uneven counts, winner and non-winner states, and titles
+with and without eligible ratings. Synthetic personal rows follow production
+Rotten Tomatoes and IMDb display rules without inventing unavailable ratings.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for the installed
+package. No configuration migration is required. Existing content eligibility,
+library selection, rating-source, privacy, and delivery settings are preserved.
+
+## Security and privacy
+
+The release does not broaden retained or exposed personal data. Production
+output continues to use the configured reporting scope and per-recipient
+statistics, and synthetic preview validation contains no production identities,
+history, artwork, credentials, or other private state.
+
+## Validation
+
+The release is covered by renderer collection tests for all maintained
+packages; 36 synthetic cross-platform integration scenarios; more-than-ten,
+uneven, one-sided, empty, rated, unrated, Binge Champion, HTML, and plain-text
+fixtures; static, accessibility, and link validation; PowerShell 5.1 and 7
+syntax and policy coverage; Manager unit tests and cross-platform builds;
+byte-reproducible release archives; Windows installer lifecycle coverage;
+multi-architecture container build and runtime boot checks; and synthetic
+desktop/mobile browser QA of production, Manager, and static showcase paths.


### PR DESCRIPTION
## Summary

- release the uncapped personal movie and TV statistics delivered by #130 as v0.20.0
- publish release notes covering the responsive two-title desktop and one-title mobile layout, compact weekly summary cards, and production-equivalent synthetic rating preview
- move the primary Quickstart feature spotlight to the newest qualifying feature release

## Validation

- `scripts/validate-repository.ps1`
- `scripts/validate-docs.ps1`
- `scripts/check-links.ps1`
- `scripts/validate-branding.ps1`
- `scripts/validate-platforms.ps1`
- `scripts/build-releases.ps1 -Version 0.20.0`
- `scripts/test-release-artifacts.ps1`
- `scripts/test-release-reproducibility.ps1 -Version 0.20.0`
- `scripts/test-windows-installer.ps1`
- feature PR #130 passed the complete repository, renderer, integration, Manager, installer, reproducibility, and multi-architecture container CI matrix

## Release boundary

After this PR is merged, tag the exact merge commit as `v0.20.0`. The tag-triggered workflows will publish the GitHub release archives and normal GHCR container output.
