### PR TITLE
chore: prepare v0.20.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-08-21
+
 ### Changed
 
 - Clarified `origin-host-mismatch` recovery in the shared Manager and macOS

--- a/docs/releases/v0.20.1.md
+++ b/docs/releases/v0.20.1.md
@@ -1,0 +1,49 @@
+# TautWeekly for Plex v0.20.1
+
+v0.20.1 preserves optional custom-card content while the card is disabled and
+adds direct recovery guidance for reverse proxies that rewrite the Manager's
+public `Host`. It applies to the shared Manager used by every maintained
+package; no renderer or newsletter-layout behavior changes.
+
+## Custom text card persistence
+
+Turning off **Enable custom text card** now has an explicit, regression-tested
+contract: the card is hidden from generated previews and delivered newsletters,
+while its saved title, title GIF, subheading, body, border color, and opacity
+remain in the configuration. Re-enabling the card restores those retained
+values. Existing enabled and disabled configurations require no migration.
+
+This release does not alter preview generation or test-send rendering. After a
+Manager update, refresh the browser before assessing newly shipped controls or
+saved state so the page uses the current embedded application assets.
+
+## Reverse-proxy Host recovery
+
+The fixed `origin-host-mismatch` Manager message now explains that the browser
+origin must match the public `Host` received by TautWeekly. A reverse proxy must
+preserve that original public host rather than rewrite it to a loopback or
+backend address. For Cloudflare Tunnel routes, remove an `httpHostHeader`
+override that replaces the public hostname, then retry the protected action.
+
+Do not work around the rejection by allowlisting the rewritten backend host.
+Exact same-origin, Host allowlisting, CSRF and authentication checks, HTTPS and
+secure-cookie requirements, and distrust of forwarding headers are unchanged.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for the installed
+package. Container installations should use their supported recreate/update
+workflow so the new shared Manager binary and embedded browser assets are
+loaded. Refresh any already-open Manager page after the update. Existing
+configuration, credentials, schedules, output, backups, operation history,
+and welcome state remain in their private locations.
+
+## Validation
+
+The release is covered by a focused save-disable-re-enable persistence test for
+every custom-card field, shared embedded-asset assertions for the sanitized
+origin guidance, the full Manager test and vet suites, JavaScript and
+accessibility checks, repository, privacy, documentation, link, platform,
+PowerShell, cross-build, release-archive reproducibility, Windows installer,
+and multi-architecture container validation. Synthetic Manager browser QA was
+also completed without production configuration or identities.


### PR DESCRIPTION
## Summary

- mark the merged custom-card persistence and reverse-proxy guidance fix as v0.20.1
- add focused maintenance release notes without changing the v0.20.0 feature spotlight
- preserve all existing package, rendering, security, privacy, and configuration behavior

## Validation

- `scripts/validate-docs.ps1`
- `scripts/check-links.ps1`
- `scripts/validate-repository.ps1`
- full feature validation and all 13 PR #132 checks passed before merge
