### PR TITLE
chore: prepare v0.20.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.2] - 2026-08-21
+
 ### Fixed
 
 - Refreshed the shared Manager preview inventory after a successful manual

--- a/docs/releases/v0.20.2.md
+++ b/docs/releases/v0.20.2.md
@@ -1,0 +1,42 @@
+# TautWeekly for Plex v0.20.2
+
+v0.20.2 refreshes the shared Manager's manual local-preview experience after
+a successful generation. Newly written previews now appear automatically and
+the visible document reloads without another click or a browser refresh. The
+fix applies to the shared Manager used by every maintained package; renderer,
+generation, delivery, configuration, scheduling, privacy, and network behavior
+are unchanged.
+
+## Automatic preview refresh
+
+When **Generate local previews** completes successfully, the Manager fetches
+the available-preview inventory once and opens the new artifact. If the
+previously selected scenario is present in the new generation, that scenario
+remains selected and its new document is loaded instead of reusing the old
+iframe content. An unavailable or empty selection falls back to the generated
+index or another available generated state.
+
+Failed, cancelled, stale, and unrelated operations do not trigger a preview
+inventory request or reload. The existing bounded operation-status polling is
+unchanged, and duplicate completion handling does not introduce redundant
+requests.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for the installed
+package. Container installations should use their supported recreate/update
+workflow so the new shared Manager binary and embedded browser assets are
+loaded. Existing configuration, credentials, schedules, output, backups,
+operation history, and welcome state remain in their private locations.
+
+## Validation
+
+The release is covered by focused regression tests for completion-triggered
+inventory refresh, selection preservation, new-artifact reload, fallback,
+failure and cancellation behavior, duplicate-request prevention, and stale
+response safety. Validation also includes the full Manager test and vet suites,
+JavaScript and accessibility checks, repository and privacy validation,
+documentation and link checks, PowerShell tests, maintained Manager
+cross-builds, reproducible release archives, the Windows installer lifecycle,
+multi-architecture containers, and synthetic desktop and mobile Manager
+browser QA.


### PR DESCRIPTION
## Summary

- publish the successful manual-preview refresh fix as v0.20.2
- add release notes and move the maintenance fix into the dated changelog section
- retain the Primary Quickstart feature spotlight on v0.20.0

## Validation

- repository privacy and structure validation
- documentation feature and relative-link validation
- focused Manager preview-completion regression suite
- v0.20.2 release artifact contracts and SHA-256 checks
- byte-identical v0.20.2 archive reproducibility
- full implementation CI and synthetic desktop/mobile Manager browser QA completed in #134
