### PR TITLE
fix: restore authentic content-rich previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored content-rich **Trending** heroes when Tautulli returns sparse
+  secondary metadata, preserving the source title's genres, year, summary, and
+  provider-labelled critic/audience ratings.
+- Made quiet weeks enumerate real active movie/TV libraries when no explicit
+  library filter is configured, so **Latest Releases** still shows up to four
+  recent movies and four recent TV titles instead of trusting an empty global
+  hub.
+- Removed fictional watch time and sample titles from **Preview All** and
+  **Send Test All**; every state now uses only the selected recipient's real
+  activity while retaining the existing stat layout and platform icons.
+
 ## [0.20.8] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -122,10 +122,15 @@ The responsive Manager is the primary workflow on every maintained package:
 
 - New movie and TV additions with artwork, summaries, genres, ratings, and
   episode details when available.
-- A private personal recap with watch time and most-watched movies and shows.
 - Adaptive **HOT NEW RELEASE** and **TRENDING THIS WEEK** highlights.
+- Quiet weeks remain useful: **Latest Releases** shows up to four real recent
+  movies and four real recent TV titles even when the report window has no new
+  additions.
+- A private personal recap with authentic watch time and most-watched movies
+  and shows; previews never invent recipient activity.
 - A privacy-preserving, server-wide Binge Champion award.
-- Welcome, active-week, quiet-week, and milestone newsletter layouts.
+- Welcome, active-week, quiet-week, and milestone newsletter layouts, including
+  recipient platform icons when real history identifies a supported platform.
 - An optional uppercase custom-card title with one allowlisted 18×18 local GIF.
 - Browser previews and controlled TestEmail delivery before scheduling.
 

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -309,12 +309,17 @@ Open **Previews** after a successful Config validation:
 1. Inspect the generated index and six HTML states in scenario order: Manual
    Welcome, New User - No History, New User - With History, Normal Newsletter,
    Established Quiet, and Established Warnings.
-2. Confirm artwork, ratings, summaries, personal statistics, conditional cards,
-   and responsive layout.
-3. When the previews are correct, select a Tautulli owner/administrator ID and
+2. Confirm artwork, genres, year, ratings, summaries, personal statistics,
+   platform icons, conditional cards, and responsive layout. Every state uses
+   the selected user's real activity; an inactive user remains inactive rather
+   than receiving sample watch rows.
+3. In a week with no new additions, confirm **Latest Releases** still contains
+   up to four real recent movies and four real recent TV titles from the active
+   library scope.
+4. When the previews are correct, select a Tautulli owner/administrator ID and
    use the guarded **Send six test messages** action. All six messages go only
    to the configured `TestEmail`.
-4. Verify the messages in a real mail client. SMTP acceptance confirms the
+5. Verify the messages in a real mail client. SMTP acceptance confirms the
    server accepted them; it does not prove inbox placement.
 
 This guarded six-message TestEmail action is the only Manager setup workflow

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -612,10 +612,16 @@ function Test-IncludedLibraryRow {
         [string]$ExpectedSectionId = ""
     )
 
-    if (-not $script:LibraryFilterEnabled) { return $true }
-
     $sectionId = (Get-OptionalStringProperty -InputObject $Row -Name "section_id").Trim()
     $expectedSectionId = ([string]$ExpectedSectionId).Trim()
+
+    if (-not $script:LibraryFilterEnabled) {
+        # Unfiltered Latest Releases now uses per-section queries. Trust rows
+        # that omit redundant section metadata, but never accept an explicit
+        # cross-section mismatch from a scoped response.
+        if ([string]::IsNullOrWhiteSpace($expectedSectionId) -or [string]::IsNullOrWhiteSpace($sectionId)) { return $true }
+        return ($sectionId -eq $expectedSectionId)
+    }
 
     if (-not [string]::IsNullOrWhiteSpace($expectedSectionId)) {
         if (-not $script:IncludedLibraryIdSet.Contains($expectedSectionId)) { return $false }
@@ -636,6 +642,37 @@ function Test-IncludedLibraryRow {
 function Get-IncludedLibraryQueryScopes {
     if (-not $script:LibraryFilterEnabled) { return @('') }
     return @($script:IncludedLibraryIdSet | Sort-Object)
+}
+
+function Get-LatestReleaseQueryScopes {
+    if ($script:LibraryFilterEnabled) {
+        return @(Get-IncludedLibraryQueryScopes)
+    }
+
+    # Tautulli's unscoped get_recently_added call is backed by Plex's global
+    # hubs. Those hubs may legitimately return no rows once every addition is
+    # older than the hub window, which is exactly when the quiet-week fallback
+    # still needs content. Query every active movie/TV section directly so the
+    # bounded Latest Releases shelves use the library's actual newest items.
+    try {
+        $sectionIds = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+        foreach ($library in @(Invoke-TautulliApi -Command "get_libraries")) {
+            $sectionType = (Get-OptionalStringProperty -InputObject $library -Name "section_type").ToLowerInvariant()
+            if ($sectionType -notin @("movie", "show")) { continue }
+            if ($null -ne $library.PSObject.Properties["is_active"] -and
+                (Safe-Int (Get-OptionalStringProperty -InputObject $library -Name "is_active")) -eq 0) { continue }
+            $sectionId = (Get-OptionalStringProperty -InputObject $library -Name "section_id").Trim()
+            if (-not [string]::IsNullOrWhiteSpace($sectionId)) { [void]$sectionIds.Add($sectionId) }
+        }
+        if ($sectionIds.Count -gt 0) {
+            Write-Log ("Latest Releases will query {0} active movie/TV library section(s)." -f $sectionIds.Count)
+            return @($sectionIds | Sort-Object)
+        }
+    }
+    catch {
+        Write-Log "Could not enumerate movie/TV library sections for Latest Releases; falling back to the global recently-added hub." "WARN"
+    }
+    return @('')
 }
 
 function Require-ConfigValue {
@@ -1072,7 +1109,13 @@ function New-ReleaseData {
                 Title           = Get-OptionalStringProperty -InputObject $item -Name "title"
                 Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
                 Rating          = $rating
+                RatingImage     = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
+                AudienceRating  = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+                AudienceRatingImage = Get-OptionalStringProperty -InputObject $item -Name "audience_rating_image"
                 Summary         = Get-OptionalStringProperty -InputObject $item -Name "summary"
+                DesignGenres    = @(if ($null -ne $item.PSObject.Properties["genres"]) {
+                    ConvertTo-DesignGenreList -Value $item.genres
+                })
                 AddedAt         = Safe-Int64 $item.added_at
                 EpisodeCount    = 0
                 SeasonCount     = 0
@@ -1667,7 +1710,7 @@ function Get-LatestReleaseData {
     $pageSize = 100
     $maxPages = 10
 
-    foreach ($sectionId in @(Get-IncludedLibraryQueryScopes)) {
+    foreach ($sectionId in @(Get-LatestReleaseQueryScopes)) {
         $start = 0
         $scopeRows = New-Object System.Collections.Generic.List[object]
         for ($page = 0; $page -lt $maxPages; $page++) {
@@ -2237,6 +2280,12 @@ function Get-GlobalTitleTotals {
         $titleType = ""
         $metadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
         $metadataYear = Get-OptionalStringProperty -InputObject $row -Name "year"
+        $metadataSummary = ""
+        $metadataRating = ""
+        $metadataRatingImage = ""
+        $metadataAudienceRating = ""
+        $metadataAudienceRatingImage = ""
+        $metadataGenres = @()
         $metadataParentIndex = 0
         $metadataIndex = 0
 
@@ -2245,6 +2294,12 @@ function Get-GlobalTitleTotals {
             $ratingKey = [string]$row.rating_key
             $key = if ([string]::IsNullOrWhiteSpace($ratingKey)) { "movie:title:" + $title } else { "movie:" + $ratingKey }
             $titleType = "movie"
+            $metadataSummary = Get-OptionalStringProperty -InputObject $row -Name "summary"
+            $metadataRating = Get-OptionalStringProperty -InputObject $row -Name "rating"
+            $metadataRatingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
+            $metadataAudienceRating = Get-OptionalStringProperty -InputObject $row -Name "audience_rating"
+            $metadataAudienceRatingImage = Get-OptionalStringProperty -InputObject $row -Name "audience_rating_image"
+            if ($null -ne $row.PSObject.Properties["genres"]) { $metadataGenres = @(ConvertTo-DesignGenreList -Value $row.genres) }
         }
         elseif ($type -eq "episode") {
             $title = [string]$row.grandparent_title
@@ -2273,6 +2328,12 @@ function Get-GlobalTitleTotals {
                 MetadataParentIndex = $metadataParentIndex
                 MetadataIndex = $metadataIndex
                 Year      = $metadataYear
+                Summary   = $metadataSummary
+                Rating    = $metadataRating
+                RatingImage = $metadataRatingImage
+                AudienceRating = $metadataAudienceRating
+                AudienceRatingImage = $metadataAudienceRatingImage
+                Genres    = @($metadataGenres)
                 Seconds   = [int64]0
                 Plays     = 0
             }
@@ -2284,6 +2345,14 @@ function Get-GlobalTitleTotals {
             $totals[$key].MetadataParentIndex = $metadataParentIndex
             $totals[$key].MetadataIndex = $metadataIndex
             $totals[$key].Year = $metadataYear
+        }
+        if ($titleType -eq "movie") {
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].Summary) -and -not [string]::IsNullOrWhiteSpace($metadataSummary)) { $totals[$key].Summary = $metadataSummary }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].Rating) -and -not [string]::IsNullOrWhiteSpace($metadataRating)) { $totals[$key].Rating = $metadataRating }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].RatingImage) -and -not [string]::IsNullOrWhiteSpace($metadataRatingImage)) { $totals[$key].RatingImage = $metadataRatingImage }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].AudienceRating) -and -not [string]::IsNullOrWhiteSpace($metadataAudienceRating)) { $totals[$key].AudienceRating = $metadataAudienceRating }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].AudienceRatingImage) -and -not [string]::IsNullOrWhiteSpace($metadataAudienceRatingImage)) { $totals[$key].AudienceRatingImage = $metadataAudienceRatingImage }
+            if (@($totals[$key].Genres).Count -eq 0 -and $metadataGenres.Count -gt 0) { $totals[$key].Genres = @($metadataGenres) }
         }
 
         $totals[$key].Seconds += $seconds
@@ -2334,15 +2403,31 @@ function New-HeroItemFromGlobalStat {
 
     $title = [string]$Stat.Title
     $year = Get-OptionalStringProperty -InputObject $Stat -Name "Year"
-    $summary = ""
+    $summary = Get-OptionalStringProperty -InputObject $Stat -Name "Summary"
+    $rating = Get-OptionalStringProperty -InputObject $Stat -Name "Rating"
+    $ratingImage = Get-OptionalStringProperty -InputObject $Stat -Name "RatingImage"
+    $audienceRating = Get-OptionalStringProperty -InputObject $Stat -Name "AudienceRating"
+    $audienceRatingImage = Get-OptionalStringProperty -InputObject $Stat -Name "AudienceRatingImage"
+    $genres = @(if ($null -ne $Stat.PSObject.Properties["Genres"]) { ConvertTo-DesignGenreList -Value $Stat.Genres })
     $posterRatingKey = [string]$Stat.RatingKey
     $addedAt = [int64]0
 
     if ($null -ne $meta) {
         $metadataTitle = Get-OptionalStringProperty -InputObject $meta -Name "title"
         if (-not [string]::IsNullOrWhiteSpace($metadataTitle)) { $title = $metadataTitle }
-        $year = Get-OptionalStringProperty -InputObject $meta -Name "year"
-        $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+        $metadataYear = Get-OptionalStringProperty -InputObject $meta -Name "year"
+        if (-not [string]::IsNullOrWhiteSpace($metadataYear)) { $year = $metadataYear }
+        $metadataSummary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+        if (-not [string]::IsNullOrWhiteSpace($metadataSummary)) { $summary = $metadataSummary }
+        $metadataRating = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+        if (-not [string]::IsNullOrWhiteSpace($metadataRating)) { $rating = $metadataRating }
+        $metadataRatingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+        if (-not [string]::IsNullOrWhiteSpace($metadataRatingImage)) { $ratingImage = $metadataRatingImage }
+        $metadataAudienceRating = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+        if (-not [string]::IsNullOrWhiteSpace($metadataAudienceRating)) { $audienceRating = $metadataAudienceRating }
+        $metadataAudienceRatingImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+        if (-not [string]::IsNullOrWhiteSpace($metadataAudienceRatingImage)) { $audienceRatingImage = $metadataAudienceRatingImage }
+        if ($null -ne $meta.PSObject.Properties["genres"]) { $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genres); if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres } }
         $addedAt = Safe-Int64 (Get-OptionalStringProperty -InputObject $meta -Name "added_at")
         if ([string]::IsNullOrWhiteSpace($posterRatingKey)) {
             $posterRatingKey = Get-OptionalStringProperty -InputObject $meta -Name "rating_key"
@@ -2359,8 +2444,12 @@ function New-HeroItemFromGlobalStat {
         MetadataIndex   = Safe-Int (Get-OptionalStringProperty -InputObject $Stat -Name "MetadataIndex")
         Title           = $title
         Year            = $year
-        Rating          = ""
+        Rating          = $rating
+        RatingImage     = $ratingImage
+        AudienceRating  = $audienceRating
+        AudienceRatingImage = $audienceRatingImage
         Summary         = $summary
+        DesignGenres    = @($genres)
         AddedAt         = $addedAt
         EpisodeCount    = 0
         SeasonCount     = 0
@@ -4413,6 +4502,34 @@ function Add-DesignRatingMetadata {
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
+        # Preserve rich fields already returned by get_recently_added or
+        # get_history. A later metadata lookup may improve them, but a sparse
+        # lookup must never erase usable source-row content.
+        if ($null -ne $item.PSObject.Properties["DesignGenres"]) {
+            $genres = @(ConvertTo-DesignGenreList -Value $item.DesignGenres)
+        }
+        elseif ($null -ne $item.PSObject.Properties["Genres"]) {
+            $genres = @(ConvertTo-DesignGenreList -Value $item.Genres)
+        }
+        $sourceRatingImage = Get-OptionalStringProperty -InputObject $item -Name "RatingImage"
+        $sourceRatingValue = Get-OptionalStringProperty -InputObject $item -Name "Rating"
+        $sourceAudienceImage = Get-OptionalStringProperty -InputObject $item -Name "AudienceRatingImage"
+        $sourceAudienceValue = Get-OptionalStringProperty -InputObject $item -Name "AudienceRating"
+        $sourceSelectedRating = Get-DesignProviderRating -RatingImage $sourceRatingImage -RatingValue $sourceRatingValue -AudienceImage $sourceAudienceImage -AudienceValue $sourceAudienceValue
+        if (-not [string]::IsNullOrWhiteSpace($sourceSelectedRating.Provider)) {
+            $provider = $sourceSelectedRating.Provider
+            $providerValue = $sourceSelectedRating.Value
+        }
+        if ($sourceRatingImage -like 'rottentomatoes://image.rating.*') {
+            $critic = Convert-DesignRatingPercent $sourceRatingValue
+            $criticImage = $sourceRatingImage
+        }
+        if ($sourceAudienceImage -like 'rottentomatoes://image.rating.*') {
+            $audience = Convert-DesignRatingPercent $sourceAudienceValue
+            $audienceImageState = $sourceAudienceImage
+        }
+        if ($mediaType -eq "show" -and $sourceRatingImage -like 'imdb://image.rating*') { $imdb = $sourceRatingValue }
+
         # Primary source for the newsletter: Tautulli exposes Plex's selected,
         # provider-labelled rating fields. Keep the dedicated RT/IMDb display
         # paths, then retain another recognized provider as a text badge.
@@ -4431,8 +4548,10 @@ function Add-DesignRatingMetadata {
                 -RatingValue $ratingValue `
                 -AudienceImage $audienceImage `
                 -AudienceValue $audienceRatingValue
-            $provider = $selectedRating.Provider
-            $providerValue = $selectedRating.Value
+            if (-not [string]::IsNullOrWhiteSpace($selectedRating.Provider)) {
+                $provider = $selectedRating.Provider
+                $providerValue = $selectedRating.Value
+            }
 
             if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
                 $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
@@ -4448,10 +4567,12 @@ function Add-DesignRatingMetadata {
             }
 
             if ($null -ne $meta.PSObject.Properties["genres"]) {
-                $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+                $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+                if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres }
             }
             elseif ($null -ne $meta.PSObject.Properties["genre"]) {
-                $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
+                $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genre)
+                if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres }
             }
 
             if ($ratingImage -like 'rottentomatoes://image.rating.*') {
@@ -8507,108 +8628,15 @@ function New-ZeroPreviewStats {
 function Get-PopulatedPreviewStats {
     param([AllowNull()][object]$RealStats)
 
-    if ($null -ne $RealStats -and (Safe-Int64 $RealStats.TotalSeconds) -gt 0) {
-        Add-UserStatsMediaMetadata -Stats $RealStats
-        return [PSCustomObject]@{
-            Stats    = $RealStats
-            IsSample = $false
-        }
-    }
-
-    # PreviewAll and SendTestAll are lifecycle regression galleries, so their
-    # explicitly populated states must remain populated even when the selected
-    # recipient has no report-window activity. Reuse current release metadata
-    # where available and add only clearly synthetic, recipient-local rows.
-    $sampleMovies = New-Object System.Collections.Generic.List[object]
-    foreach ($movie in @($activeReleaseData.Movies | Select-Object -First 2)) {
-        $sampleMovie = [ordered]@{}
-        foreach ($property in $movie.PSObject.Properties) {
-            $sampleMovie[$property.Name] = $property.Value
-        }
-        $sampleMovie["Plays"] = 1
-        $sampleMovie["Seconds"] = [int64](3600 - ($sampleMovies.Count * 900))
-        $sampleMovies.Add([PSCustomObject]$sampleMovie)
-    }
-
-    while ($sampleMovies.Count -lt 2) {
-        $index = $sampleMovies.Count + 1
-        $sampleMovies.Add([PSCustomObject]@{
-            Type="movie"; RatingKey=""; PosterRatingKey="";
-            Title="Sample Movie $index"; Year="";
-            DesignRtCritic=$(if ($index -eq 1) { "87" } else { "66" });
-            DesignRtAudience=$(if ($index -eq 1) { "74" } else { "81" });
-            DesignRtCriticImage="rottentomatoes://image.rating.ripe";
-            DesignRtAudienceImage="rottentomatoes://image.rating.upright";
-            Plays=1; Seconds=[int64](3600 - (($index - 1) * 900))
-        })
-    }
-
-    $sampleEpisodes = New-Object System.Collections.Generic.List[object]
-    foreach ($show in @($activeReleaseData.TV)) {
-        foreach ($episode in @($show.Episodes)) {
-            $sampleEpisodes.Add([PSCustomObject]@{
-                Type="episode"
-                RatingKey=[string]$episode.RatingKey
-                PosterRatingKey=[string]$show.PosterRatingKey
-                ShowTitle=[string]$show.Title
-                EpisodeTitle=[string]$episode.Title
-                Season=Safe-Int $episode.Season
-                Episode=Safe-Int $episode.Episode
-                ImdbRating=[string]$episode.ImdbRating
-                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
-                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
-            })
-            if ($sampleEpisodes.Count -ge 3) { break }
-        }
-        if ($sampleEpisodes.Count -ge 3) { break }
-    }
-
-    while ($sampleEpisodes.Count -lt 3) {
-        $index = $sampleEpisodes.Count + 1
-        $sampleEpisodes.Add([PSCustomObject]@{
-            Type="episode"; RatingKey=""; PosterRatingKey="";
-            ShowTitle="Sample Series"; EpisodeTitle="Sample Episode $index";
-            Season=1; Episode=$index; ImdbRating=$(if ($index -eq 1) { "8.5" } elseif ($index -eq 2) { "8.1" } else { "7.9" })
-        })
-    }
-
-    $sampleTvShows = New-Object System.Collections.Generic.List[object]
-    foreach ($show in @($activeReleaseData.TV | Select-Object -First 3)) {
-        $sampleTvShows.Add([PSCustomObject]@{
-            Type="show"; RatingKey=[string]$show.RatingKey; PosterRatingKey=[string]$show.PosterRatingKey;
-            Title=[string]$show.Title; ShowTitle=[string]$show.Title;
-            Plays=1; Seconds=[int64]3600; TotalTimeText="1h 0m"
-        })
-    }
-    while ($sampleTvShows.Count -lt 3) {
-        $index = $sampleTvShows.Count + 1
-        $sampleTvShows.Add([PSCustomObject]@{
-            Type="show"; RatingKey=""; PosterRatingKey="";
-            Title="Sample Series $index"; ShowTitle="Sample Series $index";
-            Plays=1; Seconds=[int64](3600 - (($index - 1) * 600));
-            TotalTimeText=$(if ($index -eq 1) { "1h 0m" } elseif ($index -eq 2) { "50m" } else { "40m" })
-        })
-    }
-
-    $sampleMost = if ($sampleMovies.Count -gt 0) {
-        [string]$sampleMovies[0].Title
+    $stats = if ($null -eq $RealStats) {
+        New-ZeroPreviewStats
     } else {
-        "Example title"
+        $RealStats
     }
-
+    Add-UserStatsMediaMetadata -Stats $stats
     return [PSCustomObject]@{
-        Stats = [PSCustomObject]@{
-            MoviesWatched    = 2
-            EpisodesStreamed = 3
-            QualifyingPlays  = 5
-            TotalSeconds     = [int64]10980
-            TotalTimeText    = "3h 3m"
-            MostWatched      = $sampleMost
-            MovieItems       = $sampleMovies.ToArray()
-            EpisodeItems     = $sampleEpisodes.ToArray()
-            TvShowItems      = $sampleTvShows.ToArray()
-        }
-        IsSample = $true
+        Stats    = $stats
+        IsSample = $false
     }
 }
 function Build-AllEmailVariants {
@@ -8727,7 +8755,7 @@ function Build-AllEmailVariants {
         -EndLabel $endLabel
 
     # 3) Established active user: always force a populated, non-warm-up state.
-    # The explicit populated state uses the sanitized gallery fallback if needed.
+    # Empty selected-user history remains an authentic zero-activity state.
     $normalHtml = Build-NewsletterHtml `
         -User $user `
         -Stats $populatedVariant.Stats `
@@ -8821,11 +8849,22 @@ function Build-AllEmailVariants {
     $oneOffSubject = Get-OneOffWelcomeSubject -User $user
     $newSubject = Get-NewsletterSubject -User $user -RecentAccess $true
     $normalSubject = Get-NewsletterSubject -User $user -RecentAccess $false
+    $hasRealActivity = (Safe-Int64 $realStats.TotalSeconds) -gt 0
+    $newWithHistoryLabel = if ($hasRealActivity) {
+        "New user first scheduled newsletter — with history"
+    } else {
+        "New user first scheduled newsletter — no selected-user activity"
+    }
+    $normalLabel = if ($hasRealActivity) {
+        "Established user — normal newsletter with activity"
+    } else {
+        "Established user — no selected-user activity"
+    }
 
     return [PSCustomObject]@{
         User = $user
         RealStats = $realStats
-        PopulatedStatsAreSample = [bool]$populatedVariant.IsSample
+        HasRealActivity = $hasRealActivity
         Variants = @(
             [PSCustomObject]@{
                 Key="manual-welcome"
@@ -8847,7 +8886,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="new-scheduled-with-history"
-                Label="New user first scheduled newsletter — with history"
+                Label=$newWithHistoryLabel
                 Subject=$newSubject
                 Html=$newWithHistoryHtml
                 Plain=$newWithHistoryPlain
@@ -8856,7 +8895,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="normal-newsletter"
-                Label="Established user — normal newsletter with activity"
+                Label=$normalLabel
                 Subject=$normalSubject
                 Html=$normalHtml
                 Plain=$normalPlain
@@ -8914,10 +8953,10 @@ if ($Mode -eq "PreviewAll") {
 
     $serverName = HtmlEncode (Get-ConfiguredServerName)
     $userName = HtmlEncode $bundle.User.FriendlyName
-    $historyNote = if ($bundle.PopulatedStatsAreSample) {
-        "The selected user has no activity in this window, so previews 03 and 04 use sanitized scenario statistics only to preserve the populated lifecycle layouts. Previews 05 and 06 intentionally remain at zero activity."
-    } else {
+    $historyNote = if ($bundle.HasRealActivity) {
         "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
+    } else {
+        "The selected user has no activity in this window, so previews 03 and 04 render authentic no-history output without fictional viewing data. Previews 05 and 06 intentionally remain at zero activity."
     }
 
     $cards = New-Object System.Text.StringBuilder

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -612,10 +612,16 @@ function Test-IncludedLibraryRow {
         [string]$ExpectedSectionId = ""
     )
 
-    if (-not $script:LibraryFilterEnabled) { return $true }
-
     $sectionId = (Get-OptionalStringProperty -InputObject $Row -Name "section_id").Trim()
     $expectedSectionId = ([string]$ExpectedSectionId).Trim()
+
+    if (-not $script:LibraryFilterEnabled) {
+        # Unfiltered Latest Releases now uses per-section queries. Trust rows
+        # that omit redundant section metadata, but never accept an explicit
+        # cross-section mismatch from a scoped response.
+        if ([string]::IsNullOrWhiteSpace($expectedSectionId) -or [string]::IsNullOrWhiteSpace($sectionId)) { return $true }
+        return ($sectionId -eq $expectedSectionId)
+    }
 
     if (-not [string]::IsNullOrWhiteSpace($expectedSectionId)) {
         if (-not $script:IncludedLibraryIdSet.Contains($expectedSectionId)) { return $false }
@@ -636,6 +642,37 @@ function Test-IncludedLibraryRow {
 function Get-IncludedLibraryQueryScopes {
     if (-not $script:LibraryFilterEnabled) { return @('') }
     return @($script:IncludedLibraryIdSet | Sort-Object)
+}
+
+function Get-LatestReleaseQueryScopes {
+    if ($script:LibraryFilterEnabled) {
+        return @(Get-IncludedLibraryQueryScopes)
+    }
+
+    # Tautulli's unscoped get_recently_added call is backed by Plex's global
+    # hubs. Those hubs may legitimately return no rows once every addition is
+    # older than the hub window, which is exactly when the quiet-week fallback
+    # still needs content. Query every active movie/TV section directly so the
+    # bounded Latest Releases shelves use the library's actual newest items.
+    try {
+        $sectionIds = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+        foreach ($library in @(Invoke-TautulliApi -Command "get_libraries")) {
+            $sectionType = (Get-OptionalStringProperty -InputObject $library -Name "section_type").ToLowerInvariant()
+            if ($sectionType -notin @("movie", "show")) { continue }
+            if ($null -ne $library.PSObject.Properties["is_active"] -and
+                (Safe-Int (Get-OptionalStringProperty -InputObject $library -Name "is_active")) -eq 0) { continue }
+            $sectionId = (Get-OptionalStringProperty -InputObject $library -Name "section_id").Trim()
+            if (-not [string]::IsNullOrWhiteSpace($sectionId)) { [void]$sectionIds.Add($sectionId) }
+        }
+        if ($sectionIds.Count -gt 0) {
+            Write-Log ("Latest Releases will query {0} active movie/TV library section(s)." -f $sectionIds.Count)
+            return @($sectionIds | Sort-Object)
+        }
+    }
+    catch {
+        Write-Log "Could not enumerate movie/TV library sections for Latest Releases; falling back to the global recently-added hub." "WARN"
+    }
+    return @('')
 }
 
 function Require-ConfigValue {
@@ -1073,7 +1110,13 @@ function New-ReleaseData {
                 Title           = Get-OptionalStringProperty -InputObject $item -Name "title"
                 Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
                 Rating          = $rating
+                RatingImage     = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
+                AudienceRating  = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+                AudienceRatingImage = Get-OptionalStringProperty -InputObject $item -Name "audience_rating_image"
                 Summary         = Get-OptionalStringProperty -InputObject $item -Name "summary"
+                DesignGenres    = @(if ($null -ne $item.PSObject.Properties["genres"]) {
+                    ConvertTo-DesignGenreList -Value $item.genres
+                })
                 AddedAt         = Safe-Int64 $item.added_at
                 EpisodeCount    = 0
                 SeasonCount     = 0
@@ -1668,7 +1711,7 @@ function Get-LatestReleaseData {
     $pageSize = 100
     $maxPages = 10
 
-    foreach ($sectionId in @(Get-IncludedLibraryQueryScopes)) {
+    foreach ($sectionId in @(Get-LatestReleaseQueryScopes)) {
         $start = 0
         $scopeRows = New-Object System.Collections.Generic.List[object]
         for ($page = 0; $page -lt $maxPages; $page++) {
@@ -2238,6 +2281,12 @@ function Get-GlobalTitleTotals {
         $titleType = ""
         $metadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
         $metadataYear = Get-OptionalStringProperty -InputObject $row -Name "year"
+        $metadataSummary = ""
+        $metadataRating = ""
+        $metadataRatingImage = ""
+        $metadataAudienceRating = ""
+        $metadataAudienceRatingImage = ""
+        $metadataGenres = @()
         $metadataParentIndex = 0
         $metadataIndex = 0
 
@@ -2246,6 +2295,12 @@ function Get-GlobalTitleTotals {
             $ratingKey = [string]$row.rating_key
             $key = if ([string]::IsNullOrWhiteSpace($ratingKey)) { "movie:title:" + $title } else { "movie:" + $ratingKey }
             $titleType = "movie"
+            $metadataSummary = Get-OptionalStringProperty -InputObject $row -Name "summary"
+            $metadataRating = Get-OptionalStringProperty -InputObject $row -Name "rating"
+            $metadataRatingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
+            $metadataAudienceRating = Get-OptionalStringProperty -InputObject $row -Name "audience_rating"
+            $metadataAudienceRatingImage = Get-OptionalStringProperty -InputObject $row -Name "audience_rating_image"
+            if ($null -ne $row.PSObject.Properties["genres"]) { $metadataGenres = @(ConvertTo-DesignGenreList -Value $row.genres) }
         }
         elseif ($type -eq "episode") {
             $title = [string]$row.grandparent_title
@@ -2274,6 +2329,12 @@ function Get-GlobalTitleTotals {
                 MetadataParentIndex = $metadataParentIndex
                 MetadataIndex = $metadataIndex
                 Year      = $metadataYear
+                Summary   = $metadataSummary
+                Rating    = $metadataRating
+                RatingImage = $metadataRatingImage
+                AudienceRating = $metadataAudienceRating
+                AudienceRatingImage = $metadataAudienceRatingImage
+                Genres    = @($metadataGenres)
                 Seconds   = [int64]0
                 Plays     = 0
             }
@@ -2285,6 +2346,14 @@ function Get-GlobalTitleTotals {
             $totals[$key].MetadataParentIndex = $metadataParentIndex
             $totals[$key].MetadataIndex = $metadataIndex
             $totals[$key].Year = $metadataYear
+        }
+        if ($titleType -eq "movie") {
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].Summary) -and -not [string]::IsNullOrWhiteSpace($metadataSummary)) { $totals[$key].Summary = $metadataSummary }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].Rating) -and -not [string]::IsNullOrWhiteSpace($metadataRating)) { $totals[$key].Rating = $metadataRating }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].RatingImage) -and -not [string]::IsNullOrWhiteSpace($metadataRatingImage)) { $totals[$key].RatingImage = $metadataRatingImage }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].AudienceRating) -and -not [string]::IsNullOrWhiteSpace($metadataAudienceRating)) { $totals[$key].AudienceRating = $metadataAudienceRating }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].AudienceRatingImage) -and -not [string]::IsNullOrWhiteSpace($metadataAudienceRatingImage)) { $totals[$key].AudienceRatingImage = $metadataAudienceRatingImage }
+            if (@($totals[$key].Genres).Count -eq 0 -and $metadataGenres.Count -gt 0) { $totals[$key].Genres = @($metadataGenres) }
         }
 
         $totals[$key].Seconds += $seconds
@@ -2335,15 +2404,31 @@ function New-HeroItemFromGlobalStat {
 
     $title = [string]$Stat.Title
     $year = Get-OptionalStringProperty -InputObject $Stat -Name "Year"
-    $summary = ""
+    $summary = Get-OptionalStringProperty -InputObject $Stat -Name "Summary"
+    $rating = Get-OptionalStringProperty -InputObject $Stat -Name "Rating"
+    $ratingImage = Get-OptionalStringProperty -InputObject $Stat -Name "RatingImage"
+    $audienceRating = Get-OptionalStringProperty -InputObject $Stat -Name "AudienceRating"
+    $audienceRatingImage = Get-OptionalStringProperty -InputObject $Stat -Name "AudienceRatingImage"
+    $genres = @(if ($null -ne $Stat.PSObject.Properties["Genres"]) { ConvertTo-DesignGenreList -Value $Stat.Genres })
     $posterRatingKey = [string]$Stat.RatingKey
     $addedAt = [int64]0
 
     if ($null -ne $meta) {
         $metadataTitle = Get-OptionalStringProperty -InputObject $meta -Name "title"
         if (-not [string]::IsNullOrWhiteSpace($metadataTitle)) { $title = $metadataTitle }
-        $year = Get-OptionalStringProperty -InputObject $meta -Name "year"
-        $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+        $metadataYear = Get-OptionalStringProperty -InputObject $meta -Name "year"
+        if (-not [string]::IsNullOrWhiteSpace($metadataYear)) { $year = $metadataYear }
+        $metadataSummary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+        if (-not [string]::IsNullOrWhiteSpace($metadataSummary)) { $summary = $metadataSummary }
+        $metadataRating = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+        if (-not [string]::IsNullOrWhiteSpace($metadataRating)) { $rating = $metadataRating }
+        $metadataRatingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+        if (-not [string]::IsNullOrWhiteSpace($metadataRatingImage)) { $ratingImage = $metadataRatingImage }
+        $metadataAudienceRating = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+        if (-not [string]::IsNullOrWhiteSpace($metadataAudienceRating)) { $audienceRating = $metadataAudienceRating }
+        $metadataAudienceRatingImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+        if (-not [string]::IsNullOrWhiteSpace($metadataAudienceRatingImage)) { $audienceRatingImage = $metadataAudienceRatingImage }
+        if ($null -ne $meta.PSObject.Properties["genres"]) { $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genres); if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres } }
         $addedAt = Safe-Int64 (Get-OptionalStringProperty -InputObject $meta -Name "added_at")
         if ([string]::IsNullOrWhiteSpace($posterRatingKey)) {
             $posterRatingKey = Get-OptionalStringProperty -InputObject $meta -Name "rating_key"
@@ -2360,8 +2445,12 @@ function New-HeroItemFromGlobalStat {
         MetadataIndex   = Safe-Int (Get-OptionalStringProperty -InputObject $Stat -Name "MetadataIndex")
         Title           = $title
         Year            = $year
-        Rating          = ""
+        Rating          = $rating
+        RatingImage     = $ratingImage
+        AudienceRating  = $audienceRating
+        AudienceRatingImage = $audienceRatingImage
         Summary         = $summary
+        DesignGenres    = @($genres)
         AddedAt         = $addedAt
         EpisodeCount    = 0
         SeasonCount     = 0
@@ -4414,6 +4503,34 @@ function Add-DesignRatingMetadata {
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
+        # Preserve rich fields already returned by get_recently_added or
+        # get_history. A later metadata lookup may improve them, but a sparse
+        # lookup must never erase usable source-row content.
+        if ($null -ne $item.PSObject.Properties["DesignGenres"]) {
+            $genres = @(ConvertTo-DesignGenreList -Value $item.DesignGenres)
+        }
+        elseif ($null -ne $item.PSObject.Properties["Genres"]) {
+            $genres = @(ConvertTo-DesignGenreList -Value $item.Genres)
+        }
+        $sourceRatingImage = Get-OptionalStringProperty -InputObject $item -Name "RatingImage"
+        $sourceRatingValue = Get-OptionalStringProperty -InputObject $item -Name "Rating"
+        $sourceAudienceImage = Get-OptionalStringProperty -InputObject $item -Name "AudienceRatingImage"
+        $sourceAudienceValue = Get-OptionalStringProperty -InputObject $item -Name "AudienceRating"
+        $sourceSelectedRating = Get-DesignProviderRating -RatingImage $sourceRatingImage -RatingValue $sourceRatingValue -AudienceImage $sourceAudienceImage -AudienceValue $sourceAudienceValue
+        if (-not [string]::IsNullOrWhiteSpace($sourceSelectedRating.Provider)) {
+            $provider = $sourceSelectedRating.Provider
+            $providerValue = $sourceSelectedRating.Value
+        }
+        if ($sourceRatingImage -like 'rottentomatoes://image.rating.*') {
+            $critic = Convert-DesignRatingPercent $sourceRatingValue
+            $criticImage = $sourceRatingImage
+        }
+        if ($sourceAudienceImage -like 'rottentomatoes://image.rating.*') {
+            $audience = Convert-DesignRatingPercent $sourceAudienceValue
+            $audienceImageState = $sourceAudienceImage
+        }
+        if ($mediaType -eq "show" -and $sourceRatingImage -like 'imdb://image.rating*') { $imdb = $sourceRatingValue }
+
         # Primary source for the newsletter: Tautulli exposes Plex's selected,
         # provider-labelled rating fields. Keep the dedicated RT/IMDb display
         # paths, then retain another recognized provider as a text badge.
@@ -4432,8 +4549,10 @@ function Add-DesignRatingMetadata {
                 -RatingValue $ratingValue `
                 -AudienceImage $audienceImage `
                 -AudienceValue $audienceRatingValue
-            $provider = $selectedRating.Provider
-            $providerValue = $selectedRating.Value
+            if (-not [string]::IsNullOrWhiteSpace($selectedRating.Provider)) {
+                $provider = $selectedRating.Provider
+                $providerValue = $selectedRating.Value
+            }
 
             if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
                 $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
@@ -4449,10 +4568,12 @@ function Add-DesignRatingMetadata {
             }
 
             if ($null -ne $meta.PSObject.Properties["genres"]) {
-                $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+                $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+                if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres }
             }
             elseif ($null -ne $meta.PSObject.Properties["genre"]) {
-                $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
+                $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genre)
+                if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres }
             }
 
             if ($ratingImage -like 'rottentomatoes://image.rating.*') {
@@ -8508,108 +8629,15 @@ function New-ZeroPreviewStats {
 function Get-PopulatedPreviewStats {
     param([AllowNull()][object]$RealStats)
 
-    if ($null -ne $RealStats -and (Safe-Int64 $RealStats.TotalSeconds) -gt 0) {
-        Add-UserStatsMediaMetadata -Stats $RealStats
-        return [PSCustomObject]@{
-            Stats    = $RealStats
-            IsSample = $false
-        }
-    }
-
-    # PreviewAll and SendTestAll are lifecycle regression galleries, so their
-    # explicitly populated states must remain populated even when the selected
-    # recipient has no report-window activity. Reuse current release metadata
-    # where available and add only clearly synthetic, recipient-local rows.
-    $sampleMovies = New-Object System.Collections.Generic.List[object]
-    foreach ($movie in @($activeReleaseData.Movies | Select-Object -First 2)) {
-        $sampleMovie = [ordered]@{}
-        foreach ($property in $movie.PSObject.Properties) {
-            $sampleMovie[$property.Name] = $property.Value
-        }
-        $sampleMovie["Plays"] = 1
-        $sampleMovie["Seconds"] = [int64](3600 - ($sampleMovies.Count * 900))
-        $sampleMovies.Add([PSCustomObject]$sampleMovie)
-    }
-
-    while ($sampleMovies.Count -lt 2) {
-        $index = $sampleMovies.Count + 1
-        $sampleMovies.Add([PSCustomObject]@{
-            Type="movie"; RatingKey=""; PosterRatingKey="";
-            Title="Sample Movie $index"; Year="";
-            DesignRtCritic=$(if ($index -eq 1) { "87" } else { "66" });
-            DesignRtAudience=$(if ($index -eq 1) { "74" } else { "81" });
-            DesignRtCriticImage="rottentomatoes://image.rating.ripe";
-            DesignRtAudienceImage="rottentomatoes://image.rating.upright";
-            Plays=1; Seconds=[int64](3600 - (($index - 1) * 900))
-        })
-    }
-
-    $sampleEpisodes = New-Object System.Collections.Generic.List[object]
-    foreach ($show in @($activeReleaseData.TV)) {
-        foreach ($episode in @($show.Episodes)) {
-            $sampleEpisodes.Add([PSCustomObject]@{
-                Type="episode"
-                RatingKey=[string]$episode.RatingKey
-                PosterRatingKey=[string]$show.PosterRatingKey
-                ShowTitle=[string]$show.Title
-                EpisodeTitle=[string]$episode.Title
-                Season=Safe-Int $episode.Season
-                Episode=Safe-Int $episode.Episode
-                ImdbRating=[string]$episode.ImdbRating
-                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
-                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
-            })
-            if ($sampleEpisodes.Count -ge 3) { break }
-        }
-        if ($sampleEpisodes.Count -ge 3) { break }
-    }
-
-    while ($sampleEpisodes.Count -lt 3) {
-        $index = $sampleEpisodes.Count + 1
-        $sampleEpisodes.Add([PSCustomObject]@{
-            Type="episode"; RatingKey=""; PosterRatingKey="";
-            ShowTitle="Sample Series"; EpisodeTitle="Sample Episode $index";
-            Season=1; Episode=$index; ImdbRating=$(if ($index -eq 1) { "8.5" } elseif ($index -eq 2) { "8.1" } else { "7.9" })
-        })
-    }
-
-    $sampleTvShows = New-Object System.Collections.Generic.List[object]
-    foreach ($show in @($activeReleaseData.TV | Select-Object -First 3)) {
-        $sampleTvShows.Add([PSCustomObject]@{
-            Type="show"; RatingKey=[string]$show.RatingKey; PosterRatingKey=[string]$show.PosterRatingKey;
-            Title=[string]$show.Title; ShowTitle=[string]$show.Title;
-            Plays=1; Seconds=[int64]3600; TotalTimeText="1h 0m"
-        })
-    }
-    while ($sampleTvShows.Count -lt 3) {
-        $index = $sampleTvShows.Count + 1
-        $sampleTvShows.Add([PSCustomObject]@{
-            Type="show"; RatingKey=""; PosterRatingKey="";
-            Title="Sample Series $index"; ShowTitle="Sample Series $index";
-            Plays=1; Seconds=[int64](3600 - (($index - 1) * 600));
-            TotalTimeText=$(if ($index -eq 1) { "1h 0m" } elseif ($index -eq 2) { "50m" } else { "40m" })
-        })
-    }
-
-    $sampleMost = if ($sampleMovies.Count -gt 0) {
-        [string]$sampleMovies[0].Title
+    $stats = if ($null -eq $RealStats) {
+        New-ZeroPreviewStats
     } else {
-        "Example title"
+        $RealStats
     }
-
+    Add-UserStatsMediaMetadata -Stats $stats
     return [PSCustomObject]@{
-        Stats = [PSCustomObject]@{
-            MoviesWatched    = 2
-            EpisodesStreamed = 3
-            QualifyingPlays  = 5
-            TotalSeconds     = [int64]10980
-            TotalTimeText    = "3h 3m"
-            MostWatched      = $sampleMost
-            MovieItems       = $sampleMovies.ToArray()
-            EpisodeItems     = $sampleEpisodes.ToArray()
-            TvShowItems      = $sampleTvShows.ToArray()
-        }
-        IsSample = $true
+        Stats    = $stats
+        IsSample = $false
     }
 }
 function Build-AllEmailVariants {
@@ -8728,7 +8756,7 @@ function Build-AllEmailVariants {
         -EndLabel $endLabel
 
     # 3) Established active user: always force a populated, non-warm-up state.
-    # The explicit populated state uses the sanitized gallery fallback if needed.
+    # Empty selected-user history remains an authentic zero-activity state.
     $normalHtml = Build-NewsletterHtml `
         -User $user `
         -Stats $populatedVariant.Stats `
@@ -8822,11 +8850,22 @@ function Build-AllEmailVariants {
     $oneOffSubject = Get-OneOffWelcomeSubject -User $user
     $newSubject = Get-NewsletterSubject -User $user -RecentAccess $true
     $normalSubject = Get-NewsletterSubject -User $user -RecentAccess $false
+    $hasRealActivity = (Safe-Int64 $realStats.TotalSeconds) -gt 0
+    $newWithHistoryLabel = if ($hasRealActivity) {
+        "New user first scheduled newsletter — with history"
+    } else {
+        "New user first scheduled newsletter — no selected-user activity"
+    }
+    $normalLabel = if ($hasRealActivity) {
+        "Established user — normal newsletter with activity"
+    } else {
+        "Established user — no selected-user activity"
+    }
 
     return [PSCustomObject]@{
         User = $user
         RealStats = $realStats
-        PopulatedStatsAreSample = [bool]$populatedVariant.IsSample
+        HasRealActivity = $hasRealActivity
         Variants = @(
             [PSCustomObject]@{
                 Key="manual-welcome"
@@ -8848,7 +8887,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="new-scheduled-with-history"
-                Label="New user first scheduled newsletter — with history"
+                Label=$newWithHistoryLabel
                 Subject=$newSubject
                 Html=$newWithHistoryHtml
                 Plain=$newWithHistoryPlain
@@ -8857,7 +8896,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="normal-newsletter"
-                Label="Established user — normal newsletter with activity"
+                Label=$normalLabel
                 Subject=$normalSubject
                 Html=$normalHtml
                 Plain=$normalPlain
@@ -8915,10 +8954,10 @@ if ($Mode -eq "PreviewAll") {
 
     $serverName = HtmlEncode (Get-ConfiguredServerName)
     $userName = HtmlEncode $bundle.User.FriendlyName
-    $historyNote = if ($bundle.PopulatedStatsAreSample) {
-        "The selected user has no activity in this window, so previews 03 and 04 use sanitized scenario statistics only to preserve the populated lifecycle layouts. Previews 05 and 06 intentionally remain at zero activity."
-    } else {
+    $historyNote = if ($bundle.HasRealActivity) {
         "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
+    } else {
+        "The selected user has no activity in this window, so previews 03 and 04 render authentic no-history output without fictional viewing data. Previews 05 and 06 intentionally remain at zero activity."
     }
 
     $cards = New-Object System.Text.StringBuilder

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -548,10 +548,16 @@ function Test-IncludedLibraryRow {
         [string]$ExpectedSectionId = ""
     )
 
-    if (-not $script:LibraryFilterEnabled) { return $true }
-
     $sectionId = (Get-OptionalStringProperty -InputObject $Row -Name "section_id").Trim()
     $expectedSectionId = ([string]$ExpectedSectionId).Trim()
+
+    if (-not $script:LibraryFilterEnabled) {
+        # Unfiltered Latest Releases now uses per-section queries. Trust rows
+        # that omit redundant section metadata, but never accept an explicit
+        # cross-section mismatch from a scoped response.
+        if ([string]::IsNullOrWhiteSpace($expectedSectionId) -or [string]::IsNullOrWhiteSpace($sectionId)) { return $true }
+        return ($sectionId -eq $expectedSectionId)
+    }
 
     if (-not [string]::IsNullOrWhiteSpace($expectedSectionId)) {
         if (-not $script:IncludedLibraryIdSet.Contains($expectedSectionId)) { return $false }
@@ -572,6 +578,37 @@ function Test-IncludedLibraryRow {
 function Get-IncludedLibraryQueryScopes {
     if (-not $script:LibraryFilterEnabled) { return @('') }
     return @($script:IncludedLibraryIdSet | Sort-Object)
+}
+
+function Get-LatestReleaseQueryScopes {
+    if ($script:LibraryFilterEnabled) {
+        return @(Get-IncludedLibraryQueryScopes)
+    }
+
+    # Tautulli's unscoped get_recently_added call is backed by Plex's global
+    # hubs. Those hubs may legitimately return no rows once every addition is
+    # older than the hub window, which is exactly when the quiet-week fallback
+    # still needs content. Query every active movie/TV section directly so the
+    # bounded Latest Releases shelves use the library's actual newest items.
+    try {
+        $sectionIds = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+        foreach ($library in @(Invoke-TautulliApi -Command "get_libraries")) {
+            $sectionType = (Get-OptionalStringProperty -InputObject $library -Name "section_type").ToLowerInvariant()
+            if ($sectionType -notin @("movie", "show")) { continue }
+            if ($null -ne $library.PSObject.Properties["is_active"] -and
+                (Safe-Int (Get-OptionalStringProperty -InputObject $library -Name "is_active")) -eq 0) { continue }
+            $sectionId = (Get-OptionalStringProperty -InputObject $library -Name "section_id").Trim()
+            if (-not [string]::IsNullOrWhiteSpace($sectionId)) { [void]$sectionIds.Add($sectionId) }
+        }
+        if ($sectionIds.Count -gt 0) {
+            Write-Log ("Latest Releases will query {0} active movie/TV library section(s)." -f $sectionIds.Count)
+            return @($sectionIds | Sort-Object)
+        }
+    }
+    catch {
+        Write-Log "Could not enumerate movie/TV library sections for Latest Releases; falling back to the global recently-added hub." "WARN"
+    }
+    return @('')
 }
 
 function Require-ConfigValue {
@@ -1037,7 +1074,13 @@ function New-ReleaseData {
                 Title           = Get-OptionalStringProperty -InputObject $item -Name "title"
                 Year            = Get-OptionalStringProperty -InputObject $item -Name "year"
                 Rating          = $rating
+                RatingImage     = Get-OptionalStringProperty -InputObject $item -Name "rating_image"
+                AudienceRating  = Get-OptionalStringProperty -InputObject $item -Name "audience_rating"
+                AudienceRatingImage = Get-OptionalStringProperty -InputObject $item -Name "audience_rating_image"
                 Summary         = Get-OptionalStringProperty -InputObject $item -Name "summary"
+                DesignGenres    = @(if ($null -ne $item.PSObject.Properties["genres"]) {
+                    ConvertTo-DesignGenreList -Value $item.genres
+                })
                 AddedAt         = Safe-Int64 $item.added_at
                 EpisodeCount    = 0
                 SeasonCount     = 0
@@ -1632,7 +1675,7 @@ function Get-LatestReleaseData {
     $pageSize = 100
     $maxPages = 10
 
-    foreach ($sectionId in @(Get-IncludedLibraryQueryScopes)) {
+    foreach ($sectionId in @(Get-LatestReleaseQueryScopes)) {
         $start = 0
         $scopeRows = New-Object System.Collections.Generic.List[object]
         for ($page = 0; $page -lt $maxPages; $page++) {
@@ -2216,6 +2259,12 @@ function Get-GlobalTitleTotals {
         $titleType = ""
         $metadataGuid = Get-OptionalStringProperty -InputObject $row -Name "guid"
         $metadataYear = Get-OptionalStringProperty -InputObject $row -Name "year"
+        $metadataSummary = ""
+        $metadataRating = ""
+        $metadataRatingImage = ""
+        $metadataAudienceRating = ""
+        $metadataAudienceRatingImage = ""
+        $metadataGenres = @()
         $metadataParentIndex = 0
         $metadataIndex = 0
 
@@ -2224,6 +2273,12 @@ function Get-GlobalTitleTotals {
             $ratingKey = [string]$row.rating_key
             $key = if ([string]::IsNullOrWhiteSpace($ratingKey)) { "movie:title:" + $title } else { "movie:" + $ratingKey }
             $titleType = "movie"
+            $metadataSummary = Get-OptionalStringProperty -InputObject $row -Name "summary"
+            $metadataRating = Get-OptionalStringProperty -InputObject $row -Name "rating"
+            $metadataRatingImage = Get-OptionalStringProperty -InputObject $row -Name "rating_image"
+            $metadataAudienceRating = Get-OptionalStringProperty -InputObject $row -Name "audience_rating"
+            $metadataAudienceRatingImage = Get-OptionalStringProperty -InputObject $row -Name "audience_rating_image"
+            if ($null -ne $row.PSObject.Properties["genres"]) { $metadataGenres = @(ConvertTo-DesignGenreList -Value $row.genres) }
         }
         elseif ($type -eq "episode") {
             $title = [string]$row.grandparent_title
@@ -2252,6 +2307,12 @@ function Get-GlobalTitleTotals {
                 MetadataParentIndex = $metadataParentIndex
                 MetadataIndex = $metadataIndex
                 Year      = $metadataYear
+                Summary   = $metadataSummary
+                Rating    = $metadataRating
+                RatingImage = $metadataRatingImage
+                AudienceRating = $metadataAudienceRating
+                AudienceRatingImage = $metadataAudienceRatingImage
+                Genres    = @($metadataGenres)
                 Seconds   = [int64]0
                 Plays     = 0
             }
@@ -2263,6 +2324,14 @@ function Get-GlobalTitleTotals {
             $totals[$key].MetadataParentIndex = $metadataParentIndex
             $totals[$key].MetadataIndex = $metadataIndex
             $totals[$key].Year = $metadataYear
+        }
+        if ($titleType -eq "movie") {
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].Summary) -and -not [string]::IsNullOrWhiteSpace($metadataSummary)) { $totals[$key].Summary = $metadataSummary }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].Rating) -and -not [string]::IsNullOrWhiteSpace($metadataRating)) { $totals[$key].Rating = $metadataRating }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].RatingImage) -and -not [string]::IsNullOrWhiteSpace($metadataRatingImage)) { $totals[$key].RatingImage = $metadataRatingImage }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].AudienceRating) -and -not [string]::IsNullOrWhiteSpace($metadataAudienceRating)) { $totals[$key].AudienceRating = $metadataAudienceRating }
+            if ([string]::IsNullOrWhiteSpace([string]$totals[$key].AudienceRatingImage) -and -not [string]::IsNullOrWhiteSpace($metadataAudienceRatingImage)) { $totals[$key].AudienceRatingImage = $metadataAudienceRatingImage }
+            if (@($totals[$key].Genres).Count -eq 0 -and $metadataGenres.Count -gt 0) { $totals[$key].Genres = @($metadataGenres) }
         }
 
         $totals[$key].Seconds += $seconds
@@ -2313,15 +2382,31 @@ function New-HeroItemFromGlobalStat {
 
     $title = [string]$Stat.Title
     $year = Get-OptionalStringProperty -InputObject $Stat -Name "Year"
-    $summary = ""
+    $summary = Get-OptionalStringProperty -InputObject $Stat -Name "Summary"
+    $rating = Get-OptionalStringProperty -InputObject $Stat -Name "Rating"
+    $ratingImage = Get-OptionalStringProperty -InputObject $Stat -Name "RatingImage"
+    $audienceRating = Get-OptionalStringProperty -InputObject $Stat -Name "AudienceRating"
+    $audienceRatingImage = Get-OptionalStringProperty -InputObject $Stat -Name "AudienceRatingImage"
+    $genres = @(if ($null -ne $Stat.PSObject.Properties["Genres"]) { ConvertTo-DesignGenreList -Value $Stat.Genres })
     $posterRatingKey = [string]$Stat.RatingKey
     $addedAt = [int64]0
 
     if ($null -ne $meta) {
         $metadataTitle = Get-OptionalStringProperty -InputObject $meta -Name "title"
         if (-not [string]::IsNullOrWhiteSpace($metadataTitle)) { $title = $metadataTitle }
-        $year = Get-OptionalStringProperty -InputObject $meta -Name "year"
-        $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+        $metadataYear = Get-OptionalStringProperty -InputObject $meta -Name "year"
+        if (-not [string]::IsNullOrWhiteSpace($metadataYear)) { $year = $metadataYear }
+        $metadataSummary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
+        if (-not [string]::IsNullOrWhiteSpace($metadataSummary)) { $summary = $metadataSummary }
+        $metadataRating = Get-OptionalStringProperty -InputObject $meta -Name "rating"
+        if (-not [string]::IsNullOrWhiteSpace($metadataRating)) { $rating = $metadataRating }
+        $metadataRatingImage = Get-OptionalStringProperty -InputObject $meta -Name "rating_image"
+        if (-not [string]::IsNullOrWhiteSpace($metadataRatingImage)) { $ratingImage = $metadataRatingImage }
+        $metadataAudienceRating = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating"
+        if (-not [string]::IsNullOrWhiteSpace($metadataAudienceRating)) { $audienceRating = $metadataAudienceRating }
+        $metadataAudienceRatingImage = Get-OptionalStringProperty -InputObject $meta -Name "audience_rating_image"
+        if (-not [string]::IsNullOrWhiteSpace($metadataAudienceRatingImage)) { $audienceRatingImage = $metadataAudienceRatingImage }
+        if ($null -ne $meta.PSObject.Properties["genres"]) { $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genres); if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres } }
         $addedAt = Safe-Int64 (Get-OptionalStringProperty -InputObject $meta -Name "added_at")
         if ([string]::IsNullOrWhiteSpace($posterRatingKey)) {
             $posterRatingKey = Get-OptionalStringProperty -InputObject $meta -Name "rating_key"
@@ -2338,8 +2423,12 @@ function New-HeroItemFromGlobalStat {
         MetadataIndex   = Safe-Int (Get-OptionalStringProperty -InputObject $Stat -Name "MetadataIndex")
         Title           = $title
         Year            = $year
-        Rating          = ""
+        Rating          = $rating
+        RatingImage     = $ratingImage
+        AudienceRating  = $audienceRating
+        AudienceRatingImage = $audienceRatingImage
         Summary         = $summary
+        DesignGenres    = @($genres)
         AddedAt         = $addedAt
         EpisodeCount    = 0
         SeasonCount     = 0
@@ -4450,6 +4539,34 @@ function Add-DesignRatingMetadata {
         $ratingKey = [string]$item.RatingKey
         $mediaType = if ([string]$item.Type -eq "show") { "show" } else { "movie" }
 
+        # Preserve rich fields already returned by get_recently_added or
+        # get_history. A later metadata lookup may improve them, but a sparse
+        # lookup must never erase usable source-row content.
+        if ($null -ne $item.PSObject.Properties["DesignGenres"]) {
+            $genres = @(ConvertTo-DesignGenreList -Value $item.DesignGenres)
+        }
+        elseif ($null -ne $item.PSObject.Properties["Genres"]) {
+            $genres = @(ConvertTo-DesignGenreList -Value $item.Genres)
+        }
+        $sourceRatingImage = Get-OptionalStringProperty -InputObject $item -Name "RatingImage"
+        $sourceRatingValue = Get-OptionalStringProperty -InputObject $item -Name "Rating"
+        $sourceAudienceImage = Get-OptionalStringProperty -InputObject $item -Name "AudienceRatingImage"
+        $sourceAudienceValue = Get-OptionalStringProperty -InputObject $item -Name "AudienceRating"
+        $sourceSelectedRating = Get-DesignProviderRating -RatingImage $sourceRatingImage -RatingValue $sourceRatingValue -AudienceImage $sourceAudienceImage -AudienceValue $sourceAudienceValue
+        if (-not [string]::IsNullOrWhiteSpace($sourceSelectedRating.Provider)) {
+            $provider = $sourceSelectedRating.Provider
+            $providerValue = $sourceSelectedRating.Value
+        }
+        if ($sourceRatingImage -like 'rottentomatoes://image.rating.*') {
+            $critic = Convert-DesignRatingPercent $sourceRatingValue
+            $criticImage = $sourceRatingImage
+        }
+        if ($sourceAudienceImage -like 'rottentomatoes://image.rating.*') {
+            $audience = Convert-DesignRatingPercent $sourceAudienceValue
+            $audienceImageState = $sourceAudienceImage
+        }
+        if ($mediaType -eq "show" -and $sourceRatingImage -like 'imdb://image.rating*') { $imdb = $sourceRatingValue }
+
         # Primary source for the newsletter: Tautulli exposes Plex's selected,
         # provider-labelled rating fields. Keep the dedicated RT/IMDb display
         # paths, then retain another recognized provider as a text badge.
@@ -4468,8 +4585,10 @@ function Add-DesignRatingMetadata {
                 -RatingValue $ratingValue `
                 -AudienceImage $audienceImage `
                 -AudienceValue $audienceRatingValue
-            $provider = $selectedRating.Provider
-            $providerValue = $selectedRating.Value
+            if (-not [string]::IsNullOrWhiteSpace($selectedRating.Provider)) {
+                $provider = $selectedRating.Provider
+                $providerValue = $selectedRating.Value
+            }
 
             if ([string]::IsNullOrWhiteSpace((Get-OptionalStringProperty -InputObject $item -Name "Summary"))) {
                 $summary = Get-OptionalStringProperty -InputObject $meta -Name "summary"
@@ -4485,10 +4604,12 @@ function Add-DesignRatingMetadata {
             }
 
             if ($null -ne $meta.PSObject.Properties["genres"]) {
-                $genres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+                $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genres)
+                if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres }
             }
             elseif ($null -ne $meta.PSObject.Properties["genre"]) {
-                $genres = @(ConvertTo-DesignGenreList -Value $meta.genre)
+                $metadataGenres = @(ConvertTo-DesignGenreList -Value $meta.genre)
+                if ($metadataGenres.Count -gt 0) { $genres = $metadataGenres }
             }
 
             if ($ratingImage -like 'rottentomatoes://image.rating.*') {
@@ -8548,108 +8669,15 @@ function New-ZeroPreviewStats {
 function Get-PopulatedPreviewStats {
     param([AllowNull()][object]$RealStats)
 
-    if ($null -ne $RealStats -and (Safe-Int64 $RealStats.TotalSeconds) -gt 0) {
-        Add-UserStatsMediaMetadata -Stats $RealStats
-        return [PSCustomObject]@{
-            Stats    = $RealStats
-            IsSample = $false
-        }
-    }
-
-    # PreviewAll and SendTestAll are lifecycle regression galleries, so their
-    # explicitly populated states must remain populated even when the selected
-    # recipient has no report-window activity. Reuse current release metadata
-    # where available and add only clearly synthetic, recipient-local rows.
-    $sampleMovies = New-Object System.Collections.Generic.List[object]
-    foreach ($movie in @($activeReleaseData.Movies | Select-Object -First 2)) {
-        $sampleMovie = [ordered]@{}
-        foreach ($property in $movie.PSObject.Properties) {
-            $sampleMovie[$property.Name] = $property.Value
-        }
-        $sampleMovie["Plays"] = 1
-        $sampleMovie["Seconds"] = [int64](3600 - ($sampleMovies.Count * 900))
-        $sampleMovies.Add([PSCustomObject]$sampleMovie)
-    }
-
-    while ($sampleMovies.Count -lt 2) {
-        $index = $sampleMovies.Count + 1
-        $sampleMovies.Add([PSCustomObject]@{
-            Type="movie"; RatingKey=""; PosterRatingKey="";
-            Title="Sample Movie $index"; Year="";
-            DesignRtCritic=$(if ($index -eq 1) { "87" } else { "66" });
-            DesignRtAudience=$(if ($index -eq 1) { "74" } else { "81" });
-            DesignRtCriticImage="rottentomatoes://image.rating.ripe";
-            DesignRtAudienceImage="rottentomatoes://image.rating.upright";
-            Plays=1; Seconds=[int64](3600 - (($index - 1) * 900))
-        })
-    }
-
-    $sampleEpisodes = New-Object System.Collections.Generic.List[object]
-    foreach ($show in @($activeReleaseData.TV)) {
-        foreach ($episode in @($show.Episodes)) {
-            $sampleEpisodes.Add([PSCustomObject]@{
-                Type="episode"
-                RatingKey=[string]$episode.RatingKey
-                PosterRatingKey=[string]$show.PosterRatingKey
-                ShowTitle=[string]$show.Title
-                EpisodeTitle=[string]$episode.Title
-                Season=Safe-Int $episode.Season
-                Episode=Safe-Int $episode.Episode
-                ImdbRating=[string]$episode.ImdbRating
-                DesignRatingProvider=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingProvider"
-                DesignRatingValue=Get-OptionalStringProperty -InputObject $episode -Name "DesignRatingValue"
-            })
-            if ($sampleEpisodes.Count -ge 3) { break }
-        }
-        if ($sampleEpisodes.Count -ge 3) { break }
-    }
-
-    while ($sampleEpisodes.Count -lt 3) {
-        $index = $sampleEpisodes.Count + 1
-        $sampleEpisodes.Add([PSCustomObject]@{
-            Type="episode"; RatingKey=""; PosterRatingKey="";
-            ShowTitle="Sample Series"; EpisodeTitle="Sample Episode $index";
-            Season=1; Episode=$index; ImdbRating=$(if ($index -eq 1) { "8.5" } elseif ($index -eq 2) { "8.1" } else { "7.9" })
-        })
-    }
-
-    $sampleTvShows = New-Object System.Collections.Generic.List[object]
-    foreach ($show in @($activeReleaseData.TV | Select-Object -First 3)) {
-        $sampleTvShows.Add([PSCustomObject]@{
-            Type="show"; RatingKey=[string]$show.RatingKey; PosterRatingKey=[string]$show.PosterRatingKey;
-            Title=[string]$show.Title; ShowTitle=[string]$show.Title;
-            Plays=1; Seconds=[int64]3600; TotalTimeText="1h 0m"
-        })
-    }
-    while ($sampleTvShows.Count -lt 3) {
-        $index = $sampleTvShows.Count + 1
-        $sampleTvShows.Add([PSCustomObject]@{
-            Type="show"; RatingKey=""; PosterRatingKey="";
-            Title="Sample Series $index"; ShowTitle="Sample Series $index";
-            Plays=1; Seconds=[int64](3600 - (($index - 1) * 600));
-            TotalTimeText=$(if ($index -eq 1) { "1h 0m" } elseif ($index -eq 2) { "50m" } else { "40m" })
-        })
-    }
-
-    $sampleMost = if ($sampleMovies.Count -gt 0) {
-        [string]$sampleMovies[0].Title
+    $stats = if ($null -eq $RealStats) {
+        New-ZeroPreviewStats
     } else {
-        "Example title"
+        $RealStats
     }
-
+    Add-UserStatsMediaMetadata -Stats $stats
     return [PSCustomObject]@{
-        Stats = [PSCustomObject]@{
-            MoviesWatched    = 2
-            EpisodesStreamed = 3
-            QualifyingPlays  = 5
-            TotalSeconds     = [int64]10980
-            TotalTimeText    = "3h 3m"
-            MostWatched      = $sampleMost
-            MovieItems       = $sampleMovies.ToArray()
-            EpisodeItems     = $sampleEpisodes.ToArray()
-            TvShowItems      = $sampleTvShows.ToArray()
-        }
-        IsSample = $true
+        Stats    = $stats
+        IsSample = $false
     }
 }
 function Build-AllEmailVariants {
@@ -8768,7 +8796,7 @@ function Build-AllEmailVariants {
         -EndLabel $endLabel
 
     # 3) Established active user: always force a populated, non-warm-up state.
-    # The explicit populated state uses the sanitized gallery fallback if needed.
+    # Empty selected-user history remains an authentic zero-activity state.
     $normalHtml = Build-NewsletterHtml `
         -User $user `
         -Stats $populatedVariant.Stats `
@@ -8862,11 +8890,22 @@ function Build-AllEmailVariants {
     $oneOffSubject = Get-OneOffWelcomeSubject -User $user
     $newSubject = Get-NewsletterSubject -User $user -RecentAccess $true
     $normalSubject = Get-NewsletterSubject -User $user -RecentAccess $false
+    $hasRealActivity = (Safe-Int64 $realStats.TotalSeconds) -gt 0
+    $newWithHistoryLabel = if ($hasRealActivity) {
+        "New user first scheduled newsletter — with history"
+    } else {
+        "New user first scheduled newsletter — no selected-user activity"
+    }
+    $normalLabel = if ($hasRealActivity) {
+        "Established user — normal newsletter with activity"
+    } else {
+        "Established user — no selected-user activity"
+    }
 
     return [PSCustomObject]@{
         User = $user
         RealStats = $realStats
-        PopulatedStatsAreSample = [bool]$populatedVariant.IsSample
+        HasRealActivity = $hasRealActivity
         Variants = @(
             [PSCustomObject]@{
                 Key="manual-welcome"
@@ -8888,7 +8927,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="new-scheduled-with-history"
-                Label="New user first scheduled newsletter — with history"
+                Label=$newWithHistoryLabel
                 Subject=$newSubject
                 Html=$newWithHistoryHtml
                 Plain=$newWithHistoryPlain
@@ -8897,7 +8936,7 @@ function Build-AllEmailVariants {
             },
             [PSCustomObject]@{
                 Key="normal-newsletter"
-                Label="Established user — normal newsletter with activity"
+                Label=$normalLabel
                 Subject=$normalSubject
                 Html=$normalHtml
                 Plain=$normalPlain
@@ -8955,10 +8994,10 @@ if ($Mode -eq "PreviewAll") {
 
     $serverName = HtmlEncode (Get-ConfiguredServerName)
     $userName = HtmlEncode $bundle.User.FriendlyName
-    $historyNote = if ($bundle.PopulatedStatsAreSample) {
-        "The selected user has no activity in this window, so previews 03 and 04 use sanitized scenario statistics only to preserve the populated lifecycle layouts. Previews 05 and 06 intentionally remain at zero activity."
-    } else {
+    $historyNote = if ($bundle.HasRealActivity) {
         "Previews 03 and 04 use the selected user's real current-window watch statistics. Previews 05 and 06 intentionally force zero activity."
+    } else {
+        "The selected user has no activity in this window, so previews 03 and 04 render authentic no-history output without fictional viewing data. Previews 05 and 06 intentionally remain at zero activity."
     }
 
     $cards = New-Object System.Text.StringBuilder

--- a/scripts/test-library-selection.ps1
+++ b/scripts/test-library-selection.ps1
@@ -98,6 +98,7 @@ foreach ($relative in @(
         'Get-DesignProviderRating',
         'Test-IncludedLibraryRow',
         'Get-IncludedLibraryQueryScopes',
+        'Get-LatestReleaseQueryScopes',
         'Get-History',
         'Get-RecentItems',
         'New-ReleaseData',
@@ -114,6 +115,11 @@ foreach ($relative in @(
         Invoke-Expression $definition.Extent.Text
     }
 
+    function Write-Log {
+        param([string]$Message, [string]$Level = 'INFO')
+        [void]$Message
+        [void]$Level
+    }
     $script:LibraryFilterEnabled = $true
     $script:IncludedLibraryIdSet = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
     [void]$script:IncludedLibraryIdSet.Add('10')
@@ -164,6 +170,15 @@ foreach ($relative in @(
 
         $scope = if ($Parameters.ContainsKey('section_id')) { [string]$Parameters.section_id } else { '' }
         $script:scopeCalls.Add("$Command`:$scope")
+
+        if ($Command -eq 'get_libraries') {
+            return @(
+                [PSCustomObject]@{ section_id = '10'; section_type = 'movie'; is_active = 1 },
+                [PSCustomObject]@{ section_id = '20'; section_type = 'show'; is_active = 1 },
+                [PSCustomObject]@{ section_id = '99'; section_type = 'movie'; is_active = 0 },
+                [PSCustomObject]@{ section_id = '30'; section_type = 'artist'; is_active = 1 }
+            )
+        }
 
         if ([string]::IsNullOrWhiteSpace($scope)) {
             # This emulates a busy private library occupying every globally
@@ -275,6 +290,14 @@ foreach ($relative in @(
         -Actual ($script:scopeCalls -join ',') -Expected 'get_history:'
     Assert-Equal -Name "$relative preserves legacy all-library history" `
         -Actual (($legacyHistory | ForEach-Object rating_key) -join ',') -Expected 'private-movie'
+
+    $script:scopeCalls.Clear()
+    $unfilteredLatest = Get-LatestReleaseData -MovieLimit 4 -TvLimit 4
+    Assert-Equal -Name "$relative enumerates active movie/TV sections for unfiltered quiet fallback" `
+        -Actual ((@($unfilteredLatest.Movies.Title) + @($unfilteredLatest.TV.Title)) -join ',') `
+        -Expected 'Selected Movie,Selected Show,Selected Show 2,Selected Show 3,Selected Show 4'
+    Assert-Equal -Name "$relative avoids the global recently-added hub for unfiltered quiet fallback" `
+        -Actual (@($script:scopeCalls | Where-Object { $_ -eq 'get_recently_added:' }).Count) -Expected 0
 }
 
 foreach ($name in @('Library-Selection.ps1', 'Manage-Library-Selection.ps1')) {

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -668,10 +668,24 @@ foreach ($engine in $engines) {
                 [string]$_.query.cmd -in @('get_history', 'get_recently_added')
             })
             Assert-True ($mediaCalls.Count -gt 0) "$($engine.Name)/$scenario made no media calls."
-            Assert-True (@($mediaCalls | Where-Object {
-                $null -eq $_.query.PSObject.Properties['section_id'] -or
-                [string]$_.query.section_id -notin @('10', '20')
-            }).Count -eq 0) "$($engine.Name)/$scenario issued an unscoped/private media query."
+            if ($scenario -eq $quietNoHistoryScenario) {
+                $unscopedRecentCalls = @($mediaCalls | Where-Object {
+                    [string]$_.query.cmd -eq 'get_recently_added' -and
+                    $null -eq $_.query.PSObject.Properties['section_id']
+                })
+                Assert-True ($unscopedRecentCalls.Count -eq 1) "$($engine.Name)/$scenario did not limit the empty global recently-added hub to weekly quiet detection."
+                $scopedRecentSections = @($mediaCalls | Where-Object {
+                    [string]$_.query.cmd -eq 'get_recently_added' -and
+                    $null -ne $_.query.PSObject.Properties['section_id']
+                } | ForEach-Object { [string]$_.query.section_id } | Sort-Object -Unique)
+                Assert-True (($scopedRecentSections -join ',') -eq '10,20') "$($engine.Name)/$scenario did not query every active movie/TV section for Latest Releases."
+            }
+            else {
+                Assert-True (@($mediaCalls | Where-Object {
+                    $null -eq $_.query.PSObject.Properties['section_id'] -or
+                    [string]$_.query.section_id -notin @('10', '20')
+                }).Count -eq 0) "$($engine.Name)/$scenario issued an unscoped/private media query."
+            }
 
             if ($scenario -in $providerRecoveryScenarios) {
                 $hostedCalls = @($calls | Where-Object { [string]$_.path -like '/hosted/library/metadata/*' })

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -185,6 +185,9 @@ foreach ($engine in $engines) {
                 CustomTextCardSubheading = 'Assessment & notes'
                 CustomTextCardBody = "Synthetic <notice> & safe`nSecond line"
             }
+            if ($scenario -eq $quietNoHistoryScenario) {
+                $configOverrides['IncludedLibraryIds'] = @()
+            }
             if ($scenario -in $sendTestScenarios) {
                 $configOverrides['SmtpHost'] = '127.0.0.1'
                 $configOverrides['SmtpPort'] = $smtpPort
@@ -312,7 +315,12 @@ foreach ($engine in $engines) {
             )
             Assert-True (($actualPreviewNames -join '|') -eq ($expectedPreviewNames -join '|')) "$($engine.Name)/$scenario generated the all-state previews in the wrong order or under unexpected names."
             $scenarioHashes = @(Get-ChildItem $outputRoot -Filter 'preview-all-*.html' | Where-Object { $_.Name -ne 'preview-all-00-INDEX.html' } | ForEach-Object { (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash } | Select-Object -Unique)
-            Assert-True ($scenarioHashes.Count -eq 6) "$($engine.Name)/$scenario collapsed distinct lifecycle scenarios into duplicate HTML."
+            if ($scenario -eq $quietNoHistoryScenario) {
+                Assert-True ($scenarioHashes.Count -eq 4) "$($engine.Name)/$scenario fabricated differences between authentic zero-history lifecycle states."
+            }
+            else {
+                Assert-True ($scenarioHashes.Count -eq 6) "$($engine.Name)/$scenario collapsed distinct lifecycle scenarios into duplicate HTML."
+            }
             Assert-True ((Get-ChildItem $outputRoot -Filter 'preview-all-*.html').Count -eq 7) "$($engine.Name)/$scenario did not generate all six states plus the index."
             if ($engine.Name -eq 'nas-docker-linux-freebsd' -and $scenario -in @('active', $platformScenario)) {
                 Assert-True (Test-Path -LiteralPath $managerResultPath) 'NAS Manager operation did not produce its structured result.'
@@ -410,6 +418,7 @@ foreach ($engine in $engines) {
             Assert-True ($normalHtml.Contains('class="email-card"')) "$($engine.Name)/$scenario lost explicit dark card classes."
             Assert-True ($normalHtml.Contains('bgcolor="#181818"')) "$($engine.Name)/$scenario lost the legacy dark card fallback."
             Assert-True ($normalHtml.Contains('background-color:#181818')) "$($engine.Name)/$scenario lost the longhand dark card fallback."
+            if ($scenario -ne $quietNoHistoryScenario) {
             Assert-True ($normalHtml.Contains('YOU CLOCKED') -and $normalHtml.Contains('total watch time')) "$($engine.Name)/$scenario lost the personal total-watch-time presentation."
             Assert-True (-not $normalHtml.Contains('>total watched<')) "$($engine.Name)/$scenario retained the old personal-time label."
             Assert-True (([regex]::Matches($normalHtml, 'class="stats-summary-cell"')).Count -eq 2) "$($engine.Name)/$scenario did not render exactly two compact desktop summary cells."
@@ -419,28 +428,34 @@ foreach ($engine in $engines) {
             Assert-True ($normalHtml.Contains('colspan="2" width="100%" valign="top"')) "$($engine.Name)/$scenario did not render the populated personal media card at full width."
             Assert-True ($normalHtml.Contains('class="stats-title-cell" width="50%"') -and $normalHtml.Contains('.stats-title-cell { display:block !important; width:100% !important;')) "$($engine.Name)/$scenario lost the two-column desktop and one-column mobile movie-title layout."
             Assert-True ($normalHtml.Contains('.stats-title-cell.stats-tv-title-cell { display:table-cell !important; width:50% !important;')) "$($engine.Name)/$scenario lost the two-column mobile TV-title rule."
+            }
             Assert-True (-not $quietHtml.Contains('class="stats-summary-cell"') -and -not $quietHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario rendered personal summary cards in the zero-activity state."
             Assert-True (-not $normalHtml.Contains('Ratings unavailable') -and -not $normalHtml.Contains('IMDb unavailable')) "$($engine.Name)/$scenario rendered an unavailable-rating placeholder."
-            $expectedMode = if ($scenario -in @('quiet', $quietNoHistoryScenario) -or $scenario -in $deletedHistoryScenarios) { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
+            $expectedMode = if ($scenario -in @('quiet', $quietNoHistoryScenario, 'optional-hero-metadata') -or $scenario -in $deletedHistoryScenarios) { 'QUIET / LATEST RELEASES' } else { 'NORMAL / NEW RELEASES' }
             Assert-True ($indexHtml.Contains($expectedMode)) "$($engine.Name)/$scenario reported the wrong release mode."
             Assert-True ($normalHtml.Contains('Selected Movie')) "$($engine.Name)/$scenario lost the selected movie."
             Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the selected TV show."
             Assert-True (-not $normalHtml.Contains('Private Movie')) "$($engine.Name)/$scenario leaked a private-library title."
             Assert-True (-not $normalHtml.Contains('Simulated Champion')) "$($engine.Name)/$scenario leaked the Binge Champion identity."
-            $expectedChampionDuration = if ($scenario -eq $quietNoHistoryScenario) { '5h 0m watched' } else { '3h 0m watched' }
+            $expectedChampionDuration = if ($scenario -eq $quietNoHistoryScenario) { '5h 0m watched' } elseif ($scenario -eq 'optional-hero-metadata') { '4h 0m watched' } else { '3h 0m watched' }
             Assert-True ($normalHtml.Contains($expectedChampionDuration)) "$($engine.Name)/$scenario lost the shared champion duration line."
-            Assert-True ($normalHtml.Contains('1 TV show')) "$($engine.Name)/$scenario lost the unique TV-show breakdown."
-            Assert-True (-not $normalHtml.Contains('0 movies')) "$($engine.Name)/$scenario rendered an empty Binge Champion movie category."
+            $expectedChampionMedia = if ($scenario -eq 'optional-hero-metadata') { '1 movie' } else { '1 TV show' }
+            Assert-True ($normalHtml.Contains($expectedChampionMedia)) "$($engine.Name)/$scenario lost the Binge Champion media breakdown."
+            Assert-True (-not $normalHtml.Contains('0 movies') -and -not $normalHtml.Contains('0 TV shows')) "$($engine.Name)/$scenario rendered an empty Binge Champion media category."
             Assert-True (-not $normalHtml.Contains('qualifying plays')) "$($engine.Name)/$scenario retained qualifying-play copy in Total Watched."
             if ($scenario -notin $deletedHistoryScenarios -and $scenario -ne 'personal-many' -and $scenario -ne $platformScenario -and $scenario -ne $quietNoHistoryScenario) {
                 Assert-True (-not $normalHtml.Contains('TV SHOWS WATCHED')) "$($engine.Name)/$scenario rendered an empty TV stats card."
             }
 
             if ($scenario -eq $quietNoHistoryScenario) {
-                Assert-True ($indexHtml.Contains('previews 03 and 04 use sanitized scenario statistics only')) "$($engine.Name)/$scenario did not disclose the populated all-state fixture."
+                Assert-True ($indexHtml.Contains('render authentic no-history output without fictional viewing data')) "$($engine.Name)/$scenario did not disclose authentic zero-history behavior."
                 Assert-True ($newNoHistoryHtml.Contains('WELCOME ABOARD') -and -not $newNoHistoryHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario lost the intentional new-user/no-history state."
-                Assert-True ($newWithHistoryHtml.Contains('WELCOME ABOARD') -and $newWithHistoryHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario did not preserve the populated new-user state."
-                Assert-True ($normalHtml.Contains('YOU CLOCKED') -and $normalHtml.Contains('Sample Movie 2')) "$($engine.Name)/$scenario did not preserve a populated established lifecycle preview."
+                Assert-True ($newWithHistoryHtml.Contains('WELCOME ABOARD') -and -not $newWithHistoryHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario invented new-user activity."
+                Assert-True (-not $normalHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario invented established-user activity."
+                foreach ($previewPath in $previewPaths) {
+                    $authenticHtml = Get-Content -LiteralPath $previewPath.FullName -Raw -Encoding UTF8
+                    Assert-True (-not $authenticHtml.Contains('Sample Movie') -and -not $authenticHtml.Contains('Sample Series')) "$($engine.Name)/$scenario emitted fabricated watch rows in $($previewPath.Name)."
+                }
                 Assert-True ($quietHtml.Contains('QUIET IN THIS SECTOR') -and -not $quietHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario lost the intentional established quiet state."
                 Assert-True ($warmupHtml.Contains('STATS ARE WARMING UP') -and -not $warmupHtml.Contains('YOU CLOCKED')) "$($engine.Name)/$scenario lost the intentional warm-up state."
                 foreach ($contentRichHtml in @($newWithHistoryHtml, $normalHtml)) {
@@ -453,6 +468,15 @@ foreach ($engine in $engines) {
                 Assert-True ($quietHtml.Contains('Selected Movie') -and ([regex]::Matches($quietHtml, 'Selected Show')).Count -ge 2) "$($engine.Name)/$scenario removed a capped latest title after also selecting it as Trending."
                 Assert-True (-not $quietHtml.Contains('Toy Story 5')) "$($engine.Name)/$scenario substituted an unrelated fallback shell."
                 Assert-True ($previewLog.Contains('Latest Releases: 1 movies and 1 TV titles.')) "$($engine.Name)/$scenario did not load the bounded quiet-week fallback."
+                Assert-True ($previewLog.Contains('Latest Releases will query 2 active movie/TV library section(s).')) "$($engine.Name)/$scenario used the empty global hub instead of enumerated library sections."
+            }
+            if ($scenario -eq 'optional-hero-metadata') {
+                $heroStart = $normalHtml.IndexOf('TRENDING THIS WEEK', [StringComparison]::Ordinal)
+                $latestStart = if ($heroStart -ge 0) { $normalHtml.IndexOf('LATEST RELEASES', $heroStart, [StringComparison]::Ordinal) } else { -1 }
+                Assert-True ($heroStart -ge 0 -and $latestStart -gt $heroStart) "$($engine.Name)/$scenario could not isolate the quiet Trending hero."
+                $heroHtml = $normalHtml.Substring($heroStart, $latestStart - $heroStart)
+                Assert-True ($heroHtml.Contains('Selected-library viewing history.') -and $heroHtml.Contains('Drama, Mystery')) "$($engine.Name)/$scenario projected away the Trending hero summary or genres."
+                Assert-True ($heroHtml.Contains('Rotten Tomatoes critic') -and $heroHtml.Contains('Rotten Tomatoes audience') -and $heroHtml.Contains('2026')) "$($engine.Name)/$scenario projected away the Trending hero year or ratings."
             }
             if ($scenario -eq 'personal-many') {
                 Assert-True ($normalHtml.Contains('Personal Movie 12') -and $normalHtml.Contains('Personal Show 11')) "$($engine.Name)/$scenario capped personal movie or TV rows before the final synthetic title."
@@ -720,7 +744,8 @@ foreach ($engine in $engines) {
                 if ($scenario -notin $directRatingScenarios -and $scenario -notin @($platformScenario, $lastPlatformScenario, $quietNoHistoryScenario)) {
                     Assert-True ($previewLog -match 'direct Plex .*404.*Not Found') "$($engine.Name)/$scenario did not exercise the recoverable direct Plex 404 fallback."
                 }
-                Assert-True ($normalHtml.Contains('Selected Show')) "$($engine.Name)/$scenario lost the global-history title fallback for sparse hero metadata."
+                $expectedSparseHeroTitle = if ($scenario -eq 'optional-hero-metadata') { 'Selected Movie' } else { 'Selected Show' }
+                Assert-True ($normalHtml.Contains($expectedSparseHeroTitle)) "$($engine.Name)/$scenario lost the global-history title fallback for sparse hero metadata."
 
                 $accessStatePath = if ($engine.Container) {
                     Join-Path $dataRoot 'access-state.json'
@@ -919,13 +944,13 @@ foreach ($engine in $engines) {
                     $stateExpectations = @(
                         [PSCustomObject]@{ Required = @('WELCOME ABOARD'); Forbidden = @('YOU CLOCKED') },
                         [PSCustomObject]@{ Required = @('WELCOME ABOARD', 'LATEST RELEASES'); Forbidden = @('YOU CLOCKED') },
-                        [PSCustomObject]@{ Required = @('WELCOME ABOARD', 'YOU CLOCKED', 'LATEST RELEASES'); Forbidden = @() },
-                        [PSCustomObject]@{ Required = @('YOU CLOCKED', 'LATEST RELEASES'); Forbidden = @('WELCOME ABOARD') },
+                        [PSCustomObject]@{ Required = @('WELCOME ABOARD', 'LATEST RELEASES'); Forbidden = @('YOU CLOCKED') },
+                        [PSCustomObject]@{ Required = @('LATEST RELEASES'); Forbidden = @('WELCOME ABOARD', 'YOU CLOCKED') },
                         [PSCustomObject]@{ Required = @('QUIET IN THIS SECTOR', 'LATEST RELEASES'); Forbidden = @('YOU CLOCKED') },
                         [PSCustomObject]@{ Required = @('STATS ARE WARMING UP', 'LATEST RELEASES'); Forbidden = @('YOU CLOCKED') }
                     )
                     for ($stateIndex = 0; $stateIndex -lt 6; $stateIndex++) {
-                        $stateArgs = @($stateCaptures[$stateIndex].FullName)
+                        $stateArgs = @($stateCaptures[$stateIndex].FullName, '--forbid-html', 'Sample Movie', '--forbid-html', 'Sample Series')
                         foreach ($requiredMarker in $stateExpectations[$stateIndex].Required) {
                             $stateArgs += @('--require-html', $requiredMarker)
                         }

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -56,6 +56,7 @@ $requiredFunctions = @(
     'Safe-Int',
     'Safe-Int64',
     'New-ReleaseData',
+    'Get-LatestReleaseQueryScopes',
     'Get-HistoryRowPlayCount',
     'Get-NewsletterPlatformCatalog',
     'ConvertTo-NewsletterPlatformAlias',
@@ -111,8 +112,9 @@ foreach ($relativePath in $rendererPaths) {
     }
 
     $rendererSource = [IO.File]::ReadAllText($path)
-    Assert-True ($rendererSource.Contains('Title="Sample Movie')) "$relativePath lacks sanitized populated-state fallback rows for lifecycle regression modes"
+    Assert-True (-not $rendererSource.Contains('Title="Sample Movie') -and -not $rendererSource.Contains('Title="Sample Series')) "$relativePath fabricates watch rows for empty preview states"
     Assert-True (([regex]::Matches($rendererSource, 'Get-PopulatedPreviewStats -RealStats')).Count -eq 1) "$relativePath allows populated-state fixture statistics outside Build-AllEmailVariants"
+    Assert-True ($rendererSource.Contains('Invoke-TautulliApi -Command "get_libraries"')) "$relativePath does not enumerate real movie/TV libraries for quiet-week fallback"
     Assert-True (([regex]::Matches($rendererSource, 'Get-NewsletterLastPlatform -ExpectedUserId \$user\.UserId')).Count -eq 3) "$relativePath does not apply Last Platform to manual, preview/test, and standard recipient paths"
 
     foreach ($functionName in $requiredFunctions) {
@@ -1155,12 +1157,9 @@ foreach ($relativePath in $rendererPaths) {
         TV = @()
     }
     $samplePreview = Get-PopulatedPreviewStats -RealStats $empty
-    Assert-True ($samplePreview.IsSample) "$relativePath did not preserve distinct populated lifecycle scenarios for empty selected-user history"
-    Assert-True ((Safe-Int64 $samplePreview.Stats.TotalSeconds) -gt 0) "$relativePath did not populate the with-history scenario"
-    Assert-True ($samplePreview.Stats.MovieItems.Count -ge 2 -and $samplePreview.Stats.EpisodeItems.Count -ge 3 -and $samplePreview.Stats.TvShowItems.Count -ge 3) "$relativePath did not build content-rich populated scenario rows"
-    foreach ($sampleMovie in $samplePreview.Stats.MovieItems) {
-        Assert-True ((Safe-Int64 $sampleMovie.Seconds) -gt 0) "$relativePath generated invalid populated-scenario movie watch time"
-    }
+    Assert-True (-not $samplePreview.IsSample) "$relativePath labels authentic empty selected-user history as sample activity"
+    Assert-True ((Safe-Int64 $samplePreview.Stats.TotalSeconds) -eq 0) "$relativePath fabricated watch time for an empty preview state"
+    Assert-True ($samplePreview.Stats.MovieItems.Count -eq 0 -and $samplePreview.Stats.EpisodeItems.Count -eq 0 -and $samplePreview.Stats.TvShowItems.Count -eq 0) "$relativePath fabricated watched titles for an empty preview state"
     $samplePlainText = Build-PlainText `
         -User ([PSCustomObject]@{ FriendlyName = 'Viewer' }) `
         -Stats $samplePreview.Stats `
@@ -1171,7 +1170,7 @@ foreach ($relativePath in $rendererPaths) {
         -RecentAccess $false `
         -StartLabel 'August 1' `
         -EndLabel 'August 7'
-    Assert-True ($samplePlainText.Contains('movies watched') -and $samplePlainText.Contains('TV shows watched')) "$relativePath could not render populated lifecycle stats as plain text"
+    Assert-True (-not $samplePlainText.Contains('Sample Movie') -and -not $samplePlainText.Contains('Sample Series')) "$relativePath rendered fictional preview activity as plain text"
     Assert-True ($samplePlainText.Contains('View & Request: https://app.plex.tv/')) "$relativePath did not render the custom button label and URL in plain text"
     Assert-True ($samplePlainText.Contains("CUSTOM <TITLE>`r`nMaintenance & more`r`nFirst <line> & safe`nSecond line")) "$relativePath did not render the plain-text custom card"
     $customPlainIndex = $samplePlainText.IndexOf('CUSTOM <TITLE>', [StringComparison]::Ordinal)

--- a/scripts/test-support/fake-tautulli.py
+++ b/scripts/test-support/fake-tautulli.py
@@ -21,8 +21,8 @@ DELETED_HISTORY_SCENARIOS = (
 def media_rows(scenario: str) -> dict[str, list[dict[str, object]]]:
     now = int(time.time())
     old = now - (30 * 86400)
-    movie_added = now if scenario in ("active", "personal-many", "platform-tie", "last-platform", "optional-hero-metadata", "rating-export-fallback", "direct-rating-optional", "direct-rating-xml-fallback", "direct-episode-rt-fallback", "cache-prime") else old
-    tv_added = now if scenario in ("active", "personal-many", "tv-only", "optional-hero-metadata", "rating-export-fallback", "direct-rating-optional", "direct-rating-xml-fallback", "direct-episode-rt-fallback", "cache-prime") else old
+    movie_added = now if scenario in ("active", "personal-many", "platform-tie", "last-platform", "rating-export-fallback", "direct-rating-optional", "direct-rating-xml-fallback", "direct-episode-rt-fallback", "cache-prime") else old
+    tv_added = now if scenario in ("active", "personal-many", "tv-only", "rating-export-fallback", "direct-rating-optional", "direct-rating-xml-fallback", "direct-episode-rt-fallback", "cache-prime") else old
     rows = {
         "10": [
             {
@@ -258,6 +258,11 @@ def history_rows(section_id: str, scenario: str) -> list[dict[str, object]]:
                 rows[0].pop(field, None)
         if scenario == "last-platform":
             rows[0]["platform"] = "Unrecognized Platform"
+        if scenario == "optional-hero-metadata":
+            rows[0]["play_duration"] = 14400
+            rows[0]["rating_image"] = "rottentomatoes://image.rating.ripe"
+            rows[0]["audience_rating_image"] = "rottentomatoes://image.rating.upright"
+            rows[0]["genres"] = ["Drama", "Mystery"]
         return rows
     if section_id == "20":
         rows = [
@@ -917,16 +922,21 @@ class Handler(BaseHTTPRequestHandler):
             self.api_success({"pms_url": self.server.base_url})  # type: ignore[attr-defined]
             return
         if command == "get_libraries":
-            self.api_success(
-                [
-                    {"section_id": "10", "section_name": "Selected Movies", "section_type": "movie", "count": 1, "is_active": 1},
-                    {"section_id": "20", "section_name": "Selected TV", "section_type": "show", "count": 1, "is_active": 1},
-                    {"section_id": "99", "section_name": "Private", "section_type": "movie", "count": 1, "is_active": 1},
-                ]
-            )
+            libraries = [
+                {"section_id": "10", "section_name": "Selected Movies", "section_type": "movie", "count": 1, "is_active": 1},
+                {"section_id": "20", "section_name": "Selected TV", "section_type": "show", "count": 1, "is_active": 1},
+                {"section_id": "99", "section_name": "Private", "section_type": "movie", "count": 1, "is_active": 1},
+            ]
+            if self.current_scenario() == "quiet-no-history":
+                libraries = libraries[:2]
+            self.api_success(libraries)
             return
         if command == "get_history":
-            rows = history_rows(query.get("section_id", ""), self.current_scenario())
+            section_id = query.get("section_id", "")
+            if self.current_scenario() == "quiet-no-history" and not section_id:
+                rows = history_rows("10", self.current_scenario()) + history_rows("20", self.current_scenario())
+            else:
+                rows = history_rows(section_id, self.current_scenario())
             user_id = query.get("user_id", "")
             if user_id and self.current_scenario() != "platform-tie":
                 rows = [row for row in rows if str(row.get("user_id", "")) == user_id]
@@ -936,7 +946,11 @@ class Handler(BaseHTTPRequestHandler):
             return
         if command == "get_recently_added":
             current_rows = media_rows(self.current_scenario())
-            rows = current_rows.get(query.get("section_id", ""), current_rows["99"])
+            section_id = query.get("section_id", "")
+            if self.current_scenario() == "quiet-no-history" and not section_id:
+                rows = []
+            else:
+                rows = current_rows.get(section_id, current_rows["99"])
             start = int(query.get("start", "0"))
             count = int(query.get("count", "100"))
             self.api_success({"recently_added": rows[start : start + count]})
@@ -985,7 +999,7 @@ class Handler(BaseHTTPRequestHandler):
                     }
                 )
                 return
-            if scenario == "optional-hero-metadata" and is_show:
+            if scenario == "optional-hero-metadata" and not is_episode:
                 # Tautulli may return a successful but sparse metadata object. The
                 # renderer must retain the global-history title and default every
                 # absent optional hero field without violating strict mode.


### PR DESCRIPTION
## Summary
- remove fictional watch rows from Preview All and Send Test All while preserving the stat layout and real recipient platform icons
- query active movie/TV sections for quiet-week Latest Releases when no explicit library filter is configured
- preserve source-row genres, year, summary, and provider-labelled ratings when secondary metadata is sparse

## Root cause
The platform-icon change did not alter release or history selection. Two later shared-renderer regressions were responsible: v0.20.8 deliberately synthesized watch stats for empty selected-user states, and quiet fallback continued to use Tautulli's unscoped Plex global hub, which can be empty after its hub window. Rich hero fields were also projected away before sparse metadata enrichment.

## Validation
- repository, branding, platform, links, docs, and PowerShell validation
- renderer collections on PowerShell 7 and Windows PowerShell 5.1 across Windows/NAS/macOS copies
- library selection and quiet fallback scope tests across all copies
- Binge Champion, scheduler timezone, update, exclusions, cache, backup, and Manager JavaScript suites
- hosted CI supplies Python/Go, full mocked Tautulli/SMTP integration, Manager/installer tests, shell/container checks

No real Plex, Tautulli, or SMTP service was contacted.