### PR TITLE
chore: prepare v0.20.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.8] - 2026-08-25
+
 ### Fixed
 
 - Restored distinct populated lifecycle states in **Preview All** and **Send Test

--- a/docs/releases/v0.20.8.md
+++ b/docs/releases/v0.20.8.md
@@ -1,0 +1,17 @@
+# TautWeekly for Plex v0.20.8
+
+v0.20.8 restores the seven distinct, content-rich **Preview All** lifecycle
+artifacts and their **Send Test All** counterparts. When the selected recipient
+has no report-window activity, these all-state diagnostic operations now use
+clearly disclosed, sanitized scenario-only statistics while retaining current
+release metadata. Ordinary Preview and Send Test continue to render only the
+selected recipient's real state.
+
+Quiet weeks again keep the **Trending** hero in **Latest Releases** alongside the
+capped recent-library fallback of up to four movies and four TV titles. A week
+without report-window additions therefore still presents useful library choices
+instead of an empty release section when recent library metadata is available.
+
+The current personal-stat card layout and recipient platform icons are retained,
+including the most-played platform selection, recency tie-break, exact-user Last
+Platform fallback, white embedded glyphs, responsive sizing, and privacy guards.


### PR DESCRIPTION
## Summary

- roll the validated Preview All / Send Test All regression fix into v0.20.8
- document the restored quiet-week Trending and capped latest-release behavior
- confirm the personal-stat layout and recipient platform icons remain unchanged
- keep the feature spotlight on v0.20.0 because this is a maintenance release

## Validation

- documentation, links, and repository validation passed
- exact v0.20.8 packages built for Windows, NAS/Docker, macOS, Linux/systemd, and FreeBSD/Podman
- package payload contracts and SHA-256 checks passed
- repeated v0.20.8 builds produced byte-identical archives and checksums
- regression implementation and post-merge main CI/container workflows were already green on merge b120f69c371390a44cf7c48065157e0de8bd12c6