### PR TITLE
chore: prepare v0.20.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.9] - 2026-08-25
+
 ### Fixed
 
 - Restored content-rich **Trending** heroes when Tautulli returns sparse

--- a/docs/releases/v0.20.9.md
+++ b/docs/releases/v0.20.9.md
@@ -1,0 +1,22 @@
+# TautWeekly for Plex v0.20.9
+
+v0.20.9 repairs the shared Preview/Send Test regression without changing the
+current personal-stat layout or recipient platform icons.
+
+**Preview All**, **Send Test**, and **Send Test All** now use only the selected
+recipient's real watch activity. An inactive recipient remains inactive in every
+state: TautWeekly no longer inserts sample movies, series, or watch time merely
+to make lifecycle previews look different.
+
+When the report window contains no new additions, **Latest Releases** now
+enumerates the active movie and TV libraries instead of relying solely on
+Tautulli's unscoped global recently-added hub. The newsletter therefore remains
+useful with up to four real recent movies and four real recent TV titles when
+that global hub is empty.
+
+Content-rich **Trending** heroes also retain genres, year, summary, and
+provider-labelled critic/audience ratings from real release or history rows when
+a secondary metadata lookup succeeds with a sparse response.
+
+All release data, personal statistics, Binge Champion results, and platform
+icons continue to respect the configured library and recipient privacy scopes.


### PR DESCRIPTION
## Summary
- roll the validated regression fixes into the v0.20.9 changelog
- add maintenance release notes covering authentic activity, quiet-week Latest Releases, rich hero metadata, and retained stat/platform presentation

## Validation
The implementation was merged in #148 after the full duplicate CI matrices passed, including mocked PreviewAll/SendTest/SendTestAll integration, reproducible archives, multi-architecture image build, and Windows installer lifecycle. This release-prep commit additionally passes repository, docs, link, privacy, and diff hygiene checks.

Publication will occur only after this PR is green and merged, using the verified v0.20.9 tag workflow.