### PR TITLE
chore: prepare v0.20.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.10] - 2026-08-25
+
 ### Fixed
 
 - Unified Preview, Preview All, Send Test, Send Test All, and one-off welcome

--- a/docs/releases/v0.20.10.md
+++ b/docs/releases/v0.20.10.md
@@ -1,0 +1,27 @@
+# TautWeekly for Plex v0.20.10
+
+v0.20.10 restores the shared production-quality newsletter pipeline used by
+Preview, Preview All, Send Test, Send Test All, and one-off welcome messages.
+
+Active weeks retain real release counts and a metadata-rich **Hot New Release**
+hero with eligible poster or title art, genres, year, provider-labelled ratings,
+summary, and authentic play totals. Quiet weeks are never replaced by a generic
+or synthetic shell: when real recent media exists, they use an authentic
+movie-only **Trending** hero, up to four other recent movies, and up to four TV
+titles strictly newer than one calendar month. The hero is excluded from the
+Latest Releases shelves and the lower server-wide Trending footer so it is not
+duplicated.
+
+All lifecycle scenarios now vary their introduction and recipient state without
+inventing watch starts, titles, or history. Personal movie rows retain posters,
+genres, and Rotten Tomatoes scores; TV rows retain posters, watch duration, and
+IMDb ratings when available. The existing desktop/mobile card layout and
+recipient platform icons are unchanged.
+
+Manager header **Refresh** also repeats the saved-revision LAN-only Tautulli
+choices lookup and an eligible stable update check, serializes repeated clicks,
+and clears its cooldown message automatically without requiring a browser
+reload.
+
+All release selection, activity, statistics, and platform presentation continue
+to honor the configured library and recipient privacy boundaries.


### PR DESCRIPTION
## Summary
- publish the merged newsletter-state and metadata regression repair as v0.20.10
- document quiet-week, stat-card, platform-icon, and Manager Refresh behavior
- retain v0.20.0 as the Primary Quickstart feature spotlight

## Validation
- repository, privacy, link, and documentation validation
- 10 release payloads plus SHA256SUMS contract validation
- byte-identical repeated v0.20.10 artifact build
- product PR #150 fully green before merge