### PR TITLE
chore: prepare v0.20.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.5] - 2026-08-23
+
+### Changed
+
+- Show the selected recipient's most-played recognized platform icon directly
+  after the weekly heading, using most-recent activity to break play-count ties.
+  Icons remain local and embedded; blank, unknown, missing, or mismatched-user
+  platform data is omitted without leaving a gap.
+
 ## [0.20.4] - 2026-08-22
 
 ### Fixed

--- a/docs/releases/v0.20.5.md
+++ b/docs/releases/v0.20.5.md
@@ -1,0 +1,24 @@
+# TautWeekly for Plex v0.20.5
+
+v0.20.5 adds a small recipient-specific platform mark to the weekly newsletter
+heading without changing configuration or private-data boundaries.
+
+## Recipient-scoped platform icon
+
+When report-window Tautulli history contains a recognized platform, the icon
+after **YOUR WEEK ON PLEX** represents that recipient's highest play total. The
+most recently used platform breaks ties. Unknown, blank, missing, or
+mismatched-user data leaves the original heading unchanged.
+
+The 21px icons are bundled with TautWeekly and embedded into email; newsletters
+make no external image request. The same behavior applies to production sends,
+manual/test sends, and applicable preview states on every supported package.
+Platform and device details are not added to logs or Manager history.
+
+## Validation and update
+
+Coverage includes platform aliases, grouped plays, tie-breaking, recipient
+isolation, unknown/no-activity fallbacks, escaping, accessible MIME rendering,
+package parity, checksums, and desktop/mobile visual QA. Update with the normal
+package-specific procedure; existing configuration and private runtime data are
+preserved.


### PR DESCRIPTION
## Summary

- add a brief v0.20.5 `Changed` entry for the recipient-scoped newsletter platform icon
- add concise v0.20.5 release notes without changing the v0.20.0 Quickstart feature spotlight

## Validation

- built all v0.20.5 release artifacts locally
- packaged runtime contracts, platform icon hashes/dimensions, notices, and checksums passed
- repeated v0.20.5 builds produced byte-identical artifacts
- repository privacy, docs policy, and 85 relative-link checks passed

Release contents are implementation merge `1e1bee56e0d75954e04b3f1ad8f7aa31c9932dfc` plus this metadata commit.