### PR TITLE
fix: refresh generated previews on completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           node --check docs/gui-preview/app.js
           node scripts/test-gui-preview-personal-stats.mjs
           node scripts/test-manager-update-indicator.mjs
+          node scripts/test-manager-preview-refresh.mjs
       - name: Validate shell scripts
         run: ./scripts/validate-shell.sh
       - name: Test container health behavior

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,9 @@ jobs:
         shell: pwsh
         run: ./scripts/test-manager-cross-builds.ps1
       - name: Validate embedded Manager JavaScript
-        run: node --check manager/internal/manager/web/app.js
+        run: |
+          node --check manager/internal/manager/web/app.js
+          node scripts/test-manager-preview-refresh.mjs
       - name: Validate Manager accessibility structure
         run: python scripts/test-manager-accessibility.py
       - name: Test synthetic GUI preview personal statistics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Refreshed the shared Manager preview inventory after a successful manual
+  generation and reloaded the selected state's new artifact without a click or
+  browser refresh, while preserving the selected scenario when available.
+
 ## [0.20.1] - 2026-08-21
 
 ### Changed

--- a/manager/internal/manager/web/app.js
+++ b/manager/internal/manager/web/app.js
@@ -2355,7 +2355,24 @@ function orderedPreviews() {
   });
 }
 
-function renderPreviews() {
+function preferredPreviewForInventory(previews, selectedID, preferredScenario, generatedPreviewIDs) {
+  const generated = new Set(generatedPreviewIDs || []);
+  const selected = previews.find((preview) => preview.id === selectedID);
+  const scenarioAvailable = Number.isInteger(preferredScenario) && preferredScenario >= 0 && preferredScenario < Number.MAX_SAFE_INTEGER;
+  const sameScenario = scenarioAvailable
+    ? previews.find((preview) => previewScenarioIndex(preview) === preferredScenario)
+    : null;
+  return (selected && generated.has(selected.id) ? selected : null)
+    || (sameScenario && generated.has(sameScenario.id) ? sameScenario : null)
+    || selected
+    || sameScenario
+    || previews.find((preview) => generated.has(preview.id) && /-00-index(?:\.html)?$/i.test(preview.name))
+    || previews.find((preview) => generated.has(preview.id))
+    || previews[0]
+    || null;
+}
+
+function renderPreviews(options = {}) {
   const list = byId("preview-list");
   list.replaceChildren();
   const previews = orderedPreviews();
@@ -2366,6 +2383,7 @@ function renderPreviews() {
     const frame = byId("preview-frame");
     frame.hidden = true;
     frame.removeAttribute("data-preview-id");
+    frame.removeAttribute("data-preview-reload-key");
     frame.src = "about:blank";
     const empty = document.createElement("div");
     empty.className = "config-empty";
@@ -2386,15 +2404,16 @@ function renderPreviews() {
     button.addEventListener("click", () => openPreview(preview.id, button));
     list.append(button);
   }
-  const selected = previews.find((preview) => preview.id === state.selectedPreviewID);
   const latestRun = state.history.find((operation) => operation.type === "preview-all" && operation.state === "succeeded" && operation.generatedPreviewIds?.length);
-  const generated = new Set(latestRun?.generatedPreviewIds || []);
-  const preferred = selected
-    || previews.find((preview) => generated.has(preview.id) && /-00-index(?:\.html)?$/i.test(preview.name))
-    || previews.find((preview) => generated.has(preview.id))
-    || previews[0];
+  const preferred = preferredPreviewForInventory(
+    previews,
+    state.selectedPreviewID,
+    options.preferredScenario,
+    options.generatedPreviewIDs || latestRun?.generatedPreviewIds,
+  );
+  if (!preferred) return;
   const button = list.querySelector(`[data-preview-id="${CSS.escape(preferred.id)}"]`);
-  if (button) openPreview(preferred.id, button);
+  if (button) openPreview(preferred.id, button, { reloadKey: options.reloadKey });
 }
 
 function renderOperations() {
@@ -2760,6 +2779,8 @@ async function cancelPreviewOperation() {
 }
 
 let operationPollTimer;
+let operationPollSequence = 0;
+let operationCompletionProcessedID = "";
 
 function manageDeliveryStatusPolling() {
   clearTimeout(deliveryStatusPollTimer);
@@ -2785,33 +2806,63 @@ async function pollDeliveryStatus() {
 
 function manageOperationPolling() {
   clearTimeout(operationPollTimer);
+  operationPollSequence += 1;
   if (!operationIsActive(state.operation)) return;
-  operationPollTimer = setTimeout(pollOperation, 1000);
+  const expectedOperationID = state.operation?.id || "";
+  const expectedSequence = operationPollSequence;
+  operationPollTimer = setTimeout(() => pollOperation(expectedOperationID, expectedSequence), 1000);
 }
 
-async function pollOperation() {
+function operationPollIsCurrent(expectedOperationID, expectedSequence) {
+  return expectedSequence === operationPollSequence && state.operation?.id === expectedOperationID;
+}
+
+function successfulPreviewGeneration(operation) {
+  return operation?.type === "preview-all" && operation.state === "succeeded";
+}
+
+async function pollOperation(expectedOperationID = state.operation?.id || "", expectedSequence = operationPollSequence) {
+  if (!operationPollIsCurrent(expectedOperationID, expectedSequence)) return;
+  if (!operationIsActive(state.operation) && operationCompletionProcessedID === expectedOperationID) return;
   const priorState = state.operation?.state;
   try {
     const response = await request("/api/v1/operations/current");
-    state.operation = response.current || null;
+    if (!operationPollIsCurrent(expectedOperationID, expectedSequence)) return;
+    if (!response.current || response.current.id !== expectedOperationID) return;
+    state.operation = response.current;
     if (operationIsActive(state.operation)) {
       renderOperations();
       renderStatus();
       manageOperationPolling();
       return;
     }
-    const [previews, history, status, configurationStatus] = await Promise.all([
-      request("/api/v1/previews"),
+    if (operationCompletionProcessedID === state.operation.id) return;
+    const completedOperation = state.operation;
+    const refreshPreviews = successfulPreviewGeneration(completedOperation);
+    const selectedPreview = refreshPreviews
+      ? state.previews.find((preview) => preview.id === state.selectedPreviewID)
+      : null;
+    const requests = [
       request("/api/v1/history"),
       request("/api/v1/status"),
       request("/api/v1/config/status"),
-    ]);
-    state.previews = previews.previews || [];
+    ];
+    if (refreshPreviews) requests.push(request("/api/v1/previews"));
+    const [history, status, configurationStatus, previews] = await Promise.all(requests);
+    if (!operationPollIsCurrent(expectedOperationID, expectedSequence)) return;
+    if (refreshPreviews) state.previews = previews?.previews || [];
     state.historyMaximum = Number(history.maximumEntries) || 20;
     state.history = (history.operations || []).slice(0, state.historyMaximum);
     state.status = status;
     state.setupWorkflow = configurationStatus?.available ? configurationStatus : null;
-    renderPreviews();
+    operationCompletionProcessedID = completedOperation.id;
+    if (refreshPreviews) {
+      renderPreviews({
+        preferredScenario: previewScenarioIndex(selectedPreview),
+        generatedPreviewIDs: completedOperation.generatedPreviewIds,
+        reloadKey: completedOperation.id,
+      });
+    }
     renderOperations();
     renderStatus();
     renderSetupWorkflow();
@@ -2820,10 +2871,11 @@ async function pollOperation() {
       setGlobalStatus(summary.heading + ".", true);
     }
   } catch (error) {
+    if (!operationPollIsCurrent(expectedOperationID, expectedSequence)) return;
     if (error.status === 401) showAuthentication();
     else {
       setGlobalStatus(error.message, true);
-      operationPollTimer = setTimeout(pollOperation, 2500);
+      operationPollTimer = setTimeout(() => pollOperation(expectedOperationID, expectedSequence), 2500);
     }
   }
 }
@@ -3573,15 +3625,20 @@ function diagnosticAreaLabel(area) {
   return area === "lan-verification" ? "Connection Verification" : titleCase(area);
 }
 
-function openPreview(id, button) {
+function openPreview(id, button, options = {}) {
   state.selectedPreviewID = id;
   document.querySelectorAll(".preview-button").forEach((element) => element.classList.remove("active"));
   button.classList.add("active");
   byId("preview-placeholder").hidden = true;
   const frame = byId("preview-frame");
-  if (frame.dataset.previewId !== id) {
-    frame.src = `/preview/${encodeURIComponent(id)}`;
+  const reloadKey = String(options.reloadKey || "");
+  const reloadRequested = reloadKey && frame.dataset.previewReloadKey !== reloadKey;
+  if (frame.dataset.previewId !== id || reloadRequested) {
+    const query = reloadKey ? `?refresh=${encodeURIComponent(reloadKey)}` : "";
+    frame.src = `/preview/${encodeURIComponent(id)}${query}`;
     frame.dataset.previewId = id;
+    if (reloadKey) frame.dataset.previewReloadKey = reloadKey;
+    else frame.removeAttribute("data-preview-reload-key");
   }
   frame.hidden = false;
 }

--- a/scripts/test-manager-preview-refresh.mjs
+++ b/scripts/test-manager-preview-refresh.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+"use strict";
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const productionPath = path.join(repositoryRoot, "manager", "internal", "manager", "web", "app.js");
+const productionJS = fs.readFileSync(productionPath, "utf8");
+
+function functionSource(name) {
+  const marker = `function ${name}(`;
+  let start = productionJS.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${name} in production Manager JavaScript`);
+  if (productionJS.slice(Math.max(0, start - 6), start) === "async ") start -= 6;
+  const bodyStart = productionJS.indexOf(") {", start) + 2;
+  let depth = 0;
+  let quote = "";
+  let escaped = false;
+  for (let index = bodyStart; index < productionJS.length; index += 1) {
+    const character = productionJS[index];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === quote) quote = "";
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+      continue;
+    }
+    if (character === "{") depth += 1;
+    if (character === "}") {
+      depth -= 1;
+      if (depth === 0) return productionJS.slice(start, index + 1);
+    }
+  }
+  assert.fail(`unterminated ${name} in production Manager JavaScript`);
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+const functions = [
+  "previewScenarioIndex",
+  "preferredPreviewForInventory",
+  "operationIsActive",
+  "manageOperationPolling",
+  "operationPollIsCurrent",
+  "successfulPreviewGeneration",
+  "pollOperation",
+  "openPreview",
+].map(functionSource).join("\n\n");
+
+function createHarness({ terminalState = "succeeded", previewResponse, selectedPreviewID = "normal-old", previewDeferred } = {}) {
+  const calls = [];
+  const renders = [];
+  const timers = [];
+  const oldPreviews = [
+    { id: "index-old", name: "preview-all-00-index", modifiedUtc: "2031-01-01T00:00:00Z", sizeBytes: 10 },
+    { id: "normal-old", name: "preview-all-04-normal-newsletter", modifiedUtc: "2031-01-01T00:00:00Z", sizeBytes: 20 },
+  ];
+  const nextPreviews = previewResponse || [
+    { id: "index-new", name: "preview-all-00-index", modifiedUtc: "2031-01-02T00:00:00Z", sizeBytes: 11 },
+    { id: "normal-new", name: "preview-all-04-normal-newsletter", modifiedUtc: "2031-01-02T00:00:00Z", sizeBytes: 21 },
+  ];
+  const operation = { id: "operation-2", type: "preview-all", state: "running", generatedPreviewIds: [] };
+  const terminal = {
+    ...operation,
+    state: terminalState,
+    generatedPreviewIds: terminalState === "succeeded" ? nextPreviews.map((preview) => preview.id) : [],
+  };
+  const context = {
+    state: {
+      operation,
+      previews: oldPreviews,
+      selectedPreviewID,
+      history: [],
+      historyMaximum: 20,
+      status: {},
+      setupWorkflow: null,
+    },
+    async request(target) {
+      calls.push(target);
+      if (target === "/api/v1/operations/current") return { current: terminal };
+      if (target === "/api/v1/history") return { maximumEntries: 20, operations: [terminal] };
+      if (target === "/api/v1/status") return { overall: "healthy" };
+      if (target === "/api/v1/config/status") return { available: true };
+      if (target === "/api/v1/previews") {
+        if (previewDeferred) return previewDeferred.promise;
+        return { previews: nextPreviews };
+      }
+      throw new Error(`unexpected request ${target}`);
+    },
+    renderPreviews(options) { renders.push({ name: "previews", options }); },
+    renderOperations() { renders.push({ name: "operations" }); },
+    renderStatus() { renders.push({ name: "status" }); },
+    renderSetupWorkflow() { renders.push({ name: "setup" }); },
+    operationSummary() { return { heading: "Preview generation completed" }; },
+    setGlobalStatus() {},
+    showAuthentication() {},
+    setTimeout(callback, delay) { timers.push({ callback, delay }); return timers.length; },
+    clearTimeout() {},
+    console,
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    let operationPollTimer;
+    let operationPollSequence = 0;
+    let operationCompletionProcessedID = "";
+    ${functions}
+    globalThis.testAPI = {
+      pollOperation,
+      manageOperationPolling,
+      preferredPreviewForInventory,
+      previewScenarioIndex,
+      openPreview,
+      sequence: () => operationPollSequence,
+    };
+  `, context);
+  return { context, calls, renders, timers, oldPreviews, nextPreviews, operation, terminal };
+}
+
+{
+  const harness = createHarness();
+  await harness.context.testAPI.pollOperation("operation-2", 0);
+  assert.equal(harness.calls.filter((target) => target === "/api/v1/previews").length, 1, "successful completion did not refresh inventory exactly once");
+  assert.deepEqual(harness.context.state.previews, harness.nextPreviews, "fresh preview inventory was not applied");
+  const previewRender = harness.renders.find((render) => render.name === "previews");
+  assert.equal(previewRender.options.preferredScenario, 4, "selected scenario was not preserved across changed preview IDs");
+  assert.equal(previewRender.options.reloadKey, "operation-2", "successful generation did not request a new-artifact reload");
+  assert.deepEqual(Array.from(previewRender.options.generatedPreviewIDs), ["index-new", "normal-new"]);
+  const requestCount = harness.calls.length;
+  await harness.context.testAPI.pollOperation("operation-2", 0);
+  assert.equal(harness.calls.length, requestCount, "processed completion issued redundant follow-up requests");
+  assert.equal(harness.calls.filter((target) => target === "/api/v1/previews").length, 1, "processed completion issued a redundant inventory request");
+}
+
+for (const terminalState of ["failed", "cancelled"]) {
+  const harness = createHarness({ terminalState });
+  await harness.context.testAPI.pollOperation("operation-2", 0);
+  assert.equal(harness.calls.includes("/api/v1/previews"), false, `${terminalState} generation refreshed preview inventory`);
+  assert.equal(harness.renders.some((render) => render.name === "previews"), false, `${terminalState} generation reloaded the visible preview`);
+}
+
+{
+  const harness = createHarness({ selectedPreviewID: "missing" });
+  const preferred = harness.context.testAPI.preferredPreviewForInventory(harness.nextPreviews, "missing", Number.MAX_SAFE_INTEGER, ["index-new", "normal-new"]);
+  assert.equal(preferred.id, "index-new", "invalid selection did not fall back to the newly generated index");
+  const previewsWithLegacyFile = [{ id: "legacy", name: "preview-legacy" }, ...harness.nextPreviews];
+  const emptySelection = harness.context.testAPI.preferredPreviewForInventory(previewsWithLegacyFile, "", Number.MAX_SAFE_INTEGER, ["normal-new"]);
+  assert.equal(emptySelection.id, "normal-new", "empty selection did not fall back to an available newly generated state");
+}
+
+{
+  const gate = deferred();
+  const harness = createHarness({ previewDeferred: gate });
+  const stalePoll = harness.context.testAPI.pollOperation("operation-2", 0);
+  await Promise.resolve();
+  await Promise.resolve();
+  harness.context.state.operation = { id: "operation-3", type: "preview-all", state: "running" };
+  harness.context.testAPI.manageOperationPolling();
+  gate.resolve({ previews: harness.nextPreviews });
+  await stalePoll;
+  assert.deepEqual(harness.context.state.previews, harness.oldPreviews, "stale completion overwrote the next operation's inventory");
+  assert.equal(harness.renders.some((render) => render.name === "previews"), false, "stale completion reloaded the next operation's frame");
+}
+
+{
+  let sourceAssignments = 0;
+  let source = "/preview/normal-old";
+  const attributes = {};
+  const frame = {
+    dataset: { previewId: "normal-old" },
+    hidden: false,
+    get src() { return source; },
+    set src(value) { source = value; sourceAssignments += 1; },
+    removeAttribute(name) { delete attributes[name]; if (name === "data-preview-reload-key") delete this.dataset.previewReloadKey; },
+  };
+  const button = { classList: { add() {} } };
+  const context = {
+    state: { selectedPreviewID: "normal-old" },
+    document: { querySelectorAll() { return [{ classList: { remove() {} } }]; } },
+    byId(id) {
+      if (id === "preview-frame") return frame;
+      if (id === "preview-placeholder") return { hidden: false };
+      throw new Error(`unexpected element ${id}`);
+    },
+    encodeURIComponent,
+  };
+  vm.createContext(context);
+  vm.runInContext(`${functionSource("openPreview")}; globalThis.openPreviewForTest = openPreview;`, context);
+  context.openPreviewForTest("normal-old", button, { reloadKey: "operation-2" });
+  assert.equal(source, "/preview/normal-old?refresh=operation-2", "selected preview did not navigate to its new artifact URL");
+  assert.equal(sourceAssignments, 1);
+  context.openPreviewForTest("normal-old", button, { reloadKey: "operation-2" });
+  assert.equal(sourceAssignments, 1, "same completion redundantly reloaded the iframe");
+}
+
+console.log("[PASS] Manager preview completion refresh, selection, reload, terminal-state, request, and race contracts.");


### PR DESCRIPTION
## Summary

- refresh the shared Manager preview inventory exactly once when a manual `preview-all` operation succeeds
- preserve the selected newsletter scenario when it remains available and force the iframe to navigate to the newly generated artifact
- ignore stale completion responses and avoid preview requests/reloads for failed, cancelled, or non-preview operations
- regression-test completion refresh, selection/fallback, iframe reload, redundant-request, terminal-state, and race contracts in CI and release workflows

## Validation

- `node scripts/test-manager-preview-refresh.mjs`
- Manager and installer `go test ./...` / `go vet ./...`, including uninstaller tags
- Manager cross-builds for Windows, Linux, macOS, and FreeBSD amd64/arm64
- repository/privacy, branding, docs, links, platforms, PowerShell syntax, Unraid, and accessibility validation
- all nine release artifacts, checksums, functional contracts, reproducibility, and isolated Windows installer lifecycle
- PowerShell cache, backup, renderer parity, 33-scenario recipient policy, scheduler timezone, and Windows update tests
- desktop and 390x844 mobile browser QA against the reviewed loopback-only synthetic fixture

The Primary Quickstart feature spotlight remains on v0.20.0 because this is a maintenance fix.
