### PR TITLE
fix: make header refresh check updates

### DIFF
--- a/docs/gui-preview/README.md
+++ b/docs/gui-preview/README.md
@@ -13,9 +13,9 @@ notification, **Check now**, and the confirmed updater state entirely in
 memory. It does not contact GitHub, launch a process, request elevation, or
 change a file. Successful synthetic results are reused for five minutes to
 mirror the production duplicate-check guard. The header **Refresh** completes
-its synthetic local-status refresh before starting a recommended in-memory
-background check; the other scoped refresh controls remain isolated. Reload
-resets the demonstration.
+its synthetic local-status refresh before running the same in-memory manual
+check as **Check now**; the other scoped refresh controls remain isolated.
+Reload resets the demonstration.
 
 The newsletter frames intentionally mirror the production email presentation.
 They bundle local copies of public media artwork and title logos plus dated

--- a/docs/gui-preview/app.js
+++ b/docs/gui-preview/app.js
@@ -283,7 +283,7 @@ async function loadAll() {
 }
 
 async function refreshApplicationStatus() {
-  if (await loadAll()) checkForUpdatesInBackground();
+  if (await loadAll()) await checkForUpdates();
 }
 
 function renderFirstTimeSetup() {

--- a/manager/README.md
+++ b/manager/README.md
@@ -183,14 +183,13 @@ and exact platform asset plus checksum URLs. `POST /api/v1/updates/install`
 accepts no caller-controlled update arguments. Cached failures contain only
 fixed public messages and support codes.
 
-Authenticated entry and the main header **Refresh** both render the local
-`GET /api/v1/updates` result before consulting its typed
-`backgroundCheckRecommended` field. The header's local refresh completes
-without waiting for GitHub; only an applicable stale or missing result starts
-the same non-blocking check. The five-minute success cache, failure backoff,
-and single active-check lock suppress repeated clicks. Settings **Check now**
-remains the explicit manual action, and no scoped refresh control inherits this
-behavior.
+Authenticated entry renders the local `GET /api/v1/updates` result before
+consulting its typed `backgroundCheckRecommended` field, so only a stale or
+missing result starts a non-blocking check. The main header **Refresh** renders
+local status first and then runs the same manual check path as Settings **Check
+now**, including its visible result. The five-minute success delay, failure
+backoff, and single active-check lock suppress repeated upstream requests. No
+scoped refresh control inherits this behavior.
 
 The Windows release build cross-compiles this module as
 `tautweekly-manager.exe`, packages it into the portable Windows ZIP, and embeds

--- a/manager/internal/manager/web/app.js
+++ b/manager/internal/manager/web/app.js
@@ -324,7 +324,7 @@ async function loadAll() {
 }
 
 async function refreshApplicationStatus() {
-  if (await loadAll()) checkForUpdatesInBackground();
+  if (await loadAll()) await checkForUpdates();
 }
 
 function runtimeMode() {
@@ -3443,7 +3443,7 @@ function renderUpdates() {
   else if (update.installState === "completed") message.textContent = "The verified Windows updater completed. Refreshing local package status.";
   else if (backoffActive) message.textContent = `The next manual check is available after ${formatDate(update.nextCheckAllowedAtUtc)}. This bounded delay prevents repeated upstream requests.`;
   else if (update.lastFailure?.action === "check") message.textContent = "The last check failed safely. Cached local status remains available, and newsletter delivery is unaffected.";
-  else message.textContent = "Normal Manager and dashboard health never depend on Internet availability. Authenticated entry and header Refresh render local status first, then check only when release status is stale or missing; Check now provides an explicit refresh.";
+  else message.textContent = "Normal Manager and dashboard health never depend on Internet availability. Authenticated entry checks only when cached release status is stale or missing. Header Refresh and Check now both request a manual stable-release check after local status loads.";
 }
 
 function renderUpdateStatusButton(update) {

--- a/scripts/test-manager-accessibility.py
+++ b/scripts/test-manager-accessibility.py
@@ -463,8 +463,8 @@ def main() -> int:
         failures.append("background checks retain a session-wide suppression flag")
     if 'state.updateChecking || !state.updates?.backgroundCheckRecommended' not in javascript or 'void runUpdateCheck(true);' not in javascript:
         failures.append("background update refresh is not gated by server cache freshness and backoff")
-    if 'async function refreshApplicationStatus()' not in javascript or 'byId("refresh-button").addEventListener("click", refreshApplicationStatus)' not in javascript:
-        failures.append("header Refresh does not run the scoped local-first background update handler")
+    if 'if (await loadAll()) await checkForUpdates();' not in javascript or 'byId("refresh-button").addEventListener("click", refreshApplicationStatus)' not in javascript:
+        failures.append("header Refresh does not run the scoped local-first Check now handler")
     if 'Update available — Version' in args.html.read_text(encoding="utf-8"):
         failures.append("static header markup exposes a stale update version before validated state is rendered")
     if ".update-status-button" not in css or "color:var(--violet)" not in css or "animation:hero-pulse" not in css:

--- a/scripts/test-manager-header-refresh.mjs
+++ b/scripts/test-manager-header-refresh.mjs
@@ -97,7 +97,7 @@ function createHarness({ localStatuses = [staleStatus], localGate, localSuccess 
       return localSuccess;
     },
     async request(target, options = {}) {
-      assert.equal(target, "/api/v1/updates/check", "background refresh used an unexpected endpoint");
+      assert.equal(target, "/api/v1/updates/check", "refresh update check used an unexpected endpoint");
       assert.equal(options.method, "POST", "update check method changed");
       assert.equal(options.body, "{}", "update check body changed");
       events.push(state.updateCheckBackground ? "check:background" : "check:manual");
@@ -141,26 +141,27 @@ async function flushAsyncWork() {
   const refresh = harness.context.testAPI.refreshApplicationStatus();
   assert.equal(harness.requests.length, 0, "header Refresh checked before local status completed");
   gate.resolve();
-  await refresh;
-  assert.equal(harness.requests.length, 1, "stale applicable header Refresh did not start exactly one check");
-  assert.deepEqual(harness.events.slice(0, 3), ["local:start", "local:complete", "updates:render"]);
-  assert.ok(harness.events.indexOf("check:background") > harness.events.indexOf("local:complete"), "background check preceded local completion");
-  assert.equal(harness.requests[0].background, true);
-  assert.equal(harness.state.updateChecking, true, "header Refresh waited for the release request");
-  check.resolve(freshStatus);
   await flushAsyncWork();
+  assert.equal(harness.requests.length, 1, "header Refresh did not start exactly one manual check");
+  assert.deepEqual(harness.events.slice(0, 3), ["local:start", "local:complete", "updates:render"]);
+  assert.ok(harness.events.indexOf("check:manual") > harness.events.indexOf("local:complete"), "manual check preceded local completion");
+  assert.equal(harness.requests[0].background, false);
+  assert.equal(harness.state.updateChecking, true, "header Refresh did not share Check now's in-flight state");
+  check.resolve(freshStatus);
+  await refresh;
   assert.equal(harness.state.updateChecking, false);
+  assert.equal(harness.globalStatuses.at(-1).message, "Stable update check completed.");
 }
 
-for (const [name, status] of Object.entries({
-  fresh: freshStatus,
-  backoff: { ...staleStatus, backgroundCheckRecommended: false, nextCheckAllowedAtUtc: "2031-04-18T16:40:00Z" },
-  "in progress": { ...staleStatus, backgroundCheckRecommended: false, checkInProgress: true },
-  unsupported: { ...staleStatus, updateChannel: "unsupported", backgroundCheckRecommended: false },
-})) {
-  const harness = createHarness({ localStatuses: [status] });
+{
+  const harness = createHarness({
+    localStatuses: [freshStatus],
+    checkResults: [{ ...freshStatus, state: "update-available", updateAvailable: true }],
+  });
   await harness.context.testAPI.refreshApplicationStatus();
-  assert.equal(harness.requests.length, 0, `${name} status initiated a header update check`);
+  assert.equal(harness.requests.length, 1, "fresh cached status suppressed the explicit header Refresh check");
+  assert.equal(harness.requests[0].background, false, "header Refresh did not use Check now semantics");
+  assert.equal(harness.globalStatuses.at(-1).message, "Stable update found.");
 }
 
 {
@@ -175,14 +176,14 @@ for (const [name, status] of Object.entries({
     localStatuses: [staleStatus, staleStatus, staleStatus],
     checkResults: [firstCheck.promise, freshStatus],
   });
-  await harness.context.testAPI.refreshApplicationStatus();
+  const firstRefresh = harness.context.testAPI.refreshApplicationStatus();
+  await flushAsyncWork();
   await harness.context.testAPI.refreshApplicationStatus();
   assert.equal(harness.requests.length, 1, "repeated header clicks created concurrent checks");
   firstCheck.resolve(freshStatus);
-  await flushAsyncWork();
+  await firstRefresh;
   await harness.context.testAPI.refreshApplicationStatus();
-  assert.equal(harness.requests.length, 2, "a later newly applicable header refresh was permanently suppressed");
-  await flushAsyncWork();
+  assert.equal(harness.requests.length, 2, "a later header Refresh was permanently suppressed");
 }
 
 {
@@ -191,9 +192,9 @@ for (const [name, status] of Object.entries({
   const harness = createHarness({ checkResults: [Promise.reject(failure)] });
   await harness.context.testAPI.refreshApplicationStatus();
   await flushAsyncWork();
-  assert.equal(harness.globalStatuses.at(-1).message, "Local status refreshed.", "background failure replaced local refresh success");
-  assert.equal(harness.state.updates, staleStatus, "background failure discarded cached local update status");
-  assert.equal(harness.updateMessage.textContent, failure.message, "background failure was not retained in update presentation");
+  assert.equal(harness.globalStatuses.at(-1).message, failure.message, "header Refresh did not expose Check now's failure result");
+  assert.equal(harness.state.updates, staleStatus, "manual failure discarded cached local update status");
+  assert.equal(harness.updateMessage.textContent, failure.message, "manual failure was not retained in update presentation");
 }
 
 {
@@ -216,10 +217,11 @@ for (const [name, status] of Object.entries({
 for (const [name, source] of [["production", productionJS], ["preview", previewJS]]) {
   assert.doesNotMatch(source, /backgroundUpdateCheckAttempted/, `${name} retains a session-wide suppression flag`);
   assert.match(source, /byId\("refresh-button"\)\.addEventListener\("click", refreshApplicationStatus\)/, `${name} header Refresh is not scoped to the new handler`);
+  assert.match(source, /async function refreshApplicationStatus\(\) \{\s+if \(await loadAll\(\)\) await checkForUpdates\(\);\s+\}/, `${name} header Refresh does not share Check now semantics`);
   assert.equal((source.match(/refreshApplicationStatus/g) || []).length, 2, `${name} invokes the header-only handler from another path`);
   assert.equal((source.match(/addEventListener\("click", refreshApplicationStatus\)/g) || []).length, 1, `${name} attached the behavior to another control`);
   assert.match(source, /byId\("update-check-button"\)\.addEventListener\("click", checkForUpdates\)/, `${name} explicit Check now semantics changed`);
   assert.doesNotMatch(source, /byId\("tailscale-refresh-button"\)\.addEventListener\("click", refreshApplicationStatus\)/, `${name} Tailscale verification gained an update check`);
 }
 
-console.log("[PASS] Header Refresh local-first, applicability, concurrency, retry, failure, entry, manual, and isolation contracts.");
+console.log("[PASS] Header Refresh local-first Check now parity, concurrency, retry, failure, entry, and isolation contracts.");

--- a/scripts/test-manager-update-indicator.mjs
+++ b/scripts/test-manager-update-indicator.mjs
@@ -98,9 +98,9 @@ const initializeSource = productionJS.slice(productionJS.indexOf("async function
 const authenticatedEntrySource = productionJS.slice(productionJS.indexOf("async function enterApplication"), productionJS.indexOf("async function loadAll()"));
 assert.doesNotMatch(initializeSource.slice(0, initializeSource.indexOf("await enterApplication()")), /checkForUpdatesInBackground/, "unauthenticated bootstrap can trigger an update check");
 assert.match(authenticatedEntrySource, /const localStatusLoaded = await loadAll\(\);[\s\S]+if \(localStatusLoaded\) checkForUpdatesInBackground\(\);/, "cached status must render before the authenticated background check");
-assert.match(productionJS, /async function refreshApplicationStatus\(\) \{\s+if \(await loadAll\(\)\) checkForUpdatesInBackground\(\);\s+\}/, "header Refresh does not sequence the local load before the eligible check");
+assert.match(productionJS, /async function refreshApplicationStatus\(\) \{\s+if \(await loadAll\(\)\) await checkForUpdates\(\);\s+\}/, "header Refresh does not sequence local loading before the Check now path");
 assert.match(productionJS, /byId\("refresh-button"\)\.addEventListener\("click", refreshApplicationStatus\)/, "header Refresh is not wired to the scoped update-aware handler");
-assert.equal((productionJS.match(/checkForUpdatesInBackground\(\)/g) || []).length, 3, "background checks escaped authenticated entry and the header Refresh handler");
+assert.equal((productionJS.match(/checkForUpdatesInBackground\(\)/g) || []).length, 2, "background checks escaped authenticated entry");
 assert.match(productionJS, /addEventListener\("click", openUpdateSettings\)/);
 assert.match(productionJS, /addEventListener\("popstate", applyLocationRoute\)/);
 assert.match(productionJS, /update-settings-heading"\)\.focus/);


### PR DESCRIPTION
## Summary
- make the main header Refresh load local state and then run the exact manual Check now path
- keep authenticated startup on the cache-aware background path
- keep preview behavior and focused assertions aligned

## Root cause
v0.20.4 treated a successful release lookup as background-fresh for 24 hours, so header Refresh could reuse the cached version after a newer release was published.

## Validation
- `node --check manager/internal/manager/web/app.js`
- `node --check docs/gui-preview/app.js`
- `node scripts/test-manager-header-refresh.mjs`
- `node scripts/test-manager-update-indicator.mjs`