### PR TITLE
fix: restore rich preview scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored distinct populated lifecycle states in **Preview All** and **Send Test
+  All** when the selected recipient has no report-window activity, using
+  sanitized scenario-only statistics while ordinary Preview and Send Test keep
+  using the recipient's real state.
+- Kept the **Trending** hero in the quiet-week **Latest Releases** shelves, capped
+  at four movies and four TV titles, so newsletters still contain recent library
+  choices when no titles were added during the report window.
+
 ## [0.20.7] - 2026-08-24
 
 ### Fixed

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -6646,7 +6646,7 @@ function Build-NewsletterHtml {
         [bool]$HotRelease.IsTrending
     )
     if ($null -ne $HotRelease -and $null -ne $HotRelease.Item -and
-        -not ($trendingHeroMode -and -not $QuietReleaseMode)) {
+        -not $trendingHeroMode) {
         $featuredReleaseKey = [string]$HotRelease.Item.ReleaseKey
     }
 
@@ -8507,15 +8507,108 @@ function New-ZeroPreviewStats {
 function Get-PopulatedPreviewStats {
     param([AllowNull()][object]$RealStats)
 
-    $stats = if ($null -eq $RealStats) {
-        New-ZeroPreviewStats
-    } else {
-        $RealStats
+    if ($null -ne $RealStats -and (Safe-Int64 $RealStats.TotalSeconds) -gt 0) {
+        Add-UserStatsMediaMetadata -Stats $RealStats
+        return [PSCustomObject]@{
+            Stats    = $RealStats
+            IsSample = $false
+        }
     }
-    Add-UserStatsMediaMetadata -Stats $stats
+
+    # PreviewAll and SendTestAll are lifecycle regression galleries, so their
+    # explicitly populated states must remain populated even when the selected
+    # recipient has no report-window activity. Reuse current release metadata
+    # where available and add only clearly synthetic, recipient-local rows.
+    $sampleMovies = New-Object System.Collections.Generic.List[object]
+    foreach ($movie in @($activeReleaseData.Movies | Select-Object -First 2)) {
+        $sampleMovie = [ordered]@{}
+        foreach ($property in $movie.PSObject.Properties) {
+            $sampleMovie[$property.Name] = $property.Value
+        }
+        $sampleMovie["Plays"] = 1
+        $sampleMovie["Seconds"] = [int64](3600 - ($sampleMovies.Count * 900))
+        $sampleMovies.Add([PSCustomObject]$sampleMovie)
+    }
+
+    while ($sampleMovies.Count -lt 2) {
+        $index = $sampleMovies.Count + 1
+        $sampleMovies.Add([PSCustomObject]@{
+            Type="movie"; RatingKey=""; PosterRatingKey="";
+            Title="Sample Movie $index"; Year="";
+            DesignRtCritic=$(if ($index -eq 1) { "87" } else { "66" });
+            DesignRtAudience=$(if ($index -eq 1) { "74" } else { "81" });
+            DesignRtCriticImage="rottentomatoes://image.rating.ripe";
+            DesignRtAudienceImage="rottentomatoes://image.rating.upright";
+            Plays=1; Seconds=[int64](3600 - (($index - 1) * 900))
+        })
+    }
+
+    $sampleEpisodes = New-Object System.Collections.Generic.List[object]
+    foreach ($show in @($activeReleaseData.TV)) {
+        foreach ($episode in @($show.Episodes)) {
+            $sampleEpisodes.Add([PSCustomObject]@{
+                Type="episode"
+                RatingKey=[string]$episode.RatingKey
+                PosterRatingKey=[string]$show.PosterRatingKey
+                ShowTitle=[string]$show.Title
+                EpisodeTitle=[string]$episode.Title
+                Season=Safe-Int $episode.Season
+                Episode=Safe-Int $episode.Episode
+                ImdbRating=[string]$episode.ImdbRating
+                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
+            })
+            if ($sampleEpisodes.Count -ge 3) { break }
+        }
+        if ($sampleEpisodes.Count -ge 3) { break }
+    }
+
+    while ($sampleEpisodes.Count -lt 3) {
+        $index = $sampleEpisodes.Count + 1
+        $sampleEpisodes.Add([PSCustomObject]@{
+            Type="episode"; RatingKey=""; PosterRatingKey="";
+            ShowTitle="Sample Series"; EpisodeTitle="Sample Episode $index";
+            Season=1; Episode=$index; ImdbRating=$(if ($index -eq 1) { "8.5" } elseif ($index -eq 2) { "8.1" } else { "7.9" })
+        })
+    }
+
+    $sampleTvShows = New-Object System.Collections.Generic.List[object]
+    foreach ($show in @($activeReleaseData.TV | Select-Object -First 3)) {
+        $sampleTvShows.Add([PSCustomObject]@{
+            Type="show"; RatingKey=[string]$show.RatingKey; PosterRatingKey=[string]$show.PosterRatingKey;
+            Title=[string]$show.Title; ShowTitle=[string]$show.Title;
+            Plays=1; Seconds=[int64]3600; TotalTimeText="1h 0m"
+        })
+    }
+    while ($sampleTvShows.Count -lt 3) {
+        $index = $sampleTvShows.Count + 1
+        $sampleTvShows.Add([PSCustomObject]@{
+            Type="show"; RatingKey=""; PosterRatingKey="";
+            Title="Sample Series $index"; ShowTitle="Sample Series $index";
+            Plays=1; Seconds=[int64](3600 - (($index - 1) * 600));
+            TotalTimeText=$(if ($index -eq 1) { "1h 0m" } elseif ($index -eq 2) { "50m" } else { "40m" })
+        })
+    }
+
+    $sampleMost = if ($sampleMovies.Count -gt 0) {
+        [string]$sampleMovies[0].Title
+    } else {
+        "Example title"
+    }
+
     return [PSCustomObject]@{
-        Stats    = $stats
-        IsSample = $false
+        Stats = [PSCustomObject]@{
+            MoviesWatched    = 2
+            EpisodesStreamed = 3
+            QualifyingPlays  = 5
+            TotalSeconds     = [int64]10980
+            TotalTimeText    = "3h 3m"
+            MostWatched      = $sampleMost
+            MovieItems       = $sampleMovies.ToArray()
+            EpisodeItems     = $sampleEpisodes.ToArray()
+            TvShowItems      = $sampleTvShows.ToArray()
+        }
+        IsSample = $true
     }
 }
 function Build-AllEmailVariants {
@@ -8634,7 +8727,7 @@ function Build-AllEmailVariants {
         -EndLabel $endLabel
 
     # 3) Established active user: always force a populated, non-warm-up state.
-    # Empty selected-user history remains an authentic zero-activity state.
+    # The explicit populated state uses the sanitized gallery fallback if needed.
     $normalHtml = Build-NewsletterHtml `
         -User $user `
         -Stats $populatedVariant.Stats `
@@ -8728,22 +8821,11 @@ function Build-AllEmailVariants {
     $oneOffSubject = Get-OneOffWelcomeSubject -User $user
     $newSubject = Get-NewsletterSubject -User $user -RecentAccess $true
     $normalSubject = Get-NewsletterSubject -User $user -RecentAccess $false
-    $hasRealActivity = (Safe-Int64 $realStats.TotalSeconds) -gt 0
-    $newWithHistoryLabel = if ($hasRealActivity) {
-        "New user first scheduled newsletter — with history"
-    } else {
-        "New user first scheduled newsletter — no selected-user activity"
-    }
-    $normalLabel = if ($hasRealActivity) {
-        "Established user — normal newsletter with activity"
-    } else {
-        "Established user — no selected-user activity"
-    }
 
     return [PSCustomObject]@{
         User = $user
         RealStats = $realStats
-        HasRealActivity = $hasRealActivity
+        PopulatedStatsAreSample = [bool]$populatedVariant.IsSample
         Variants = @(
             [PSCustomObject]@{
                 Key="manual-welcome"
@@ -8765,7 +8847,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="new-scheduled-with-history"
-                Label=$newWithHistoryLabel
+                Label="New user first scheduled newsletter — with history"
                 Subject=$newSubject
                 Html=$newWithHistoryHtml
                 Plain=$newWithHistoryPlain
@@ -8774,7 +8856,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="normal-newsletter"
-                Label=$normalLabel
+                Label="Established user — normal newsletter with activity"
                 Subject=$normalSubject
                 Html=$normalHtml
                 Plain=$normalPlain
@@ -8832,10 +8914,10 @@ if ($Mode -eq "PreviewAll") {
 
     $serverName = HtmlEncode (Get-ConfiguredServerName)
     $userName = HtmlEncode $bundle.User.FriendlyName
-    $historyNote = if ($bundle.HasRealActivity) {
-        "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
+    $historyNote = if ($bundle.PopulatedStatsAreSample) {
+        "The selected user has no activity in this window, so previews 03 and 04 use sanitized scenario statistics only to preserve the populated lifecycle layouts. Previews 05 and 06 intentionally remain at zero activity."
     } else {
-        "The selected user has no activity in this window, so previews 03 and 04 render authentic no-history output without fictional viewing data. Previews 05 and 06 intentionally remain at zero activity."
+        "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
     }
 
     $cards = New-Object System.Text.StringBuilder

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -6647,7 +6647,7 @@ function Build-NewsletterHtml {
         [bool]$HotRelease.IsTrending
     )
     if ($null -ne $HotRelease -and $null -ne $HotRelease.Item -and
-        -not ($trendingHeroMode -and -not $QuietReleaseMode)) {
+        -not $trendingHeroMode) {
         $featuredReleaseKey = [string]$HotRelease.Item.ReleaseKey
     }
 
@@ -8508,15 +8508,108 @@ function New-ZeroPreviewStats {
 function Get-PopulatedPreviewStats {
     param([AllowNull()][object]$RealStats)
 
-    $stats = if ($null -eq $RealStats) {
-        New-ZeroPreviewStats
-    } else {
-        $RealStats
+    if ($null -ne $RealStats -and (Safe-Int64 $RealStats.TotalSeconds) -gt 0) {
+        Add-UserStatsMediaMetadata -Stats $RealStats
+        return [PSCustomObject]@{
+            Stats    = $RealStats
+            IsSample = $false
+        }
     }
-    Add-UserStatsMediaMetadata -Stats $stats
+
+    # PreviewAll and SendTestAll are lifecycle regression galleries, so their
+    # explicitly populated states must remain populated even when the selected
+    # recipient has no report-window activity. Reuse current release metadata
+    # where available and add only clearly synthetic, recipient-local rows.
+    $sampleMovies = New-Object System.Collections.Generic.List[object]
+    foreach ($movie in @($activeReleaseData.Movies | Select-Object -First 2)) {
+        $sampleMovie = [ordered]@{}
+        foreach ($property in $movie.PSObject.Properties) {
+            $sampleMovie[$property.Name] = $property.Value
+        }
+        $sampleMovie["Plays"] = 1
+        $sampleMovie["Seconds"] = [int64](3600 - ($sampleMovies.Count * 900))
+        $sampleMovies.Add([PSCustomObject]$sampleMovie)
+    }
+
+    while ($sampleMovies.Count -lt 2) {
+        $index = $sampleMovies.Count + 1
+        $sampleMovies.Add([PSCustomObject]@{
+            Type="movie"; RatingKey=""; PosterRatingKey="";
+            Title="Sample Movie $index"; Year="";
+            DesignRtCritic=$(if ($index -eq 1) { "87" } else { "66" });
+            DesignRtAudience=$(if ($index -eq 1) { "74" } else { "81" });
+            DesignRtCriticImage="rottentomatoes://image.rating.ripe";
+            DesignRtAudienceImage="rottentomatoes://image.rating.upright";
+            Plays=1; Seconds=[int64](3600 - (($index - 1) * 900))
+        })
+    }
+
+    $sampleEpisodes = New-Object System.Collections.Generic.List[object]
+    foreach ($show in @($activeReleaseData.TV)) {
+        foreach ($episode in @($show.Episodes)) {
+            $sampleEpisodes.Add([PSCustomObject]@{
+                Type="episode"
+                RatingKey=[string]$episode.RatingKey
+                PosterRatingKey=[string]$show.PosterRatingKey
+                ShowTitle=[string]$show.Title
+                EpisodeTitle=[string]$episode.Title
+                Season=Safe-Int $episode.Season
+                Episode=Safe-Int $episode.Episode
+                ImdbRating=[string]$episode.ImdbRating
+                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
+            })
+            if ($sampleEpisodes.Count -ge 3) { break }
+        }
+        if ($sampleEpisodes.Count -ge 3) { break }
+    }
+
+    while ($sampleEpisodes.Count -lt 3) {
+        $index = $sampleEpisodes.Count + 1
+        $sampleEpisodes.Add([PSCustomObject]@{
+            Type="episode"; RatingKey=""; PosterRatingKey="";
+            ShowTitle="Sample Series"; EpisodeTitle="Sample Episode $index";
+            Season=1; Episode=$index; ImdbRating=$(if ($index -eq 1) { "8.5" } elseif ($index -eq 2) { "8.1" } else { "7.9" })
+        })
+    }
+
+    $sampleTvShows = New-Object System.Collections.Generic.List[object]
+    foreach ($show in @($activeReleaseData.TV | Select-Object -First 3)) {
+        $sampleTvShows.Add([PSCustomObject]@{
+            Type="show"; RatingKey=[string]$show.RatingKey; PosterRatingKey=[string]$show.PosterRatingKey;
+            Title=[string]$show.Title; ShowTitle=[string]$show.Title;
+            Plays=1; Seconds=[int64]3600; TotalTimeText="1h 0m"
+        })
+    }
+    while ($sampleTvShows.Count -lt 3) {
+        $index = $sampleTvShows.Count + 1
+        $sampleTvShows.Add([PSCustomObject]@{
+            Type="show"; RatingKey=""; PosterRatingKey="";
+            Title="Sample Series $index"; ShowTitle="Sample Series $index";
+            Plays=1; Seconds=[int64](3600 - (($index - 1) * 600));
+            TotalTimeText=$(if ($index -eq 1) { "1h 0m" } elseif ($index -eq 2) { "50m" } else { "40m" })
+        })
+    }
+
+    $sampleMost = if ($sampleMovies.Count -gt 0) {
+        [string]$sampleMovies[0].Title
+    } else {
+        "Example title"
+    }
+
     return [PSCustomObject]@{
-        Stats    = $stats
-        IsSample = $false
+        Stats = [PSCustomObject]@{
+            MoviesWatched    = 2
+            EpisodesStreamed = 3
+            QualifyingPlays  = 5
+            TotalSeconds     = [int64]10980
+            TotalTimeText    = "3h 3m"
+            MostWatched      = $sampleMost
+            MovieItems       = $sampleMovies.ToArray()
+            EpisodeItems     = $sampleEpisodes.ToArray()
+            TvShowItems      = $sampleTvShows.ToArray()
+        }
+        IsSample = $true
     }
 }
 function Build-AllEmailVariants {
@@ -8635,7 +8728,7 @@ function Build-AllEmailVariants {
         -EndLabel $endLabel
 
     # 3) Established active user: always force a populated, non-warm-up state.
-    # Empty selected-user history remains an authentic zero-activity state.
+    # The explicit populated state uses the sanitized gallery fallback if needed.
     $normalHtml = Build-NewsletterHtml `
         -User $user `
         -Stats $populatedVariant.Stats `
@@ -8729,22 +8822,11 @@ function Build-AllEmailVariants {
     $oneOffSubject = Get-OneOffWelcomeSubject -User $user
     $newSubject = Get-NewsletterSubject -User $user -RecentAccess $true
     $normalSubject = Get-NewsletterSubject -User $user -RecentAccess $false
-    $hasRealActivity = (Safe-Int64 $realStats.TotalSeconds) -gt 0
-    $newWithHistoryLabel = if ($hasRealActivity) {
-        "New user first scheduled newsletter — with history"
-    } else {
-        "New user first scheduled newsletter — no selected-user activity"
-    }
-    $normalLabel = if ($hasRealActivity) {
-        "Established user — normal newsletter with activity"
-    } else {
-        "Established user — no selected-user activity"
-    }
 
     return [PSCustomObject]@{
         User = $user
         RealStats = $realStats
-        HasRealActivity = $hasRealActivity
+        PopulatedStatsAreSample = [bool]$populatedVariant.IsSample
         Variants = @(
             [PSCustomObject]@{
                 Key="manual-welcome"
@@ -8766,7 +8848,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="new-scheduled-with-history"
-                Label=$newWithHistoryLabel
+                Label="New user first scheduled newsletter — with history"
                 Subject=$newSubject
                 Html=$newWithHistoryHtml
                 Plain=$newWithHistoryPlain
@@ -8775,7 +8857,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="normal-newsletter"
-                Label=$normalLabel
+                Label="Established user — normal newsletter with activity"
                 Subject=$normalSubject
                 Html=$normalHtml
                 Plain=$normalPlain
@@ -8833,10 +8915,10 @@ if ($Mode -eq "PreviewAll") {
 
     $serverName = HtmlEncode (Get-ConfiguredServerName)
     $userName = HtmlEncode $bundle.User.FriendlyName
-    $historyNote = if ($bundle.HasRealActivity) {
-        "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
+    $historyNote = if ($bundle.PopulatedStatsAreSample) {
+        "The selected user has no activity in this window, so previews 03 and 04 use sanitized scenario statistics only to preserve the populated lifecycle layouts. Previews 05 and 06 intentionally remain at zero activity."
     } else {
-        "The selected user has no activity in this window, so previews 03 and 04 render authentic no-history output without fictional viewing data. Previews 05 and 06 intentionally remain at zero activity."
+        "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
     }
 
     $cards = New-Object System.Text.StringBuilder

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -6683,7 +6683,7 @@ function Build-NewsletterHtml {
         [bool]$HotRelease.IsTrending
     )
     if ($null -ne $HotRelease -and $null -ne $HotRelease.Item -and
-        -not ($trendingHeroMode -and -not $QuietReleaseMode)) {
+        -not $trendingHeroMode) {
         $featuredReleaseKey = [string]$HotRelease.Item.ReleaseKey
     }
 
@@ -8548,15 +8548,108 @@ function New-ZeroPreviewStats {
 function Get-PopulatedPreviewStats {
     param([AllowNull()][object]$RealStats)
 
-    $stats = if ($null -eq $RealStats) {
-        New-ZeroPreviewStats
-    } else {
-        $RealStats
+    if ($null -ne $RealStats -and (Safe-Int64 $RealStats.TotalSeconds) -gt 0) {
+        Add-UserStatsMediaMetadata -Stats $RealStats
+        return [PSCustomObject]@{
+            Stats    = $RealStats
+            IsSample = $false
+        }
     }
-    Add-UserStatsMediaMetadata -Stats $stats
+
+    # PreviewAll and SendTestAll are lifecycle regression galleries, so their
+    # explicitly populated states must remain populated even when the selected
+    # recipient has no report-window activity. Reuse current release metadata
+    # where available and add only clearly synthetic, recipient-local rows.
+    $sampleMovies = New-Object System.Collections.Generic.List[object]
+    foreach ($movie in @($activeReleaseData.Movies | Select-Object -First 2)) {
+        $sampleMovie = [ordered]@{}
+        foreach ($property in $movie.PSObject.Properties) {
+            $sampleMovie[$property.Name] = $property.Value
+        }
+        $sampleMovie["Plays"] = 1
+        $sampleMovie["Seconds"] = [int64](3600 - ($sampleMovies.Count * 900))
+        $sampleMovies.Add([PSCustomObject]$sampleMovie)
+    }
+
+    while ($sampleMovies.Count -lt 2) {
+        $index = $sampleMovies.Count + 1
+        $sampleMovies.Add([PSCustomObject]@{
+            Type="movie"; RatingKey=""; PosterRatingKey="";
+            Title="Sample Movie $index"; Year="";
+            DesignRtCritic=$(if ($index -eq 1) { "87" } else { "66" });
+            DesignRtAudience=$(if ($index -eq 1) { "74" } else { "81" });
+            DesignRtCriticImage="rottentomatoes://image.rating.ripe";
+            DesignRtAudienceImage="rottentomatoes://image.rating.upright";
+            Plays=1; Seconds=[int64](3600 - (($index - 1) * 900))
+        })
+    }
+
+    $sampleEpisodes = New-Object System.Collections.Generic.List[object]
+    foreach ($show in @($activeReleaseData.TV)) {
+        foreach ($episode in @($show.Episodes)) {
+            $sampleEpisodes.Add([PSCustomObject]@{
+                Type="episode"
+                RatingKey=[string]$episode.RatingKey
+                PosterRatingKey=[string]$show.PosterRatingKey
+                ShowTitle=[string]$show.Title
+                EpisodeTitle=[string]$episode.Title
+                Season=Safe-Int $episode.Season
+                Episode=Safe-Int $episode.Episode
+                ImdbRating=[string]$episode.ImdbRating
+                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
+                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
+            })
+            if ($sampleEpisodes.Count -ge 3) { break }
+        }
+        if ($sampleEpisodes.Count -ge 3) { break }
+    }
+
+    while ($sampleEpisodes.Count -lt 3) {
+        $index = $sampleEpisodes.Count + 1
+        $sampleEpisodes.Add([PSCustomObject]@{
+            Type="episode"; RatingKey=""; PosterRatingKey="";
+            ShowTitle="Sample Series"; EpisodeTitle="Sample Episode $index";
+            Season=1; Episode=$index; ImdbRating=$(if ($index -eq 1) { "8.5" } elseif ($index -eq 2) { "8.1" } else { "7.9" })
+        })
+    }
+
+    $sampleTvShows = New-Object System.Collections.Generic.List[object]
+    foreach ($show in @($activeReleaseData.TV | Select-Object -First 3)) {
+        $sampleTvShows.Add([PSCustomObject]@{
+            Type="show"; RatingKey=[string]$show.RatingKey; PosterRatingKey=[string]$show.PosterRatingKey;
+            Title=[string]$show.Title; ShowTitle=[string]$show.Title;
+            Plays=1; Seconds=[int64]3600; TotalTimeText="1h 0m"
+        })
+    }
+    while ($sampleTvShows.Count -lt 3) {
+        $index = $sampleTvShows.Count + 1
+        $sampleTvShows.Add([PSCustomObject]@{
+            Type="show"; RatingKey=""; PosterRatingKey="";
+            Title="Sample Series $index"; ShowTitle="Sample Series $index";
+            Plays=1; Seconds=[int64](3600 - (($index - 1) * 600));
+            TotalTimeText=$(if ($index -eq 1) { "1h 0m" } elseif ($index -eq 2) { "50m" } else { "40m" })
+        })
+    }
+
+    $sampleMost = if ($sampleMovies.Count -gt 0) {
+        [string]$sampleMovies[0].Title
+    } else {
+        "Example title"
+    }
+
     return [PSCustomObject]@{
-        Stats    = $stats
-        IsSample = $false
+        Stats = [PSCustomObject]@{
+            MoviesWatched    = 2
+            EpisodesStreamed = 3
+            QualifyingPlays  = 5
+            TotalSeconds     = [int64]10980
+            TotalTimeText    = "3h 3m"
+            MostWatched      = $sampleMost
+            MovieItems       = $sampleMovies.ToArray()
+            EpisodeItems     = $sampleEpisodes.ToArray()
+            TvShowItems      = $sampleTvShows.ToArray()
+        }
+        IsSample = $true
     }
 }
 function Build-AllEmailVariants {
@@ -8675,7 +8768,7 @@ function Build-AllEmailVariants {
         -EndLabel $endLabel
 
     # 3) Established active user: always force a populated, non-warm-up state.
-    # Empty selected-user history remains an authentic zero-activity state.
+    # The explicit populated state uses the sanitized gallery fallback if needed.
     $normalHtml = Build-NewsletterHtml `
         -User $user `
         -Stats $populatedVariant.Stats `
@@ -8769,22 +8862,11 @@ function Build-AllEmailVariants {
     $oneOffSubject = Get-OneOffWelcomeSubject -User $user
     $newSubject = Get-NewsletterSubject -User $user -RecentAccess $true
     $normalSubject = Get-NewsletterSubject -User $user -RecentAccess $false
-    $hasRealActivity = (Safe-Int64 $realStats.TotalSeconds) -gt 0
-    $newWithHistoryLabel = if ($hasRealActivity) {
-        "New user first scheduled newsletter — with history"
-    } else {
-        "New user first scheduled newsletter — no selected-user activity"
-    }
-    $normalLabel = if ($hasRealActivity) {
-        "Established user — normal newsletter with activity"
-    } else {
-        "Established user — no selected-user activity"
-    }
 
     return [PSCustomObject]@{
         User = $user
         RealStats = $realStats
-        HasRealActivity = $hasRealActivity
+        PopulatedStatsAreSample = [bool]$populatedVariant.IsSample
         Variants = @(
             [PSCustomObject]@{
                 Key="manual-welcome"
@@ -8806,7 +8888,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="new-scheduled-with-history"
-                Label=$newWithHistoryLabel
+                Label="New user first scheduled newsletter — with history"
                 Subject=$newSubject
                 Html=$newWithHistoryHtml
                 Plain=$newWithHistoryPlain
@@ -8815,7 +8897,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="normal-newsletter"
-                Label=$normalLabel
+                Label="Established user — normal newsletter with activity"
                 Subject=$normalSubject
                 Html=$normalHtml
                 Plain=$normalPlain
@@ -8873,10 +8955,10 @@ if ($Mode -eq "PreviewAll") {
 
     $serverName = HtmlEncode (Get-ConfiguredServerName)
     $userName = HtmlEncode $bundle.User.FriendlyName
-    $historyNote = if ($bundle.HasRealActivity) {
-        "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
+    $historyNote = if ($bundle.PopulatedStatsAreSample) {
+        "The selected user has no activity in this window, so previews 03 and 04 use sanitized scenario statistics only to preserve the populated lifecycle layouts. Previews 05 and 06 intentionally remain at zero activity."
     } else {
-        "The selected user has no activity in this window, so previews 03 and 04 render authentic no-history output without fictional viewing data. Previews 05 and 06 intentionally remain at zero activity."
+        "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
     }
 
     $cards = New-Object System.Text.StringBuilder

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -43,7 +43,8 @@ $directRatingScenarios = @($directImdbRatingScenarios) + @($directEpisodeRtScena
 $deletedHistoryScenarios = @($providerRecoveryScenarios) + @($cacheScenario)
 $platformScenario = 'platform-tie'
 $lastPlatformScenario = 'last-platform'
-$sendTestScenarios = @($platformScenario, $lastPlatformScenario, 'optional-hero-metadata', 'rating-export-fallback') + @($directRatingScenarios) + @($deletedHistoryScenarios)
+$quietNoHistoryScenario = 'quiet-no-history'
+$sendTestScenarios = @($platformScenario, $lastPlatformScenario, $quietNoHistoryScenario, 'optional-hero-metadata', 'rating-export-fallback') + @($directRatingScenarios) + @($deletedHistoryScenarios)
 
 $executed = 0
 foreach ($engine in $engines) {
@@ -52,7 +53,7 @@ foreach ($engine in $engines) {
         continue
     }
 
-    foreach ($scenario in @('active', 'quiet', 'tv-only', 'personal-many', $platformScenario, $lastPlatformScenario, 'optional-hero-metadata', 'rating-export-fallback') + $directRatingScenarios + $deletedHistoryScenarios) {
+    foreach ($scenario in @('active', 'quiet', $quietNoHistoryScenario, 'tv-only', 'personal-many', $platformScenario, $lastPlatformScenario, 'optional-hero-metadata', 'rating-export-fallback') + $directRatingScenarios + $deletedHistoryScenarios) {
         $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ('tautweekly-integration-' + [Guid]::NewGuid().ToString('N'))
         $appRoot = Join-Path $tempRoot 'app'
         $dataRoot = Join-Path $tempRoot 'data'
@@ -72,6 +73,7 @@ foreach ($engine in $engines) {
         $smtpCallLog = Join-Path $tempRoot 'smtp-calls.jsonl'
         $smtpDataFile = Join-Path $tempRoot 'smtp-message.eml'
         $smtpReadyFile = Join-Path $tempRoot 'smtp-ready.txt'
+        $smtpDataDirectory = Join-Path $tempRoot 'smtp-messages'
         $smtpStdout = Join-Path $tempRoot 'smtp.stdout.txt'
         $smtpStderr = Join-Path $tempRoot 'smtp.stderr.txt'
         $sendStdout = Join-Path $tempRoot 'send.stdout.txt'
@@ -79,6 +81,9 @@ foreach ($engine in $engines) {
         $sendAllStdout = Join-Path $tempRoot 'send-all.stdout.txt'
         $sendAllStderr = Join-Path $tempRoot 'send-all.stderr.txt'
         $managerResultPath = Join-Path $tempRoot 'manager-operation-result.json'
+        $sendTestAllStdout = Join-Path $tempRoot 'send-test-all.stdout.txt'
+        $sendTestAllStderr = Join-Path $tempRoot 'send-test-all.stderr.txt'
+        $sendTestAllResultPath = Join-Path $tempRoot 'send-test-all-result.json'
         $failureResultPath = Join-Path $tempRoot 'manager-operation-failure.json'
         $failureStdout = Join-Path $tempRoot 'failure.stdout.txt'
         $failureStderr = Join-Path $tempRoot 'failure.stderr.txt'
@@ -142,7 +147,8 @@ foreach ($engine in $engines) {
                 $smtpServer = Start-Process -FilePath $PythonPath -ArgumentList @(
                     '-u', $fakeSmtp, '--port', [string]$smtpPort,
                     '--call-log', $smtpCallLog, '--ready-file', $smtpReadyFile,
-                    '--data-file', $smtpDataFile
+                    '--data-file', $smtpDataFile,
+                    '--data-directory', $smtpDataDirectory
                 ) -PassThru -WindowStyle Hidden -RedirectStandardOutput $smtpStdout -RedirectStandardError $smtpStderr
                 for ($attempt = 0; $attempt -lt 100 -and -not (Test-Path $smtpReadyFile); $attempt++) {
                     if ($smtpServer.HasExited) {
@@ -174,6 +180,7 @@ foreach ($engine in $engines) {
                 CustomTextCardBorderColor = '#72aef7'
                 CustomTextCardBorderOpacity = 34
                 CustomTextCardTitle = 'Custom <Title>'
+                TestSendDelaySeconds = 0
                 CustomTextCardTitleGif = 'celebrate'
                 CustomTextCardSubheading = 'Assessment & notes'
                 CustomTextCardBody = "Synthetic <notice> & safe`nSecond line"
@@ -289,6 +296,23 @@ foreach ($engine in $engines) {
             $indexPath = Join-Path $outputRoot 'preview-all-00-INDEX.html'
             $normalPath = Join-Path $outputRoot 'preview-all-04-normal-newsletter.html'
             Assert-True (Test-Path $indexPath) "$($engine.Name)/$scenario did not generate the preview index."
+            $expectedPreviewNames = @(
+                'preview-all-00-INDEX.html',
+                'preview-all-01-manual-welcome.html',
+                'preview-all-02-new-user-no-history.html',
+                'preview-all-03-new-user-with-history.html',
+                'preview-all-04-normal-newsletter.html',
+                'preview-all-05-established-quiet.html',
+                'preview-all-06-established-warmup.html'
+            )
+            $actualPreviewNames = @(
+                Get-ChildItem $outputRoot -Filter 'preview-all-*.html' |
+                    Sort-Object Name |
+                    Select-Object -ExpandProperty Name
+            )
+            Assert-True (($actualPreviewNames -join '|') -eq ($expectedPreviewNames -join '|')) "$($engine.Name)/$scenario generated the all-state previews in the wrong order or under unexpected names."
+            $scenarioHashes = @(Get-ChildItem $outputRoot -Filter 'preview-all-*.html' | Where-Object { $_.Name -ne 'preview-all-00-INDEX.html' } | ForEach-Object { (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash } | Select-Object -Unique)
+            Assert-True ($scenarioHashes.Count -eq 6) "$($engine.Name)/$scenario collapsed distinct lifecycle scenarios into duplicate HTML."
             Assert-True ((Get-ChildItem $outputRoot -Filter 'preview-all-*.html').Count -eq 7) "$($engine.Name)/$scenario did not generate all six states plus the index."
             if ($engine.Name -eq 'nas-docker-linux-freebsd' -and $scenario -in @('active', $platformScenario)) {
                 Assert-True (Test-Path -LiteralPath $managerResultPath) 'NAS Manager operation did not produce its structured result.'
@@ -306,6 +330,15 @@ foreach ($engine in $engines) {
                 Assert-True (-not $managerResultRaw.Contains($configPath)) 'NAS Manager result exposed its configuration path.'
             }
             $indexHtml = Get-Content $indexPath -Raw -Encoding UTF8
+            $previousScenarioLinkIndex = -1
+            foreach ($scenarioPreviewName in @($expectedPreviewNames[1..6])) {
+                $scenarioLinkIndex = $indexHtml.IndexOf(('href="' + $scenarioPreviewName + '"'), [StringComparison]::Ordinal)
+                Assert-True ($scenarioLinkIndex -gt $previousScenarioLinkIndex) "$($engine.Name)/$scenario preview index listed lifecycle scenarios out of order."
+                $previousScenarioLinkIndex = $scenarioLinkIndex
+            }
+            $newNoHistoryHtml = Get-Content (Join-Path $outputRoot 'preview-all-02-new-user-no-history.html') -Raw -Encoding UTF8
+            $newWithHistoryHtml = Get-Content (Join-Path $outputRoot 'preview-all-03-new-user-with-history.html') -Raw -Encoding UTF8
+            $warmupHtml = Get-Content (Join-Path $outputRoot 'preview-all-06-established-warmup.html') -Raw -Encoding UTF8
             $normalHtml = Get-Content $normalPath -Raw -Encoding UTF8
             $quietHtml = Get-Content (Join-Path $outputRoot 'preview-all-05-established-quiet.html') -Raw -Encoding UTF8
             $previewThemeMarkers = @(
@@ -388,23 +421,43 @@ foreach ($engine in $engines) {
             Assert-True ($normalHtml.Contains('.stats-title-cell.stats-tv-title-cell { display:table-cell !important; width:50% !important;')) "$($engine.Name)/$scenario lost the two-column mobile TV-title rule."
             Assert-True (-not $quietHtml.Contains('class="stats-summary-cell"') -and -not $quietHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario rendered personal summary cards in the zero-activity state."
             Assert-True (-not $normalHtml.Contains('Ratings unavailable') -and -not $normalHtml.Contains('IMDb unavailable')) "$($engine.Name)/$scenario rendered an unavailable-rating placeholder."
-            $expectedMode = if ($scenario -eq 'quiet' -or $scenario -in $deletedHistoryScenarios) { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
+            $expectedMode = if ($scenario -in @('quiet', $quietNoHistoryScenario) -or $scenario -in $deletedHistoryScenarios) { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
             Assert-True ($indexHtml.Contains($expectedMode)) "$($engine.Name)/$scenario reported the wrong release mode."
             Assert-True ($normalHtml.Contains('Selected Movie')) "$($engine.Name)/$scenario lost the selected movie."
             Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the selected TV show."
             Assert-True (-not $normalHtml.Contains('Private Movie')) "$($engine.Name)/$scenario leaked a private-library title."
             Assert-True (-not $normalHtml.Contains('Simulated Champion')) "$($engine.Name)/$scenario leaked the Binge Champion identity."
-            Assert-True ($normalHtml.Contains('3h 0m watched')) "$($engine.Name)/$scenario lost the shared champion duration line."
+            $expectedChampionDuration = if ($scenario -eq $quietNoHistoryScenario) { '5h 0m watched' } else { '3h 0m watched' }
+            Assert-True ($normalHtml.Contains($expectedChampionDuration)) "$($engine.Name)/$scenario lost the shared champion duration line."
             Assert-True ($normalHtml.Contains('1 TV show')) "$($engine.Name)/$scenario lost the unique TV-show breakdown."
             Assert-True (-not $normalHtml.Contains('0 movies')) "$($engine.Name)/$scenario rendered an empty Binge Champion movie category."
             Assert-True (-not $normalHtml.Contains('qualifying plays')) "$($engine.Name)/$scenario retained qualifying-play copy in Total Watched."
-            if ($scenario -notin $deletedHistoryScenarios -and $scenario -ne 'personal-many' -and $scenario -ne $platformScenario) {
+            if ($scenario -notin $deletedHistoryScenarios -and $scenario -ne 'personal-many' -and $scenario -ne $platformScenario -and $scenario -ne $quietNoHistoryScenario) {
                 Assert-True (-not $normalHtml.Contains('TV SHOWS WATCHED')) "$($engine.Name)/$scenario rendered an empty TV stats card."
             }
 
+            if ($scenario -eq $quietNoHistoryScenario) {
+                Assert-True ($indexHtml.Contains('previews 03 and 04 use sanitized scenario statistics only')) "$($engine.Name)/$scenario did not disclose the populated all-state fixture."
+                Assert-True ($newNoHistoryHtml.Contains('WELCOME ABOARD') -and -not $newNoHistoryHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario lost the intentional new-user/no-history state."
+                Assert-True ($newWithHistoryHtml.Contains('WELCOME ABOARD') -and $newWithHistoryHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario did not preserve the populated new-user state."
+                Assert-True ($normalHtml.Contains('YOU CLOCKED') -and $normalHtml.Contains('Sample Movie 2')) "$($engine.Name)/$scenario did not preserve a populated established lifecycle preview."
+                Assert-True ($quietHtml.Contains('QUIET IN THIS SECTOR') -and -not $quietHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario lost the intentional established quiet state."
+                Assert-True ($warmupHtml.Contains('STATS ARE WARMING UP') -and -not $warmupHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario lost the intentional warm-up state."
+                foreach ($contentRichHtml in @($newWithHistoryHtml, $normalHtml)) {
+                    Assert-True ($contentRichHtml.Contains('Selected Movie') -and $contentRichHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost real latest-release titles from a populated lifecycle state."
+                    Assert-True ($contentRichHtml.Contains('A release from the selected movie library.') -and $contentRichHtml.Contains('Drama, Mystery')) "$($engine.Name)/$scenario lost latest movie summary or genres."
+                    Assert-True ($contentRichHtml.Contains('Rotten Tomatoes critic') -and $contentRichHtml.Contains('Rotten Tomatoes audience')) "$($engine.Name)/$scenario lost latest movie ratings."
+                    Assert-True ($contentRichHtml.Contains('posters/poster_selected-movie.jpg') -and $contentRichHtml.Contains('posters/poster_selected-show.jpg')) "$($engine.Name)/$scenario lost latest release posters."
+                }
+                Assert-True ($quietHtml.Contains('TRENDING THIS WEEK') -and $quietHtml.Contains('LATEST RELEASES')) "$($engine.Name)/$scenario did not render Trending plus the latest-release fallback."
+                Assert-True ($quietHtml.Contains('Selected Movie') -and ([regex]::Matches($quietHtml, 'Selected Show')).Count -ge 2) "$($engine.Name)/$scenario removed a capped latest title after also selecting it as Trending."
+                Assert-True (-not $quietHtml.Contains('Toy Story 5')) "$($engine.Name)/$scenario substituted an unrelated fallback shell."
+                Assert-True ($previewLog.Contains('Latest Releases: 1 movies and 1 TV titles.')) "$($engine.Name)/$scenario did not load the bounded quiet-week fallback."
+            }
             if ($scenario -eq 'personal-many') {
                 Assert-True ($normalHtml.Contains('Personal Movie 12') -and $normalHtml.Contains('Personal Show 11')) "$($engine.Name)/$scenario capped personal movie or TV rows before the final synthetic title."
                 Assert-True (([regex]::Matches($normalHtml, 'class="stats-title-cell(?: stats-tv-title-cell stats-tv-title-(?:left|right))?"')).Count -eq 23) "$($engine.Name)/$scenario did not render all 12 movie and 11 TV title cells."
+
                 Assert-True (([regex]::Matches($normalHtml, 'class="stats-title-cell stats-tv-title-cell stats-tv-title-(?:left|right)"')).Count -eq 11) "$($engine.Name)/$scenario did not identify every TV cell for two-column mobile rendering."
                 Assert-True (([regex]::Matches($normalHtml, 'class="stats-title-spacer stats-tv-title-spacer"')).Count -eq 1) "$($engine.Name)/$scenario did not preserve the odd TV grid row without a visible empty mobile item."
                 $movieStatsStart = $normalHtml.IndexOf('MOVIES WATCHED', [StringComparison]::Ordinal)
@@ -664,7 +717,7 @@ foreach ($engine in $engines) {
 
             if ($scenario -in $sendTestScenarios) {
                 $previewLog = Get-Content $stdout -Raw
-                if ($scenario -notin $directRatingScenarios -and $scenario -notin @($platformScenario, $lastPlatformScenario)) {
+                if ($scenario -notin $directRatingScenarios -and $scenario -notin @($platformScenario, $lastPlatformScenario, $quietNoHistoryScenario)) {
                     Assert-True ($previewLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario did not exercise the recoverable direct Plex 404 fallback."
                 }
                 Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the global-history title fallback for sparse hero metadata."
@@ -723,7 +776,7 @@ foreach ($engine in $engines) {
                 }
                 $sendLog = Get-Content $sendStdout -Raw
                 Assert-True ($sendLog.Contains('Test email sent successfully.')) "$($engine.Name)/$scenario SendTest did not complete delivery."
-                if ($scenario -notin $directRatingScenarios -and $scenario -notin @($platformScenario, $lastPlatformScenario)) {
+                if ($scenario -notin $directRatingScenarios -and $scenario -notin @($platformScenario, $lastPlatformScenario, $quietNoHistoryScenario)) {
                     Assert-True ($sendLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario SendTest did not preserve the direct Plex 404 warning."
                 }
 
@@ -774,6 +827,15 @@ foreach ($engine in $engines) {
                     )
                     Assert-True (-not $sendLog.Contains('tvOS') -and -not $sendLog.Contains('Roku') -and -not $sendLog.Contains('Unrecognized Platform')) "$($engine.Name)/$scenario exposed Last Platform details in SendTest logs."
                 }
+                if ($scenario -eq $quietNoHistoryScenario) {
+                    $emailThemeArgs += @(
+                        '--require-html', 'TRENDING THIS WEEK',
+                        '--require-html', 'LATEST RELEASES',
+                        '--require-html', 'Selected Movie',
+                        '--require-html', 'Selected Show',
+                        '--forbid-html', 'Toy Story 5'
+                    )
+                }
                 if ($scenario -eq 'rating-export-fallback') {
                     $emailThemeArgs += @(
                         # Windows PowerShell 5.1 strips embedded quote
@@ -819,6 +881,65 @@ foreach ($engine in $engines) {
                 }
                 & $PythonPath $emailThemeAssertion @emailThemeArgs
                 Assert-True ($LASTEXITCODE -eq 0) "$($engine.Name)/$scenario delivered HTML lost the dark email contract."
+                if ($scenario -eq $quietNoHistoryScenario) {
+                    $capturesBeforeSendTestAll = @(Get-ChildItem -LiteralPath $smtpDataDirectory -Filter 'message-*.eml').Count
+                    Assert-True ($capturesBeforeSendTestAll -eq 1) "$($engine.Name)/$scenario expected exactly one captured SendTest message before SendTestAll."
+                    $oldDataRoot = $env:TAUTWEEKLY_DATA_DIR
+                    $oldConfig = $env:TAUTWEEKLY_CONFIG
+                    try {
+                        if ($engine.Container) {
+                            $env:TAUTWEEKLY_DATA_DIR = $dataRoot
+                            $env:TAUTWEEKLY_CONFIG = $configPath
+                        }
+                        $sendTestAllProcess = Start-Process -FilePath $engine.Host -ArgumentList @(
+                            '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $headlessRunner,
+                            '-RendererPath', (Join-Path $appRoot $engine.Renderer), '-ConfigPath', $configPath,
+                            '-UserId', '1', '-Mode', 'SendTestAll', '-ResultPath', $sendTestAllResultPath
+                        ) -Wait -PassThru -WindowStyle Hidden -RedirectStandardOutput $sendTestAllStdout -RedirectStandardError $sendTestAllStderr
+                    }
+                    finally {
+                        $env:TAUTWEEKLY_DATA_DIR = $oldDataRoot
+                        $env:TAUTWEEKLY_CONFIG = $oldConfig
+                    }
+                    if ($sendTestAllProcess.ExitCode -ne 0) {
+                        throw "$($engine.Name)/$scenario SendTestAll failed ($($sendTestAllProcess.ExitCode))."
+                    }
+                    $sendTestAllLog = Get-Content -LiteralPath $sendTestAllStdout -Raw -Encoding UTF8
+                    Assert-True ($sendTestAllLog.Contains('All six email-state tests were sent to TestEmail only.')) "$($engine.Name)/$scenario SendTestAll did not complete its test-only delivery."
+                    Assert-True (Test-Path -LiteralPath $sendTestAllResultPath) "$($engine.Name)/$scenario SendTestAll omitted its structured result."
+                    $sendTestAllResultRaw = Get-Content -LiteralPath $sendTestAllResultPath -Raw -Encoding UTF8
+                    $sendTestAllResult = $sendTestAllResultRaw | ConvertFrom-Json
+                    Assert-True ($sendTestAllResult.mode -eq 'SendTestAll' -and $sendTestAllResult.outcome -eq 'succeeded') "$($engine.Name)/$scenario SendTestAll reported the wrong outcome."
+                    Assert-True ($sendTestAllResult.deliveryScope -eq 'test' -and $sendTestAllResult.smtpAcceptedCount -eq 6) "$($engine.Name)/$scenario SendTestAll did not report six test-only SMTP acceptances."
+                    Assert-True (-not $sendTestAllResultRaw.Contains('viewer@example.com') -and -not $sendTestAllResultRaw.Contains('virtual-api-key')) "$($engine.Name)/$scenario SendTestAll structured result exposed private fixture data."
+
+                    $allCaptures = @(Get-ChildItem -LiteralPath $smtpDataDirectory -Filter 'message-*.eml' | Sort-Object Name)
+                    Assert-True ($allCaptures.Count -eq 7) "$($engine.Name)/$scenario SendTestAll did not add exactly six captured messages after SendTest."
+                    $stateCaptures = @($allCaptures | Select-Object -Last 6)
+                    $stateExpectations = @(
+                        [PSCustomObject]@{ Required = @('WELCOME ABOARD'); Forbidden = @('YOU CLOCKED') },
+                        [PSCustomObject]@{ Required = @('WELCOME ABOARD', 'LATEST RELEASES'); Forbidden = @('YOU CLOCKED') },
+                        [PSCustomObject]@{ Required = @('WELCOME ABOARD', 'YOU CLOCKED', 'LATEST RELEASES'); Forbidden = @() },
+                        [PSCustomObject]@{ Required = @('YOU CLOCKED', 'LATEST RELEASES'); Forbidden = @('WELCOME ABOARD') },
+                        [PSCustomObject]@{ Required = @('QUIET IN THIS SECTOR', 'LATEST RELEASES'); Forbidden = @('YOU CLOCKED') },
+                        [PSCustomObject]@{ Required = @('STATS ARE WARMING UP', 'LATEST RELEASES'); Forbidden = @('YOU CLOCKED') }
+                    )
+                    for ($stateIndex = 0; $stateIndex -lt 6; $stateIndex++) {
+                        $stateArgs = @($stateCaptures[$stateIndex].FullName)
+                        foreach ($requiredMarker in $stateExpectations[$stateIndex].Required) {
+                            $stateArgs += @('--require-html', $requiredMarker)
+                        }
+                        foreach ($forbiddenMarker in $stateExpectations[$stateIndex].Forbidden) {
+                            $stateArgs += @('--forbid-html', $forbiddenMarker)
+                        }
+                        if ($stateIndex -gt 0) {
+                            $stateArgs += @('--require-html', 'Selected Movie', '--require-html', 'Selected Show', '--forbid-html', 'Toy Story 5')
+                        }
+                        & $PythonPath $emailThemeAssertion @stateArgs
+                        Assert-True ($LASTEXITCODE -eq 0) "$($engine.Name)/$scenario SendTestAll message $($stateIndex + 1) did not match its PreviewAll lifecycle counterpart."
+                    }
+                }
+
 
                 if ($scenario -eq $cacheScenario) {
                     Remove-Item -LiteralPath (Join-Path $outputRoot 'posters') -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -111,7 +111,8 @@ foreach ($relativePath in $rendererPaths) {
     }
 
     $rendererSource = [IO.File]::ReadAllText($path)
-    Assert-True (-not $rendererSource.Contains('Title="Sample Movie')) "$relativePath still contains fabricated production preview movie stats"
+    Assert-True ($rendererSource.Contains('Title="Sample Movie')) "$relativePath lacks sanitized populated-state fallback rows for lifecycle regression modes"
+    Assert-True (([regex]::Matches($rendererSource, 'Get-PopulatedPreviewStats -RealStats')).Count -eq 1) "$relativePath allows populated-state fixture statistics outside Build-AllEmailVariants"
     Assert-True (([regex]::Matches($rendererSource, 'Get-NewsletterLastPlatform -ExpectedUserId \$user\.UserId')).Count -eq 3) "$relativePath does not apply Last Platform to manual, preview/test, and standard recipient paths"
 
     foreach ($functionName in $requiredFunctions) {
@@ -1153,15 +1154,16 @@ foreach ($relativePath in $rendererPaths) {
         })
         TV = @()
     }
-    $emptyPreview = Get-PopulatedPreviewStats -RealStats $empty
-    Assert-True (-not $emptyPreview.IsSample) "$relativePath marked authentic empty history as sample data"
-    Assert-True ((Safe-Int64 $emptyPreview.Stats.TotalSeconds) -eq 0) "$relativePath invented watch time for an empty-history preview"
-    Assert-True ($emptyPreview.Stats.MovieItems.Count -eq 0 -and $emptyPreview.Stats.EpisodeItems.Count -eq 0 -and $emptyPreview.Stats.TvShowItems.Count -eq 0) "$relativePath invented watch rows for an empty-history preview"
-    $nullPreview = Get-PopulatedPreviewStats -RealStats $null
-    Assert-True (-not $nullPreview.IsSample -and (Safe-Int64 $nullPreview.Stats.TotalSeconds) -eq 0) "$relativePath did not safely convert absent real stats to an authentic zero state"
-    $emptyPlainText = Build-PlainText `
+    $samplePreview = Get-PopulatedPreviewStats -RealStats $empty
+    Assert-True ($samplePreview.IsSample) "$relativePath did not preserve distinct populated lifecycle scenarios for empty selected-user history"
+    Assert-True ((Safe-Int64 $samplePreview.Stats.TotalSeconds) -gt 0) "$relativePath did not populate the with-history scenario"
+    Assert-True ($samplePreview.Stats.MovieItems.Count -ge 2 -and $samplePreview.Stats.EpisodeItems.Count -ge 3 -and $samplePreview.Stats.TvShowItems.Count -ge 3) "$relativePath did not build content-rich populated scenario rows"
+    foreach ($sampleMovie in $samplePreview.Stats.MovieItems) {
+        Assert-True ((Safe-Int64 $sampleMovie.Seconds) -gt 0) "$relativePath generated invalid populated-scenario movie watch time"
+    }
+    $samplePlainText = Build-PlainText `
         -User ([PSCustomObject]@{ FriendlyName = 'Viewer' }) `
-        -Stats $emptyPreview.Stats `
+        -Stats $samplePreview.Stats `
         -ReleaseData $script:activeReleaseData `
         -HotRelease $null `
         -TrendingTitle '' `
@@ -1169,11 +1171,11 @@ foreach ($relativePath in $rendererPaths) {
         -RecentAccess $false `
         -StartLabel 'August 1' `
         -EndLabel 'August 7'
-    Assert-True (-not $emptyPlainText.Contains('Sample Movie') -and -not $emptyPlainText.Contains('Sample Series')) "$relativePath leaked fabricated viewing stats into an empty-history preview"
-    Assert-True ($emptyPlainText.Contains('View & Request: https://app.plex.tv/')) "$relativePath did not render the custom button label and URL in plain text"
-    Assert-True ($emptyPlainText.Contains("CUSTOM <TITLE>`r`nMaintenance & more`r`nFirst <line> & safe`nSecond line")) "$relativePath did not render the plain-text custom card"
-    $customPlainIndex = $emptyPlainText.IndexOf('CUSTOM <TITLE>', [StringComparison]::Ordinal)
-    $releasePlainIndex = if ($customPlainIndex -ge 0) { $emptyPlainText.IndexOf('1 new movie', $customPlainIndex + 1, [StringComparison]::Ordinal) } else { -1 }
+    Assert-True ($samplePlainText.Contains('movies watched') -and $samplePlainText.Contains('TV shows watched')) "$relativePath could not render populated lifecycle stats as plain text"
+    Assert-True ($samplePlainText.Contains('View & Request: https://app.plex.tv/')) "$relativePath did not render the custom button label and URL in plain text"
+    Assert-True ($samplePlainText.Contains("CUSTOM <TITLE>`r`nMaintenance & more`r`nFirst <line> & safe`nSecond line")) "$relativePath did not render the plain-text custom card"
+    $customPlainIndex = $samplePlainText.IndexOf('CUSTOM <TITLE>', [StringComparison]::Ordinal)
+    $releasePlainIndex = if ($customPlainIndex -ge 0) { $samplePlainText.IndexOf('1 new movie', $customPlainIndex + 1, [StringComparison]::Ordinal) } else { -1 }
     Assert-True ($customPlainIndex -ge 0 -and $releasePlainIndex -gt $customPlainIndex) "$relativePath placed the plain-text custom card after the release metadata (custom=$customPlainIndex release=$releasePlainIndex)"
 
     $uncappedPlainText = Build-PlainText `

--- a/scripts/test-support/fake-smtp.py
+++ b/scripts/test-support/fake-smtp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import threading
 import socketserver
 import time
 from pathlib import Path
@@ -67,8 +68,15 @@ class Handler(socketserver.StreamRequestHandler):
                         data_line = data_line[1:]
                     data_lines.append(data_line)
                 data_file: Path | None = self.server.data_file  # type: ignore[attr-defined]
+                message = ("\r\n".join(data_lines) + "\r\n").encode("utf-8")
                 if data_file is not None:
-                    data_file.write_bytes(("\r\n".join(data_lines) + "\r\n").encode("utf-8"))
+                    data_file.write_bytes(message)
+                data_directory: Path | None = self.server.data_directory  # type: ignore[attr-defined]
+                if data_directory is not None:
+                    with self.server.capture_lock:  # type: ignore[attr-defined]
+                        self.server.message_count += 1  # type: ignore[attr-defined]
+                        capture_number = self.server.message_count  # type: ignore[attr-defined]
+                    (data_directory / f"message-{capture_number:02d}.eml").write_bytes(message)
                 if self.server.drop_after_data:  # type: ignore[attr-defined]
                     return
                 self.send("250 Queued")
@@ -88,6 +96,7 @@ def main() -> None:
     parser.add_argument("--port", type=int, required=True)
     parser.add_argument("--call-log", type=Path, required=True)
     parser.add_argument("--ready-file", type=Path, required=True)
+    parser.add_argument("--data-directory", type=Path)
     parser.add_argument("--data-file", type=Path)
     parser.add_argument("--reject-recipient", action="append", default=[])
     parser.add_argument("--auth-failure", action="store_true")
@@ -96,10 +105,15 @@ def main() -> None:
     parser.add_argument("--reject-policy", action="store_true")
     args = parser.parse_args()
 
+    if args.data_directory is not None:
+        args.data_directory.mkdir(parents=True, exist_ok=True)
     args.call_log.write_text("", encoding="utf-8")
     with Server(("127.0.0.1", args.port), Handler) as server:
         server.call_log = args.call_log  # type: ignore[attr-defined]
         server.data_file = args.data_file  # type: ignore[attr-defined]
+        server.data_directory = args.data_directory  # type: ignore[attr-defined]
+        server.capture_lock = threading.Lock()  # type: ignore[attr-defined]
+        server.message_count = 0  # type: ignore[attr-defined]
         server.reject_recipients = [value.lower() for value in args.reject_recipient]  # type: ignore[attr-defined]
         server.auth_failure = args.auth_failure  # type: ignore[attr-defined]
         server.rate_limit_greeting = args.rate_limit_greeting  # type: ignore[attr-defined]

--- a/scripts/test-support/fake-tautulli.py
+++ b/scripts/test-support/fake-tautulli.py
@@ -243,6 +243,11 @@ def history_rows(section_id: str, scenario: str) -> list[dict[str, object]]:
                 "started": 100,
             }
         ]
+        if scenario == "quiet-no-history":
+            rows[0]["user_id"] = "2"
+            rows[0]["friendly_name"] = "Simulated Champion"
+            rows[0]["platform"] = "Roku"
+            rows[0]["started"] = 200
         if scenario in DELETED_HISTORY_SCENARIOS:
             rows[0]["guid"] = (
                 "com.plexapp.agents.tmdb://12345?lang=en"
@@ -1141,6 +1146,7 @@ def main() -> None:
             "last-platform",
             "quiet",
             "tv-only",
+            "quiet-no-history",
             "optional-hero-metadata",
             "rating-export-fallback",
             "direct-rating-optional",

--- a/scripts/test-support/invoke-renderer-headless.ps1
+++ b/scripts/test-support/invoke-renderer-headless.ps1
@@ -3,7 +3,7 @@ param(
     [Parameter(Mandatory = $true)][string]$RendererPath,
     [Parameter(Mandatory = $true)][string]$ConfigPath,
     [Parameter(Mandatory = $true)][string]$UserId,
-    [ValidateSet('VerifyPlex', 'PreviewAll', 'SendTest', 'SendAll')][string]$Mode = 'PreviewAll',
+    [ValidateSet('VerifyPlex', 'Preview', 'PreviewAll', 'SendTest', 'SendTestAll', 'SendAll')][string]$Mode = 'PreviewAll',
     [string]$ResultPath = '',
     [switch]$NoConfirmSendAll
 )


### PR DESCRIPTION
## Summary
- restore distinct populated Preview All and Send Test All lifecycle states when the selected recipient has no report-window history
- keep Trending in the quiet-week Latest Releases shelves (bounded to four movies and four TV titles)
- add deterministic cross-renderer Preview/SendTest/SendTestAll regression coverage without real services or delivery

## Root cause
The v0.20.5 platform-icon change was the first suspect, but its renderer diff only added recipient platform selection and icon rendering. The regression was introduced in v0.20.7 when the populated all-state fallback was removed: scenarios 03/04 inherited the same zero selected-user history as scenarios 02/05. Separately, Trending was filtered from the quiet Latest Releases shelf after being selected as the hero, which could empty a sparse category.

## Validation
- `scripts/test-newsletter-integration.ps1`: 45/45 across Windows, NAS/Linux/FreeBSD, and macOS; seven ordered files, six unique lifecycle documents, rich release metadata/posters, quiet fallback, mocked SendTest and six-message SendTestAll parity
- renderer collections, library selection, recipient policy (33), Binge Champion, exclusions, deleted-item cache, config retention, scheduler, update, SMTP, wrapper routing, shell, PowerShell, repository/docs/platform validation
- Manager and installer Go tests/vet, maintained-target cross-builds, accessibility and JavaScript tests
- local `ci` release archives: functional contracts, checksums, reproducibility, and isolated Windows installer lifecycle passed
- in-app browser screenshot QA could not start because its Windows sandbox failed while applying workspace deny-read ACLs; the isolated fictional fixture itself launched successfully, and responsive/stat/platform DOM contracts passed automated tests

No release is published by this pull request.