### PR TITLE
chore: prepare v0.20.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.3] - 2026-08-21
+
 ### Changed
 
 - Kept the full-width TV watched card at two titles per row on mobile while

--- a/docs/releases/v0.20.3.md
+++ b/docs/releases/v0.20.3.md
@@ -1,0 +1,40 @@
+# TautWeekly for Plex v0.20.3
+
+v0.20.3 refines the uncapped personal-stat layout introduced in v0.20.0.
+Movies watched and TV watched remain separate full-width cards with two titles
+per row on desktop. On mobile, movie titles stack one per row while TV titles
+retain two columns, including a safe half-width spacer when the TV count is
+odd.
+
+## Mobile TV pairing
+
+The responsive TV-specific cell classes and email-compatible media rules are
+applied consistently across the Windows, NAS/Linux/FreeBSD, and macOS
+renderers. The static email fixture and network-local synthetic Manager preview
+mirror the same layout. Movie rows and compact personal total-watch-time and
+Binge Champion cards keep their existing mobile stacking behavior.
+
+The synthetic preview also limits poster sizing to direct poster images so its
+nested IMDb badge retains the production 28-by-14 treatment instead of being
+stretched. Rating eligibility, aggregation, deduplication, ranking, privacy,
+watch-time semantics, plain-text output, and empty-state behavior are
+unchanged.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for the installed
+package. Container installations should use their supported recreate/update
+workflow so the refreshed renderer and Manager preview assets are loaded.
+Existing configuration, credentials, schedules, output, backups, operation
+history, and welcome state remain in their private locations.
+
+## Validation
+
+The release is covered by focused renderer, integration, preview, artifact,
+documentation, and accessibility contracts for uncapped 12-movie/11-TV data,
+uneven and odd counts, one-sided and empty states, eligible and absent ratings,
+Binge Champion states, desktop and mobile layouts, plain text, and
+email-compatible HTML. Validation also includes the full Manager and installer
+test/vet suites, maintained cross-builds, PowerShell and shell validation,
+reproducible release archives, the Windows installer lifecycle,
+multi-architecture container build and boot tests, and synthetic browser QA.


### PR DESCRIPTION
## Summary

- promote the mobile TV-pairing and synthetic IMDb preview fixes to v0.20.3 in the changelog
- add repository-standard v0.20.3 release notes covering behavior, update guidance, compatibility, and validation

## Scope

- Platforms affected: release metadata for all maintained packages
- User impact: publishes the already-merged personal-stat mobile layout refinement as v0.20.3
- Compatibility or migration notes: none

## Validation

- [x] Documentation feature and JavaScript validation passed
- [x] Repository hygiene, privacy, JSON, and sanitized-example validation passed
- [x] `git diff --check` passed
- [x] Feature PR #136 passed all required CI, reproducibility, installer lifecycle, and multi-architecture container gates

## Privacy and safety

- [x] No live config, `.env`, state, logs, generated output, credentials, personal addresses, server names, private addresses, or local paths are included
- [x] Real-send confirmation and preview-first safeguards remain intact
- [x] No new third-party code or assets were added
