### PR TITLE
chore: prepare v0.20.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.4] - 2026-08-22
+
 ### Fixed
 
 - Made the shared Manager header **Refresh** render local and cached status

--- a/docs/releases/v0.20.4.md
+++ b/docs/releases/v0.20.4.md
@@ -1,0 +1,48 @@
+# TautWeekly for Plex v0.20.4
+
+v0.20.4 makes the main Manager header **Refresh** aware of stale or missing
+stable-release status without making local status depend on the Internet.
+
+## Local first, update check second
+
+The header control finishes its normal local and cached status reload first.
+Only after that succeeds does it consult the backend's typed update status and
+start a non-blocking version check when one is recommended. GitHub latency or
+failure never delays or fails the overall local refresh; progress and sanitized
+failure remain in **Settings > Updates**.
+
+Authenticated application entry and the explicit **Check now** action retain
+their existing semantics. Repeated header clicks reuse the five-minute success
+cache, failure backoff, and single active-check lock. A later header refresh can
+start a newly stale or otherwise applicable check because no session-wide flag
+suppresses future attempts.
+
+## Preserved update boundary
+
+The check retains the 24-hour stale threshold, eight-second deadline, fixed
+stable GitHub release endpoint, strict release and platform-asset validation,
+authentication, same-origin and CSRF protection, public-only cached metadata,
+offline-capable health, and package-owned install guidance. Refreshing
+Tautulli choices, Tailscale access, schedules, operations, configuration
+status, or the browser does not initiate an update request.
+
+The shared production Manager provides the same behavior on Windows, macOS
+Docker, NAS/Docker, QNAP, Unraid, compatible Docker, native Linux, and FreeBSD.
+The static GUI Preview mirrors the sequence entirely in memory without network
+access.
+
+## Update existing installations
+
+Back up private data, then use the documented update path for the installed
+package. Existing configuration, credentials, schedules, output, backups,
+operation history, and update cache remain in their private locations.
+
+## Validation
+
+Regression coverage exercises stale, fresh, backoff, active, repeated-click,
+unsupported, failure, authenticated-entry, manual-check, and scoped-control
+cases. Release validation also includes the full Manager and installer test and
+vet suites, maintained cross-builds, desktop and mobile browser QA, repository
+privacy and package contracts, shell and PowerShell suites, reproducible
+archives and checksums, the Windows installer lifecycle, and the
+multi-architecture container build and boot tests.


### PR DESCRIPTION
## Summary

- publish the merged header Refresh maintenance fix as v0.20.4
- move the newest-first changelog entry from Unreleased into the dated patch section
- add release notes covering local-first behavior, retained update security boundaries, platform scope, and validation
- keep the Primary Quickstart feature spotlight on v0.20.0

## Validation

- repository privacy, documentation feature policy, and link validation
- product PR #138 passed all CI, reproducible archive, Windows lifecycle, and multi-architecture container checks