### PR TITLE
fix: newsletter UI refinements (v0.21.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,11 @@ These instructions apply to the entire repository.
 - A release qualifies when its changelog has an `Added` section describing a new end-user capability. Maintenance-only fixes, hardening, documentation, internal tooling, minor visual polish, and other tweaks do not replace the featured release.
 - When a qualifying feature release is published, update the spotlight's `data-feature-release` value, version label, explanation, capability summary, configuration link, and release-notes link together.
 - Keep repository validation aligned with this policy so a later maintenance release cannot silently displace the latest feature release.
+
+## Risk-based validation
+
+- Choose the smallest sufficient checks for the actual change. Use targeted tests while editing; do not automatically run the full baseline suite or repeat a full suite after each small edit.
+- Reuse passing CI evidence for the exact commit or identical tree. Do not duplicate comprehensive suites locally and in CI without a concrete risk or failure; rerun only checks invalidated by later changes.
+- Diagnose failures before retrying. For demonstrated infrastructure failures, prefer failed-job-only retries. Monitor required existing CI/release runs instead of adding duplicate manual runs.
+- Docs-only changes need relevant documentation/link checks. Presentation changes need focused renderer, parity, and static checks plus representative desktop/mobile visual QA. Recipient, data, or security changes justify broader integration and privacy coverage.
+- Keep required CI/release gates, privacy/isolation checks, package/checksum integrity, and publication verification. Never disable tests to get green, conceal omitted coverage, or claim unsupported email-client testing. Briefly explain any necessary expansion of validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.21.2] - 2026-08-25
+
+### Fixed
+
+- Displayed watched title circles at 16x16px with 8px left spacing only in
+  main movie heroes and release cards. Kept centered, safely wrapping titles,
+  accessible Watched labels, unchanged PNG bytes, no unwatched gap, and the
+  existing 26x26px desktop poster shield. Removed all footer watched markers.
+- Matched footer recap labels, titles, genres, ratings (including TV IMDb
+  numbers), and TV watch durations at 12px; count numbers remain 18px/800/1.
+  Footer Rotten Tomatoes icons now display at 16x16px.
+- Normalized Watch Time, Binge Champion, Top Genre, and compact Trending
+  headings to 12px/900 with 1.1px letter spacing, support to 12px/400/1.35,
+  and all four primary values to exactly 27px/800/1.1, including Binge winner,
+  non-winner, and standalone variants.
+- Preserved the intended outer stats padding of 0px 20px 0px and TV label
+  margin-bottom of -7px, artwork/card dimensions, and winner highlighting.
+  Recipient logic, privacy, lifecycle behavior, and inbox preheaders are unchanged.
+- Advanced source baselines to Windows 1.10.2, NAS/Docker 1.5.2, macOS 1.4.2,
+  native Linux 1.3.2, and FreeBSD/Podman 1.2.2. Retained the v0.21.0 feature spotlight.
+
+### Changed
+
+- Documented proportionate risk-based validation and reuse of exact-tree CI
+  evidence in the repository instructions, without changing required workflows.
+
 ## [0.21.1] - 2026-08-25
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,13 @@ The check uses a temporary browser profile, blocks non-local requests, validates
 all six lifecycle previews plus Index at 1280px, 390px, and 320px, and saves
 synthetic screenshots and geometry outside the repository. Signature-only JPEG
 test probes are displayed as code-native poster surrogates; missing files still
-fail. It checks native icon sizes, the 6px gap, text centering within one pixel,
-orphan-free wrapping, desktop overlay geometry, and broken image references.
+fail. It checks displayed icon sizes, the 8px gap, text centering within one pixel,
+orphan-free wrapping, desktop overlay geometry, footer typography (including TV
+IMDb numbers), absence of footer markers, and broken image references.
+For a presentation patch, append a preview-name filter and widths, for example
+`04-normal,05-established-quiet 1280,390,320`, to use representative states.
+Choose active, quiet, and winner fixtures as needed; deterministic tests check
+renderer parity. Reuse exact-tree CI coverage instead of duplicating full suites.
 Classic Outlook VML is checked structurally by the focused renderer tests;
 browser results are not a native Outlook-client certification.
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ The responsive Manager is the primary workflow on every maintained package:
   episode details when available.
 - Recipient-specific **Watched** marks identify movies from that recipient's
   all-time Tautulli history, never another user's activity. Desktop heroes use
-  the poster shield; mobile heroes and movie cards use a consistently spaced,
-  vertically centered title circle. Unwatched movies leave no gap and TV is unchanged.
+  the 26px poster shield; mobile heroes and main movie cards use a centered
+  16px title circle with 8px left spacing. Footer stats have no watched markers.
+  Unwatched movies leave no gap and TV watched-state behavior is unchanged.
 - Complementary server-wide highlights: a **HOT NEW RELEASE** movie hero ends
   with the existing full-width **TRENDING THIS WEEK** movie card; a
   **TRENDING THIS WEEK** movie hero ends with **TOP GENRE THIS WEEK**. Trending

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -336,10 +336,12 @@ identity-bearing diagnostics.
 The desktop full-width movie hero uses the unchanged 26×26 shield, inset 7px
 from the poster's right edge and raised 5px above its top, with an Outlook VML
 group; other clients use a table overlay without CSS positioning. Mobile
-heroes, release cards, personal movie recaps, and compact Trending titles use
-the unchanged 20×20 circle immediately after the title with 6px left spacing
+heroes and main movie release cards display the original circle PNG at 16×16px
+immediately after the title with 8px left spacing
 and shared text/icon vertical centering. Only the final title word stays with
 its icon; preceding words wrap normally without orphaning the marker.
+Footer statistics, including personal movie recaps and compact Trending, have
+no watched markers. Both original PNG files remain byte-identical.
 Both images have `alt="Watched"` and `title="Watched"`; plain text supplies the
 equivalent status. Unwatched movies add neither markup nor a spacer, and TV
 titles are unchanged. Preview, PreviewAll, SendTest, SendTestAll, welcome,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,9 @@ reviewed commit on `main`.
 1. Confirm CI, Pages, and Container workflows are green on `main`.
 2. Update `CHANGELOG.md` and move the intended entries from `Unreleased` into a
    semantic version heading.
-3. Run local validation and packaging:
+3. Choose local checks proportionate to the patch (see AGENTS.md). Reuse passing
+   CI evidence for the exact commit or identical tree instead of duplicating
+   comprehensive suites locally. The relevant commands include:
 
    ```powershell
    pwsh ./scripts/validate-repository.ps1

--- a/docs/releases/v0.21.2.md
+++ b/docs/releases/v0.21.2.md
@@ -1,0 +1,59 @@
+# TautWeekly for Plex v0.21.2
+
+v0.21.2 refines watched-marker placement and footer typography. There is no
+configuration migration or change to recipient state, privacy, lifecycle
+behavior, or dynamic inbox preview text.
+
+## Watched markers
+
+- Main movie heroes and recent/new-release cards display the original circle
+  PNG at **16x16px**, with **8px left margin**, vertical centering, safe title
+  wrapping, and accessible Watched alt/title text. Unwatched titles add no gap.
+- The desktop full-width Hot/Trending poster shield keeps its **26x26px**
+  dimensions, 7px right inset, 5px raised placement, and Outlook VML fallback.
+- Footer statistics have **no watched markers**, including personal movie
+  recaps and compact Trending. TV is never marked.
+- Original PNG bytes and recipient-specific watched-state logic are unchanged.
+
+## Footer styling
+
+| Element | Typography |
+|---|---|
+| Movies/TV labels, recap titles, genres, ratings including TV IMDb numbers, TV duration | 12px; existing role-specific weights and line heights |
+| Movie/TV count numbers | 18px / weight 800 / line-height 1 |
+| Watch Time, Binge, Genre, compact Trending headings | 12px / weight 900 / letter-spacing 1.1px |
+| Supporting summary text | 12px / weight 400 / line-height 1.35 |
+| All four primary values: personal watch time, Binge watch time, Top Genre name, compact Trending title | **27px / weight 800 / line-height 1.1** |
+
+Binge winner, non-winner, and standalone variants use the same primary-value
+typography. The outer personal stats grid keeps the requested padding of
+0px 20px 0px, and the TV SHOWS WATCHED label keeps margin-bottom: -7px.
+Footer Rotten Tomatoes icons display at 16x16px. Other artwork/card dimensions
+and winner highlighting remain unchanged.
+
+## Validation and scope
+
+Focused renderer, watched-state/isolation, Binge, Genre, parity, and package
+contracts enforce the new presentation. Representative active, quiet, winner,
+non-winner, and standalone synthetic previews are checked at desktop/mobile
+widths. The visual check measures footer text (including IMDb), marker geometry,
+wrapping, image references, and overflow.
+
+AGENTS.md now requires the smallest sufficient checks for the change, reuse of
+passing exact-commit/tree evidence, diagnosis before failed-job-only retries,
+and honest disclosure of coverage. Required CI/release gates, privacy checks,
+package/checksum integrity, and publication verification remain in place.
+Existing automatic CI suites are monitored; no extra duplicate full local
+suite or workflow redesign is included.
+
+## Packages and limitations
+
+Source baselines: Windows 1.10.2, NAS/Docker 1.5.2, macOS 1.4.2, native Linux
+1.3.2, and FreeBSD/Podman 1.2.2. Use the normal verified update process and
+retain private configuration and runtime data. Check downloads against
+SHA256SUMS.txt. The Quickstart feature spotlight remains v0.21.0.
+
+Classic Outlook's fallback is structurally tested, not natively certified.
+Watched state still requires qualifying retained Tautulli history. Windows
+executables remain unsigned. Validation uses only sanitized synthetic services
+and captured email; no real Plex, Tautulli, SMTP endpoint, or real delivery.

--- a/platforms/freebsd-podman/CHANGELOG.txt
+++ b/platforms/freebsd-podman/CHANGELOG.txt
@@ -1,5 +1,10 @@
 TautWeekly for Plex FreeBSD Podman platform changelog
 
+v1.2.2
+- refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values
+- displays unchanged watched circles at 16x16 with 8px spacing only in main movie content; preserves the 26x26 desktop shield
+- removes footer watched markers and preserves deliberate recap spacing, dynamic data, privacy, and lifecycle behavior
+
 v1.2.1
 - marks movies only from the recipient's qualifying all-time Tautulli history, never another user's activity
 - uses the supplied desktop poster shield and consistently spaced, vertically centered title circles with accessible Watched labels

--- a/platforms/freebsd-podman/VERSION.txt
+++ b/platforms/freebsd-podman/VERSION.txt
@@ -1,2 +1,2 @@
-TautWeekly for Plex FreeBSD Podman platform source v1.2.1
+TautWeekly for Plex FreeBSD Podman platform source v1.2.2
 Repository releases use the repository-level semantic version and preserve this platform baseline in release metadata.

--- a/platforms/linux/CHANGELOG.txt
+++ b/platforms/linux/CHANGELOG.txt
@@ -1,5 +1,10 @@
 TautWeekly for Plex native Linux platform changelog
 
+v1.3.2
+- refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values
+- displays unchanged watched circles at 16x16 with 8px spacing only in main movie content; preserves the 26x26 desktop shield
+- removes footer watched markers and preserves deliberate recap spacing, dynamic data, privacy, and lifecycle behavior
+
 v1.3.1
 - marks movies only from the recipient's qualifying all-time Tautulli history, never another user's activity
 - uses the supplied desktop poster shield and consistently spaced, vertically centered title circles with accessible Watched labels

--- a/platforms/linux/VERSION.txt
+++ b/platforms/linux/VERSION.txt
@@ -1,2 +1,2 @@
-TautWeekly for Plex native Linux platform source v1.3.1
+TautWeekly for Plex native Linux platform source v1.3.2
 Repository releases use the repository-level semantic version and preserve this platform baseline in release metadata.

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -1,6 +1,12 @@
 TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 ================================
 
+v1.4.2 Portable
+---------------
+- refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values
+- displays unchanged watched circles at 16x16 with 8px spacing only in main movie content; preserves the 26x26 desktop shield
+- removes footer watched markers and preserves deliberate recap spacing, dynamic data, privacy, and lifecycle behavior
+
 v1.4.1 Portable
 ---------------
 - marks movies only from the recipient's qualifying all-time Tautulli history, never another user's activity

--- a/platforms/mac-docker/VERSION.txt
+++ b/platforms/mac-docker/VERSION.txt
@@ -1,3 +1,3 @@
-TautWeekly for Plex Mac Portable v1.4.1
+TautWeekly for Plex Mac Portable v1.4.2
 Platform: macOS with Docker Desktop
 Feature: Authenticated macOS Manager

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -7004,7 +7004,7 @@ function Get-RecipientWatchedTitleIconHtml {
     }
 
     $source = Get-RecipientWatchedAssetSource -FileName "watched.png" -Cid "recipient_watched" -ImageMode $ImageMode -PreviewAssetBase $PreviewAssetBase
-    return '<img class="recipient-watched-title-icon" src="' + (HtmlEncode $source) + '" width="20" height="20" alt="Watched" title="Watched" style="display:inline-block;width:20px;height:20px;border:0;vertical-align:middle;margin-left:6px;">'
+    return '<img class="recipient-watched-title-icon" src="' + (HtmlEncode $source) + '" width="16" height="16" alt="Watched" title="Watched" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:middle;margin-left:8px;">'
 }
 
 function Get-RecipientWatchedTitleHtml {
@@ -7125,7 +7125,7 @@ function Get-StatsMovieRatingHtml {
         $icon = Get-DesignRtIconUrl -ImageState $criticImage -Kind "critic" -ImageMode $ImageMode
         $pieces.Add(
             '<span style="display:inline-block;white-space:nowrap;">' +
-            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes critic" width="14" height="14" style="display:inline-block;width:14px;height:14px;border:0;vertical-align:-3px;margin-right:3px;">' +
+            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes critic" width="16" height="16" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:-3px;margin-right:3px;">' +
             (HtmlEncode ($critic + "%")) +
             '</span>'
         )
@@ -7142,7 +7142,7 @@ function Get-StatsMovieRatingHtml {
         $icon = Get-DesignRtIconUrl -ImageState $audienceImage -Kind "audience" -ImageMode $ImageMode
         $pieces.Add(
             '<span style="display:inline-block;white-space:nowrap;">' +
-            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes audience" width="14" height="14" style="display:inline-block;width:14px;height:14px;border:0;vertical-align:-3px;margin-right:3px;">' +
+            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes audience" width="16" height="16" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:-3px;margin-right:3px;">' +
             (HtmlEncode ($audience + "%")) +
             '</span>'
         )
@@ -7175,9 +7175,7 @@ function Get-StatsMovieRowsHtml {
         [object[]]$Items,
         [object[]]$PosterAssets,
         [ValidateSet("Preview","Email")]
-        [string]$ImageMode,
-        [AllowNull()][object]$RecipientWatchedMovies = $null,
-        [string]$PreviewAssetBase = '../assets'
+        [string]$ImageMode
     )
 
     $rows = New-Object System.Text.StringBuilder
@@ -7186,10 +7184,6 @@ function Get-StatsMovieRowsHtml {
 
     foreach ($item in @($Items)) {
         $title = HtmlEncode (Truncate-Text ([string]$item.Title) 42)
-        $titleWithStatus = $title
-        if ($null -ne $RecipientWatchedMovies) {
-            $titleWithStatus = Get-RecipientWatchedTitleHtml -EncodedTitle $title -Item $item -RecipientWatchedMovies $RecipientWatchedMovies -ImageMode $ImageMode -PreviewAssetBase $PreviewAssetBase
-        }
         $posterSrc = Get-ImageSource `
             -RatingKey ([string]$item.PosterRatingKey) `
             -PosterAssets $PosterAssets `
@@ -7207,7 +7201,7 @@ function Get-StatsMovieRowsHtml {
         $genreText = Get-DesignGenreLine -Item $item
         $genreHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($genreText)) {
-            $genreHtml = '<div style="padding-top:3px;font-size:10px;line-height:1.3;color:#9b9b9b;font-weight:500;">' +
+            $genreHtml = '<div style="padding-top:3px;font-size:12px;line-height:1.3;color:#9b9b9b;font-weight:500;">' +
                 (HtmlEncode $genreText) +
                 '</div>'
         }
@@ -7216,7 +7210,7 @@ function Get-StatsMovieRowsHtml {
         $ratingPadding = if ([string]::IsNullOrWhiteSpace($genreHtml)) { "5px" } else { "4px" }
         $ratingLineHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($ratingHtml)) {
-            $ratingLineHtml = '<div style="padding-top:' + $ratingPadding + ';font-size:10px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
+            $ratingLineHtml = '<div style="padding-top:' + $ratingPadding + ';font-size:12px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
                 $ratingHtml +
                 '</div>'
         }
@@ -7228,7 +7222,7 @@ function Get-StatsMovieRowsHtml {
     <tr>
       <td width="50" valign="middle" style="width:50px;padding:0 8px 0 0;">$posterHtml</td>
       <td valign="middle" style="padding:0;">
-        <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$titleWithStatus</div>
+        <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$title</div>
         $genreHtml
         $ratingLineHtml
       </td>
@@ -7291,7 +7285,7 @@ function Get-StatsTvShowRatingHtml {
     $rtIcon = Get-DesignRtIconUrl -ImageState $rtImage -Kind $rtKind -ImageMode $ImageMode
     $rtAlt = if ($rtKind -eq "audience") { "Rotten Tomatoes audience" } else { "Rotten Tomatoes critic" }
     return '<span style="display:inline-block;white-space:nowrap;">' +
-        '<img src="' + (HtmlEncode $rtIcon) + '" alt="' + $rtAlt + '" width="14" height="14" style="display:inline-block;width:14px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:4px;">' +
+        '<img src="' + (HtmlEncode $rtIcon) + '" alt="' + $rtAlt + '" width="16" height="16" style="display:inline-block;width:16px;height:16px;object-fit:contain;border:0;vertical-align:-3px;margin-right:4px;">' +
         (HtmlEncode ($rtValue + "%")) +
         '</span>'
 }
@@ -7333,7 +7327,7 @@ function Get-StatsEpisodeRowsHtml {
         $imdbLineHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
             ""
         } else {
-            '<div style="padding-top:4px;font-size:10px;line-height:1.3;color:#e5a00d;font-weight:700;">' +
+            '<div style="padding-top:4px;font-size:12px;line-height:1.3;color:#e5a00d;font-weight:700;">' +
             '<span style="display:inline-block;white-space:nowrap;">' +
             '<img src="' + (HtmlEncode $ImdbIconSrc) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
             (HtmlEncode $imdb) +
@@ -7344,8 +7338,8 @@ function Get-StatsEpisodeRowsHtml {
 <tr>
   <td width="50" valign="middle" style="width:50px;padding:7px 8px 7px 0;border-bottom:1px solid #292929;">$posterHtml</td>
   <td valign="middle" style="padding:7px 0;border-bottom:1px solid #292929;">
-    <div style="font-size:11px;line-height:1.25;color:#ffffff;font-weight:800;">$showTitle</div>
-    <div style="padding-top:3px;font-size:10px;line-height:1.3;color:#9b9b9b;">$(HtmlEncode $prefix)$episodeTitle</div>
+    <div style="font-size:12px;line-height:1.25;color:#ffffff;font-weight:800;">$showTitle</div>
+    <div style="padding-top:3px;font-size:12px;line-height:1.3;color:#9b9b9b;">$(HtmlEncode $prefix)$episodeTitle</div>
     $imdbLineHtml
   </td>
 </tr>
@@ -7390,7 +7384,7 @@ function Get-StatsTvShowRowsHtml {
         $ratingLineHtml = if ([string]::IsNullOrWhiteSpace($ratingHtml)) {
             ""
         } else {
-            '<div style="padding-top:4px;font-size:10px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
+            '<div style="padding-top:4px;font-size:12px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
             $ratingHtml +
             '</div>'
         }
@@ -7409,7 +7403,7 @@ function Get-StatsTvShowRowsHtml {
       <td valign="middle" style="padding:0;">
         <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$showTitle</div>
         $ratingLineHtml
-        <div style="padding-top:3px;font-size:10px;line-height:1.35;color:#9b9b9b;font-weight:600;">$(HtmlEncode $watchTime) watched</div>
+        <div style="padding-top:3px;font-size:12px;line-height:1.35;color:#9b9b9b;font-weight:600;">$(HtmlEncode $watchTime) watched</div>
       </td>
     </tr>
   </table>
@@ -8222,7 +8216,6 @@ $tvCards
         $trendingPosterHtml = ""
 
         $trendingDisplay = HtmlEncode (Truncate-Text $TrendingTitle 70)
-        $trendingTitleWithStatus = Get-RecipientWatchedTitleHtml -EncodedTitle $trendingDisplay -Item $script:GlobalTrendingStat -RecipientWatchedMovies $RecipientWatchedMovies -ImageMode $ImageMode -PreviewAssetBase $previewAssetBase
         $trendingPlays = Safe-Int $script:GlobalTrendingStat.Plays
         $trendingRatingKey = [string]$script:GlobalTrendingStat.RatingKey
         $trendingPosterSrc = Get-ImageSource `
@@ -8257,9 +8250,9 @@ $tvCards
         <img src="$trendingIconSrc" width="42" height="42" alt="Trending this week" style="display:block;width:42px;height:42px;border:0;">
       </td>
       <td valign="middle" style="padding:16px 18px 16px 10px;">
-        <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.3px;">TRENDING THIS WEEK</div>
-        <div style="padding-top:5px;font-size:18px;line-height:1.25;color:#ffffff;font-weight:800;">$trendingTitleWithStatus</div>
-        <div style="padding-top:4px;font-size:12px;line-height:1.4;color:#8e8e8e;">$(HtmlEncode $trendingDescription)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">TRENDING THIS WEEK</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;overflow-wrap:anywhere;word-break:break-word;">$trendingDisplay</div>
+        <div style="padding-top:4px;font-size:12px;line-height:1.35;font-weight:400;color:#8e8e8e;">$(HtmlEncode $trendingDescription)</div>
       </td>
     </tr>
   </table>
@@ -8302,8 +8295,8 @@ $tvCards
         <img src="$(HtmlEncode $topGenreIconSrc)" width="42" height="42" alt="Top genre this week" style="display:block;width:42px;height:42px;border:0;">
       </td>
       <td valign="middle" style="padding:16px 18px 16px 10px;">
-        <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.3px;">TOP GENRE THIS WEEK</div>
-        <div style="padding-top:5px;font-size:18px;line-height:1.25;color:#ffffff;font-weight:800;">$(HtmlEncode $topGenreName)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">TOP GENRE THIS WEEK</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;">$(HtmlEncode $topGenreName)</div>
         <div style="$summarySupportingStyle">$(HtmlEncode $topGenreDescription)</div>
       </td>
     </tr>
@@ -8360,9 +8353,7 @@ $tvCards
         Get-StatsMovieRowsHtml `
             -Items $movieItems `
             -PosterAssets $PosterAssets `
-            -ImageMode $ImageMode `
-            -RecipientWatchedMovies $RecipientWatchedMovies `
-            -PreviewAssetBase $previewAssetBase
+            -ImageMode $ImageMode
     } else { "" }
 
     $tvShowRows = if ($tvShowDetailMode) {
@@ -8382,7 +8373,7 @@ $tvCards
       <table cellspacing="0" cellpadding="0" border="0">
         <tr>
           <td valign="middle" style="padding-right:8px;"><img src="$moviesIconSrc" width="42" height="42" alt="Movies watched" style="display:block;width:42px;height:42px;border:0;"></td>
-          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$movieTitleCount</div><div style="padding-top:3px;font-size:10px;color:#8e8e8e;letter-spacing:.6px;">MOVIES WATCHED</div></td>
+          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$movieTitleCount</div><div style="padding-top:3px;font-size:12px;color:#8e8e8e;letter-spacing:.6px;">MOVIES WATCHED</div></td>
         </tr>
       </table>
     </td>
@@ -8400,7 +8391,7 @@ $tvCards
       <table cellspacing="0" cellpadding="0" border="0">
         <tr>
           <td valign="middle" style="padding-right:8px;"><img src="$tvIconSrc" width="42" height="42" alt="TV shows watched" style="display:block;width:42px;height:42px;border:0;"></td>
-          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$tvShowTitleCount</div><div style="padding-top:3px;font-size:10px;color:#8e8e8e;letter-spacing:.6px;">TV SHOWS WATCHED</div></td>
+          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$tvShowTitleCount</div><div style="padding-top:3px;font-size:12px;color:#8e8e8e;letter-spacing:.6px;margin-bottom:-7px;">TV SHOWS WATCHED</div></td>
         </tr>
       </table>
     </td>
@@ -8463,7 +8454,7 @@ $tvCards
     else {
         $statsBlock = @"
 <tr>
-<td class="pad" style="padding:0 20px 24px;">
+<td class="pad" style="padding:0px 20px 0px;">
 <table width="100%" cellspacing="0" cellpadding="0" border="0">
 $mediaStatsRows
 <tr>
@@ -8471,7 +8462,7 @@ $mediaStatsRows
     <table class="email-card" width="100%" height="$summaryCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${summaryCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$summaryCardHeight" valign="middle" style="height:${summaryCardHeight}px;padding:17px;">
-          <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">YOU CLOCKED</div>
+          <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">YOU CLOCKED</div>
           <img src="$clockIconSrc" width="42" height="42" alt="Personal total watch time" style="display:block;width:42px;height:42px;border:0;margin-top:9px;">
           <div style="padding-top:8px;font-size:27px;font-weight:800;color:#ffffff;line-height:1.1;">$timeText</div>
           <div style="$summarySupportingStyle">total watch time</div>
@@ -8483,9 +8474,9 @@ $mediaStatsRows
     <table width="100%" height="$summaryCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="width:100%;height:${summaryCardHeight}px;background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$summaryCardHeight" valign="middle" style="height:${summaryCardHeight}px;padding:17px;">
-          <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
+          <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
           <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;margin-top:9px;">
-          <div style="padding-top:8px;font-size:$(if ($isBingeWinner) { 18 } else { 16 })px;line-height:1.25;font-weight:900;color:#ffffff;">$(HtmlEncode $bingeTimeLine)</div>
+          <div style="padding-top:8px;font-size:27px;line-height:1.1;font-weight:800;color:#ffffff;">$(HtmlEncode $bingeTimeLine)</div>
           $bingeBreakdownHtml
         </td>
       </tr>
@@ -8510,8 +8501,8 @@ $mediaStatsRows
         <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;">
       </td>
       <td valign="middle" style="padding:18px 20px 18px 12px;">
-        <div style="font-size:10px;color:#e5a00d;font-weight:900;letter-spacing:1.2px;">$(HtmlEncode $bingeEyebrow)</div>
-        <div style="padding-top:5px;font-size:20px;line-height:1.25;color:#ffffff;font-weight:900;">$(HtmlEncode $bingeTimeLine)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;">$(HtmlEncode $bingeTimeLine)</div>
         $bingeBreakdownHtml
       </td>
     </tr>
@@ -8748,11 +8739,10 @@ function Build-PlainText {
         $null -ne $script:GlobalTrendingStat) {
         $trendPlays = Safe-Int $script:GlobalTrendingStat.Plays
         $trendPlayWord = if ($trendPlays -eq 1) { "play" } else { "plays" }
-        $trendWatchedSuffix = Get-RecipientWatchedPlainTextSuffix -Item $script:GlobalTrendingStat -RecipientWatchedMovies $RecipientWatchedMovies
         $footerFeature += if ($trendPlays -gt 0) {
-            "`r`nTRENDING THIS WEEK: $TrendingTitle$trendWatchedSuffix — $trendPlays $trendPlayWord across the server"
+            "`r`nTRENDING THIS WEEK: $TrendingTitle — $trendPlays $trendPlayWord across the server"
         } else {
-            "`r`nTRENDING THIS WEEK: $TrendingTitle$trendWatchedSuffix"
+            "`r`nTRENDING THIS WEEK: $TrendingTitle"
         }
     }
 

--- a/platforms/nas-docker/CHANGELOG.txt
+++ b/platforms/nas-docker/CHANGELOG.txt
@@ -1,6 +1,12 @@
 TAUTWEEKLY FOR PLEX NAS PORTABLE CHANGELOG
 =================================
 
+v1.5.2 Portable
+---------------
+- refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values
+- displays unchanged watched circles at 16x16 with 8px spacing only in main movie content; preserves the 26x26 desktop shield
+- removes footer watched markers and preserves deliberate recap spacing, dynamic data, privacy, and lifecycle behavior
+
 v1.5.1 Portable
 ---------------
 - marks movies only from the recipient's qualifying all-time Tautulli history, never another user's activity

--- a/platforms/nas-docker/VERSION.txt
+++ b/platforms/nas-docker/VERSION.txt
@@ -1,3 +1,3 @@
-TautWeekly for Plex NAS Portable v1.5.1
+TautWeekly for Plex NAS Portable v1.5.2
 Platforms: QNAP, Unraid, Docker Desktop, generic Linux Docker
 Distribution: GHCR image, Unraid Community Apps template, and Docker Compose source

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -7005,7 +7005,7 @@ function Get-RecipientWatchedTitleIconHtml {
     }
 
     $source = Get-RecipientWatchedAssetSource -FileName "watched.png" -Cid "recipient_watched" -ImageMode $ImageMode -PreviewAssetBase $PreviewAssetBase
-    return '<img class="recipient-watched-title-icon" src="' + (HtmlEncode $source) + '" width="20" height="20" alt="Watched" title="Watched" style="display:inline-block;width:20px;height:20px;border:0;vertical-align:middle;margin-left:6px;">'
+    return '<img class="recipient-watched-title-icon" src="' + (HtmlEncode $source) + '" width="16" height="16" alt="Watched" title="Watched" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:middle;margin-left:8px;">'
 }
 
 function Get-RecipientWatchedTitleHtml {
@@ -7126,7 +7126,7 @@ function Get-StatsMovieRatingHtml {
         $icon = Get-DesignRtIconUrl -ImageState $criticImage -Kind "critic" -ImageMode $ImageMode
         $pieces.Add(
             '<span style="display:inline-block;white-space:nowrap;">' +
-            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes critic" width="14" height="14" style="display:inline-block;width:14px;height:14px;border:0;vertical-align:-3px;margin-right:3px;">' +
+            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes critic" width="16" height="16" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:-3px;margin-right:3px;">' +
             (HtmlEncode ($critic + "%")) +
             '</span>'
         )
@@ -7143,7 +7143,7 @@ function Get-StatsMovieRatingHtml {
         $icon = Get-DesignRtIconUrl -ImageState $audienceImage -Kind "audience" -ImageMode $ImageMode
         $pieces.Add(
             '<span style="display:inline-block;white-space:nowrap;">' +
-            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes audience" width="14" height="14" style="display:inline-block;width:14px;height:14px;border:0;vertical-align:-3px;margin-right:3px;">' +
+            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes audience" width="16" height="16" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:-3px;margin-right:3px;">' +
             (HtmlEncode ($audience + "%")) +
             '</span>'
         )
@@ -7176,9 +7176,7 @@ function Get-StatsMovieRowsHtml {
         [object[]]$Items,
         [object[]]$PosterAssets,
         [ValidateSet("Preview","Email")]
-        [string]$ImageMode,
-        [AllowNull()][object]$RecipientWatchedMovies = $null,
-        [string]$PreviewAssetBase = '../assets'
+        [string]$ImageMode
     )
 
     $rows = New-Object System.Text.StringBuilder
@@ -7187,10 +7185,6 @@ function Get-StatsMovieRowsHtml {
 
     foreach ($item in @($Items)) {
         $title = HtmlEncode (Truncate-Text ([string]$item.Title) 42)
-        $titleWithStatus = $title
-        if ($null -ne $RecipientWatchedMovies) {
-            $titleWithStatus = Get-RecipientWatchedTitleHtml -EncodedTitle $title -Item $item -RecipientWatchedMovies $RecipientWatchedMovies -ImageMode $ImageMode -PreviewAssetBase $PreviewAssetBase
-        }
         $posterSrc = Get-ImageSource `
             -RatingKey ([string]$item.PosterRatingKey) `
             -PosterAssets $PosterAssets `
@@ -7208,7 +7202,7 @@ function Get-StatsMovieRowsHtml {
         $genreText = Get-DesignGenreLine -Item $item
         $genreHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($genreText)) {
-            $genreHtml = '<div style="padding-top:3px;font-size:10px;line-height:1.3;color:#9b9b9b;font-weight:500;">' +
+            $genreHtml = '<div style="padding-top:3px;font-size:12px;line-height:1.3;color:#9b9b9b;font-weight:500;">' +
                 (HtmlEncode $genreText) +
                 '</div>'
         }
@@ -7217,7 +7211,7 @@ function Get-StatsMovieRowsHtml {
         $ratingPadding = if ([string]::IsNullOrWhiteSpace($genreHtml)) { "5px" } else { "4px" }
         $ratingLineHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($ratingHtml)) {
-            $ratingLineHtml = '<div style="padding-top:' + $ratingPadding + ';font-size:10px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
+            $ratingLineHtml = '<div style="padding-top:' + $ratingPadding + ';font-size:12px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
                 $ratingHtml +
                 '</div>'
         }
@@ -7229,7 +7223,7 @@ function Get-StatsMovieRowsHtml {
     <tr>
       <td width="50" valign="middle" style="width:50px;padding:0 8px 0 0;">$posterHtml</td>
       <td valign="middle" style="padding:0;">
-        <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$titleWithStatus</div>
+        <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$title</div>
         $genreHtml
         $ratingLineHtml
       </td>
@@ -7292,7 +7286,7 @@ function Get-StatsTvShowRatingHtml {
     $rtIcon = Get-DesignRtIconUrl -ImageState $rtImage -Kind $rtKind -ImageMode $ImageMode
     $rtAlt = if ($rtKind -eq "audience") { "Rotten Tomatoes audience" } else { "Rotten Tomatoes critic" }
     return '<span style="display:inline-block;white-space:nowrap;">' +
-        '<img src="' + (HtmlEncode $rtIcon) + '" alt="' + $rtAlt + '" width="14" height="14" style="display:inline-block;width:14px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:4px;">' +
+        '<img src="' + (HtmlEncode $rtIcon) + '" alt="' + $rtAlt + '" width="16" height="16" style="display:inline-block;width:16px;height:16px;object-fit:contain;border:0;vertical-align:-3px;margin-right:4px;">' +
         (HtmlEncode ($rtValue + "%")) +
         '</span>'
 }
@@ -7334,7 +7328,7 @@ function Get-StatsEpisodeRowsHtml {
         $imdbLineHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
             ""
         } else {
-            '<div style="padding-top:4px;font-size:10px;line-height:1.3;color:#e5a00d;font-weight:700;">' +
+            '<div style="padding-top:4px;font-size:12px;line-height:1.3;color:#e5a00d;font-weight:700;">' +
             '<span style="display:inline-block;white-space:nowrap;">' +
             '<img src="' + (HtmlEncode $ImdbIconSrc) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
             (HtmlEncode $imdb) +
@@ -7345,8 +7339,8 @@ function Get-StatsEpisodeRowsHtml {
 <tr>
   <td width="50" valign="middle" style="width:50px;padding:7px 8px 7px 0;border-bottom:1px solid #292929;">$posterHtml</td>
   <td valign="middle" style="padding:7px 0;border-bottom:1px solid #292929;">
-    <div style="font-size:11px;line-height:1.25;color:#ffffff;font-weight:800;">$showTitle</div>
-    <div style="padding-top:3px;font-size:10px;line-height:1.3;color:#9b9b9b;">$(HtmlEncode $prefix)$episodeTitle</div>
+    <div style="font-size:12px;line-height:1.25;color:#ffffff;font-weight:800;">$showTitle</div>
+    <div style="padding-top:3px;font-size:12px;line-height:1.3;color:#9b9b9b;">$(HtmlEncode $prefix)$episodeTitle</div>
     $imdbLineHtml
   </td>
 </tr>
@@ -7391,7 +7385,7 @@ function Get-StatsTvShowRowsHtml {
         $ratingLineHtml = if ([string]::IsNullOrWhiteSpace($ratingHtml)) {
             ""
         } else {
-            '<div style="padding-top:4px;font-size:10px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
+            '<div style="padding-top:4px;font-size:12px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
             $ratingHtml +
             '</div>'
         }
@@ -7410,7 +7404,7 @@ function Get-StatsTvShowRowsHtml {
       <td valign="middle" style="padding:0;">
         <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$showTitle</div>
         $ratingLineHtml
-        <div style="padding-top:3px;font-size:10px;line-height:1.35;color:#9b9b9b;font-weight:600;">$(HtmlEncode $watchTime) watched</div>
+        <div style="padding-top:3px;font-size:12px;line-height:1.35;color:#9b9b9b;font-weight:600;">$(HtmlEncode $watchTime) watched</div>
       </td>
     </tr>
   </table>
@@ -8223,7 +8217,6 @@ $tvCards
         $trendingPosterHtml = ""
 
         $trendingDisplay = HtmlEncode (Truncate-Text $TrendingTitle 70)
-        $trendingTitleWithStatus = Get-RecipientWatchedTitleHtml -EncodedTitle $trendingDisplay -Item $script:GlobalTrendingStat -RecipientWatchedMovies $RecipientWatchedMovies -ImageMode $ImageMode -PreviewAssetBase $previewAssetBase
         $trendingPlays = Safe-Int $script:GlobalTrendingStat.Plays
         $trendingRatingKey = [string]$script:GlobalTrendingStat.RatingKey
         $trendingPosterSrc = Get-ImageSource `
@@ -8258,9 +8251,9 @@ $tvCards
         <img src="$trendingIconSrc" width="42" height="42" alt="Trending this week" style="display:block;width:42px;height:42px;border:0;">
       </td>
       <td valign="middle" style="padding:16px 18px 16px 10px;">
-        <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.3px;">TRENDING THIS WEEK</div>
-        <div style="padding-top:5px;font-size:18px;line-height:1.25;color:#ffffff;font-weight:800;">$trendingTitleWithStatus</div>
-        <div style="padding-top:4px;font-size:12px;line-height:1.4;color:#8e8e8e;">$(HtmlEncode $trendingDescription)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">TRENDING THIS WEEK</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;overflow-wrap:anywhere;word-break:break-word;">$trendingDisplay</div>
+        <div style="padding-top:4px;font-size:12px;line-height:1.35;font-weight:400;color:#8e8e8e;">$(HtmlEncode $trendingDescription)</div>
       </td>
     </tr>
   </table>
@@ -8303,8 +8296,8 @@ $tvCards
         <img src="$(HtmlEncode $topGenreIconSrc)" width="42" height="42" alt="Top genre this week" style="display:block;width:42px;height:42px;border:0;">
       </td>
       <td valign="middle" style="padding:16px 18px 16px 10px;">
-        <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.3px;">TOP GENRE THIS WEEK</div>
-        <div style="padding-top:5px;font-size:18px;line-height:1.25;color:#ffffff;font-weight:800;">$(HtmlEncode $topGenreName)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">TOP GENRE THIS WEEK</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;">$(HtmlEncode $topGenreName)</div>
         <div style="$summarySupportingStyle">$(HtmlEncode $topGenreDescription)</div>
       </td>
     </tr>
@@ -8361,9 +8354,7 @@ $tvCards
         Get-StatsMovieRowsHtml `
             -Items $movieItems `
             -PosterAssets $PosterAssets `
-            -ImageMode $ImageMode `
-            -RecipientWatchedMovies $RecipientWatchedMovies `
-            -PreviewAssetBase $previewAssetBase
+            -ImageMode $ImageMode
     } else { "" }
 
     $tvShowRows = if ($tvShowDetailMode) {
@@ -8383,7 +8374,7 @@ $tvCards
       <table cellspacing="0" cellpadding="0" border="0">
         <tr>
           <td valign="middle" style="padding-right:8px;"><img src="$moviesIconSrc" width="42" height="42" alt="Movies watched" style="display:block;width:42px;height:42px;border:0;"></td>
-          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$movieTitleCount</div><div style="padding-top:3px;font-size:10px;color:#8e8e8e;letter-spacing:.6px;">MOVIES WATCHED</div></td>
+          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$movieTitleCount</div><div style="padding-top:3px;font-size:12px;color:#8e8e8e;letter-spacing:.6px;">MOVIES WATCHED</div></td>
         </tr>
       </table>
     </td>
@@ -8401,7 +8392,7 @@ $tvCards
       <table cellspacing="0" cellpadding="0" border="0">
         <tr>
           <td valign="middle" style="padding-right:8px;"><img src="$tvIconSrc" width="42" height="42" alt="TV shows watched" style="display:block;width:42px;height:42px;border:0;"></td>
-          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$tvShowTitleCount</div><div style="padding-top:3px;font-size:10px;color:#8e8e8e;letter-spacing:.6px;">TV SHOWS WATCHED</div></td>
+          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$tvShowTitleCount</div><div style="padding-top:3px;font-size:12px;color:#8e8e8e;letter-spacing:.6px;margin-bottom:-7px;">TV SHOWS WATCHED</div></td>
         </tr>
       </table>
     </td>
@@ -8464,7 +8455,7 @@ $tvCards
     else {
         $statsBlock = @"
 <tr>
-<td class="pad" style="padding:0 20px 24px;">
+<td class="pad" style="padding:0px 20px 0px;">
 <table width="100%" cellspacing="0" cellpadding="0" border="0">
 $mediaStatsRows
 <tr>
@@ -8472,7 +8463,7 @@ $mediaStatsRows
     <table class="email-card" width="100%" height="$summaryCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${summaryCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$summaryCardHeight" valign="middle" style="height:${summaryCardHeight}px;padding:17px;">
-          <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">YOU CLOCKED</div>
+          <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">YOU CLOCKED</div>
           <img src="$clockIconSrc" width="42" height="42" alt="Personal total watch time" style="display:block;width:42px;height:42px;border:0;margin-top:9px;">
           <div style="padding-top:8px;font-size:27px;font-weight:800;color:#ffffff;line-height:1.1;">$timeText</div>
           <div style="$summarySupportingStyle">total watch time</div>
@@ -8484,9 +8475,9 @@ $mediaStatsRows
     <table width="100%" height="$summaryCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="width:100%;height:${summaryCardHeight}px;background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$summaryCardHeight" valign="middle" style="height:${summaryCardHeight}px;padding:17px;">
-          <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
+          <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
           <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;margin-top:9px;">
-          <div style="padding-top:8px;font-size:$(if ($isBingeWinner) { 18 } else { 16 })px;line-height:1.25;font-weight:900;color:#ffffff;">$(HtmlEncode $bingeTimeLine)</div>
+          <div style="padding-top:8px;font-size:27px;line-height:1.1;font-weight:800;color:#ffffff;">$(HtmlEncode $bingeTimeLine)</div>
           $bingeBreakdownHtml
         </td>
       </tr>
@@ -8511,8 +8502,8 @@ $mediaStatsRows
         <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;">
       </td>
       <td valign="middle" style="padding:18px 20px 18px 12px;">
-        <div style="font-size:10px;color:#e5a00d;font-weight:900;letter-spacing:1.2px;">$(HtmlEncode $bingeEyebrow)</div>
-        <div style="padding-top:5px;font-size:20px;line-height:1.25;color:#ffffff;font-weight:900;">$(HtmlEncode $bingeTimeLine)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;">$(HtmlEncode $bingeTimeLine)</div>
         $bingeBreakdownHtml
       </td>
     </tr>
@@ -8749,11 +8740,10 @@ function Build-PlainText {
         $null -ne $script:GlobalTrendingStat) {
         $trendPlays = Safe-Int $script:GlobalTrendingStat.Plays
         $trendPlayWord = if ($trendPlays -eq 1) { "play" } else { "plays" }
-        $trendWatchedSuffix = Get-RecipientWatchedPlainTextSuffix -Item $script:GlobalTrendingStat -RecipientWatchedMovies $RecipientWatchedMovies
         $footerFeature += if ($trendPlays -gt 0) {
-            "`r`nTRENDING THIS WEEK: $TrendingTitle$trendWatchedSuffix — $trendPlays $trendPlayWord across the server"
+            "`r`nTRENDING THIS WEEK: $TrendingTitle — $trendPlays $trendPlayWord across the server"
         } else {
-            "`r`nTRENDING THIS WEEK: $TrendingTitle$trendWatchedSuffix"
+            "`r`nTRENDING THIS WEEK: $TrendingTitle"
         }
     }
 

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -1,6 +1,12 @@
 TAUTWEEKLY FOR PLEX PORTABLE CHANGELOG
 ===============================
 
+v1.10.2 Windows
+---------------
+- refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values
+- displays unchanged watched circles at 16x16 with 8px spacing only in main movie content; preserves the 26x26 desktop shield
+- removes footer watched markers and preserves deliberate recap spacing, dynamic data, privacy, and lifecycle behavior
+
 v1.10.1 Windows
 ---------------
 - marks movies only from the recipient's qualifying all-time Tautulli history, never another user's activity

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -6956,7 +6956,7 @@ function Get-RecipientWatchedTitleIconHtml {
     }
 
     $source = Get-RecipientWatchedAssetSource -FileName "watched.png" -Cid "recipient_watched" -ImageMode $ImageMode -PreviewAssetBase $PreviewAssetBase
-    return '<img class="recipient-watched-title-icon" src="' + (HtmlEncode $source) + '" width="20" height="20" alt="Watched" title="Watched" style="display:inline-block;width:20px;height:20px;border:0;vertical-align:middle;margin-left:6px;">'
+    return '<img class="recipient-watched-title-icon" src="' + (HtmlEncode $source) + '" width="16" height="16" alt="Watched" title="Watched" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:middle;margin-left:8px;">'
 }
 
 function Get-RecipientWatchedTitleHtml {
@@ -7077,7 +7077,7 @@ function Get-StatsMovieRatingHtml {
         $icon = Get-DesignRtIconUrl -ImageState $criticImage -Kind "critic" -ImageMode $ImageMode
         $pieces.Add(
             '<span style="display:inline-block;white-space:nowrap;">' +
-            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes critic" width="14" height="14" style="display:inline-block;width:14px;height:14px;border:0;vertical-align:-3px;margin-right:3px;">' +
+            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes critic" width="16" height="16" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:-3px;margin-right:3px;">' +
             (HtmlEncode ($critic + "%")) +
             '</span>'
         )
@@ -7094,7 +7094,7 @@ function Get-StatsMovieRatingHtml {
         $icon = Get-DesignRtIconUrl -ImageState $audienceImage -Kind "audience" -ImageMode $ImageMode
         $pieces.Add(
             '<span style="display:inline-block;white-space:nowrap;">' +
-            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes audience" width="14" height="14" style="display:inline-block;width:14px;height:14px;border:0;vertical-align:-3px;margin-right:3px;">' +
+            '<img src="' + (HtmlEncode $icon) + '" alt="Rotten Tomatoes audience" width="16" height="16" style="display:inline-block;width:16px;height:16px;border:0;vertical-align:-3px;margin-right:3px;">' +
             (HtmlEncode ($audience + "%")) +
             '</span>'
         )
@@ -7127,9 +7127,7 @@ function Get-StatsMovieRowsHtml {
         [object[]]$Items,
         [object[]]$PosterAssets,
         [ValidateSet("Preview","Email")]
-        [string]$ImageMode,
-        [AllowNull()][object]$RecipientWatchedMovies = $null,
-        [string]$PreviewAssetBase = '../assets'
+        [string]$ImageMode
     )
 
     $rows = New-Object System.Text.StringBuilder
@@ -7138,10 +7136,6 @@ function Get-StatsMovieRowsHtml {
 
     foreach ($item in @($Items)) {
         $title = HtmlEncode (Truncate-Text ([string]$item.Title) 42)
-        $titleWithStatus = $title
-        if ($null -ne $RecipientWatchedMovies) {
-            $titleWithStatus = Get-RecipientWatchedTitleHtml -EncodedTitle $title -Item $item -RecipientWatchedMovies $RecipientWatchedMovies -ImageMode $ImageMode -PreviewAssetBase $PreviewAssetBase
-        }
         $posterSrc = Get-ImageSource `
             -RatingKey ([string]$item.PosterRatingKey) `
             -PosterAssets $PosterAssets `
@@ -7159,7 +7153,7 @@ function Get-StatsMovieRowsHtml {
         $genreText = Get-DesignGenreLine -Item $item
         $genreHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($genreText)) {
-            $genreHtml = '<div style="padding-top:3px;font-size:10px;line-height:1.3;color:#9b9b9b;font-weight:500;">' +
+            $genreHtml = '<div style="padding-top:3px;font-size:12px;line-height:1.3;color:#9b9b9b;font-weight:500;">' +
                 (HtmlEncode $genreText) +
                 '</div>'
         }
@@ -7168,7 +7162,7 @@ function Get-StatsMovieRowsHtml {
         $ratingPadding = if ([string]::IsNullOrWhiteSpace($genreHtml)) { "5px" } else { "4px" }
         $ratingLineHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($ratingHtml)) {
-            $ratingLineHtml = '<div style="padding-top:' + $ratingPadding + ';font-size:10px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
+            $ratingLineHtml = '<div style="padding-top:' + $ratingPadding + ';font-size:12px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
                 $ratingHtml +
                 '</div>'
         }
@@ -7180,7 +7174,7 @@ function Get-StatsMovieRowsHtml {
     <tr>
       <td width="50" valign="middle" style="width:50px;padding:0 8px 0 0;">$posterHtml</td>
       <td valign="middle" style="padding:0;">
-        <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$titleWithStatus</div>
+        <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$title</div>
         $genreHtml
         $ratingLineHtml
       </td>
@@ -7243,7 +7237,7 @@ function Get-StatsTvShowRatingHtml {
     $rtIcon = Get-DesignRtIconUrl -ImageState $rtImage -Kind $rtKind -ImageMode $ImageMode
     $rtAlt = if ($rtKind -eq "audience") { "Rotten Tomatoes audience" } else { "Rotten Tomatoes critic" }
     return '<span style="display:inline-block;white-space:nowrap;">' +
-        '<img src="' + (HtmlEncode $rtIcon) + '" alt="' + $rtAlt + '" width="14" height="14" style="display:inline-block;width:14px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:4px;">' +
+        '<img src="' + (HtmlEncode $rtIcon) + '" alt="' + $rtAlt + '" width="16" height="16" style="display:inline-block;width:16px;height:16px;object-fit:contain;border:0;vertical-align:-3px;margin-right:4px;">' +
         (HtmlEncode ($rtValue + "%")) +
         '</span>'
 }
@@ -7285,7 +7279,7 @@ function Get-StatsEpisodeRowsHtml {
         $imdbLineHtml = if ([string]::IsNullOrWhiteSpace($imdb)) {
             ""
         } else {
-            '<div style="padding-top:4px;font-size:10px;line-height:1.3;color:#e5a00d;font-weight:700;">' +
+            '<div style="padding-top:4px;font-size:12px;line-height:1.3;color:#e5a00d;font-weight:700;">' +
             '<span style="display:inline-block;white-space:nowrap;">' +
             '<img src="' + (HtmlEncode $ImdbIconSrc) + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
             (HtmlEncode $imdb) +
@@ -7296,8 +7290,8 @@ function Get-StatsEpisodeRowsHtml {
 <tr>
   <td width="50" valign="middle" style="width:50px;padding:7px 8px 7px 0;border-bottom:1px solid #292929;">$posterHtml</td>
   <td valign="middle" style="padding:7px 0;border-bottom:1px solid #292929;">
-    <div style="font-size:11px;line-height:1.25;color:#ffffff;font-weight:800;">$showTitle</div>
-    <div style="padding-top:3px;font-size:10px;line-height:1.3;color:#9b9b9b;">$(HtmlEncode $prefix)$episodeTitle</div>
+    <div style="font-size:12px;line-height:1.25;color:#ffffff;font-weight:800;">$showTitle</div>
+    <div style="padding-top:3px;font-size:12px;line-height:1.3;color:#9b9b9b;">$(HtmlEncode $prefix)$episodeTitle</div>
     $imdbLineHtml
   </td>
 </tr>
@@ -7342,7 +7336,7 @@ function Get-StatsTvShowRowsHtml {
         $ratingLineHtml = if ([string]::IsNullOrWhiteSpace($ratingHtml)) {
             ""
         } else {
-            '<div style="padding-top:4px;font-size:10px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
+            '<div style="padding-top:4px;font-size:12px;line-height:1.35;color:#e5a00d;font-weight:700;">' +
             $ratingHtml +
             '</div>'
         }
@@ -7361,7 +7355,7 @@ function Get-StatsTvShowRowsHtml {
       <td valign="middle" style="padding:0;">
         <div style="font-size:12px;line-height:1.3;color:#ffffff;font-weight:800;">$showTitle</div>
         $ratingLineHtml
-        <div style="padding-top:3px;font-size:10px;line-height:1.35;color:#9b9b9b;font-weight:600;">$(HtmlEncode $watchTime) watched</div>
+        <div style="padding-top:3px;font-size:12px;line-height:1.35;color:#9b9b9b;font-weight:600;">$(HtmlEncode $watchTime) watched</div>
       </td>
     </tr>
   </table>
@@ -8174,7 +8168,6 @@ $tvCards
         $trendingPosterHtml = ""
 
         $trendingDisplay = HtmlEncode (Truncate-Text $TrendingTitle 70)
-        $trendingTitleWithStatus = Get-RecipientWatchedTitleHtml -EncodedTitle $trendingDisplay -Item $script:GlobalTrendingStat -RecipientWatchedMovies $RecipientWatchedMovies -ImageMode $ImageMode -PreviewAssetBase $previewAssetBase
         $trendingPlays = Safe-Int $script:GlobalTrendingStat.Plays
         $trendingRatingKey = [string]$script:GlobalTrendingStat.RatingKey
         $trendingPosterSrc = Get-ImageSource `
@@ -8209,9 +8202,9 @@ $tvCards
         <img src="$trendingIconSrc" width="42" height="42" alt="Trending this week" style="display:block;width:42px;height:42px;border:0;">
       </td>
       <td valign="middle" style="padding:16px 18px 16px 10px;">
-        <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.3px;">TRENDING THIS WEEK</div>
-        <div style="padding-top:5px;font-size:18px;line-height:1.25;color:#ffffff;font-weight:800;">$trendingTitleWithStatus</div>
-        <div style="padding-top:4px;font-size:12px;line-height:1.4;color:#8e8e8e;">$(HtmlEncode $trendingDescription)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">TRENDING THIS WEEK</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;overflow-wrap:anywhere;word-break:break-word;">$trendingDisplay</div>
+        <div style="padding-top:4px;font-size:12px;line-height:1.35;font-weight:400;color:#8e8e8e;">$(HtmlEncode $trendingDescription)</div>
       </td>
     </tr>
   </table>
@@ -8254,8 +8247,8 @@ $tvCards
         <img src="$(HtmlEncode $topGenreIconSrc)" width="42" height="42" alt="Top genre this week" style="display:block;width:42px;height:42px;border:0;">
       </td>
       <td valign="middle" style="padding:16px 18px 16px 10px;">
-        <div style="font-size:11px;color:#e5a00d;font-weight:800;letter-spacing:1.3px;">TOP GENRE THIS WEEK</div>
-        <div style="padding-top:5px;font-size:18px;line-height:1.25;color:#ffffff;font-weight:800;">$(HtmlEncode $topGenreName)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">TOP GENRE THIS WEEK</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;">$(HtmlEncode $topGenreName)</div>
         <div style="$summarySupportingStyle">$(HtmlEncode $topGenreDescription)</div>
       </td>
     </tr>
@@ -8312,9 +8305,7 @@ $tvCards
         Get-StatsMovieRowsHtml `
             -Items $movieItems `
             -PosterAssets $PosterAssets `
-            -ImageMode $ImageMode `
-            -RecipientWatchedMovies $RecipientWatchedMovies `
-            -PreviewAssetBase $previewAssetBase
+            -ImageMode $ImageMode
     } else { "" }
 
     $tvShowRows = if ($tvShowDetailMode) {
@@ -8334,7 +8325,7 @@ $tvCards
       <table cellspacing="0" cellpadding="0" border="0">
         <tr>
           <td valign="middle" style="padding-right:8px;"><img src="$moviesIconSrc" width="42" height="42" alt="Movies watched" style="display:block;width:42px;height:42px;border:0;"></td>
-          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$movieTitleCount</div><div style="padding-top:3px;font-size:10px;color:#8e8e8e;letter-spacing:.6px;">MOVIES WATCHED</div></td>
+          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$movieTitleCount</div><div style="padding-top:3px;font-size:12px;color:#8e8e8e;letter-spacing:.6px;">MOVIES WATCHED</div></td>
         </tr>
       </table>
     </td>
@@ -8352,7 +8343,7 @@ $tvCards
       <table cellspacing="0" cellpadding="0" border="0">
         <tr>
           <td valign="middle" style="padding-right:8px;"><img src="$tvIconSrc" width="42" height="42" alt="TV shows watched" style="display:block;width:42px;height:42px;border:0;"></td>
-          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$tvShowTitleCount</div><div style="padding-top:3px;font-size:10px;color:#8e8e8e;letter-spacing:.6px;">TV SHOWS WATCHED</div></td>
+          <td valign="middle"><div style="font-size:18px;font-weight:800;color:#ffffff;line-height:1;">$tvShowTitleCount</div><div style="padding-top:3px;font-size:12px;color:#8e8e8e;letter-spacing:.6px;margin-bottom:-7px;">TV SHOWS WATCHED</div></td>
         </tr>
       </table>
     </td>
@@ -8415,7 +8406,7 @@ $tvCards
     else {
         $statsBlock = @"
 <tr>
-<td class="pad" style="padding:0 20px 24px;">
+<td class="pad" style="padding:0px 20px 0px;">
 <table width="100%" cellspacing="0" cellpadding="0" border="0">
 $mediaStatsRows
 <tr>
@@ -8423,7 +8414,7 @@ $mediaStatsRows
     <table class="email-card" width="100%" height="$summaryCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="#181818" style="width:100%;height:${summaryCardHeight}px;background-color:#181818;border:1px solid #2b2b2b;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$summaryCardHeight" valign="middle" style="height:${summaryCardHeight}px;padding:17px;">
-          <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">YOU CLOCKED</div>
+          <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">YOU CLOCKED</div>
           <img src="$clockIconSrc" width="42" height="42" alt="Personal total watch time" style="display:block;width:42px;height:42px;border:0;margin-top:9px;">
           <div style="padding-top:8px;font-size:27px;font-weight:800;color:#ffffff;line-height:1.1;">$timeText</div>
           <div style="$summarySupportingStyle">total watch time</div>
@@ -8435,9 +8426,9 @@ $mediaStatsRows
     <table width="100%" height="$summaryCardHeight" cellspacing="0" cellpadding="0" border="0" bgcolor="$bingeBackground" style="width:100%;height:${summaryCardHeight}px;background-color:$bingeBackground;border:1px solid $bingeBorder;border-radius:10px;border-collapse:separate;">
       <tr>
         <td height="$summaryCardHeight" valign="middle" style="height:${summaryCardHeight}px;padding:17px;">
-          <div style="font-size:9px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
+          <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
           <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;margin-top:9px;">
-          <div style="padding-top:8px;font-size:$(if ($isBingeWinner) { 18 } else { 16 })px;line-height:1.25;font-weight:900;color:#ffffff;">$(HtmlEncode $bingeTimeLine)</div>
+          <div style="padding-top:8px;font-size:27px;line-height:1.1;font-weight:800;color:#ffffff;">$(HtmlEncode $bingeTimeLine)</div>
           $bingeBreakdownHtml
         </td>
       </tr>
@@ -8462,8 +8453,8 @@ $mediaStatsRows
         <img src="$trophyIconSrc" width="$(if ($isBingeWinner) { 54 } else { 42 })" height="$(if ($isBingeWinner) { 54 } else { 42 })" alt="Binge Champion award" style="display:block;width:$(if ($isBingeWinner) { 54 } else { 42 })px;height:$(if ($isBingeWinner) { 54 } else { 42 })px;border:0;">
       </td>
       <td valign="middle" style="padding:18px 20px 18px 12px;">
-        <div style="font-size:10px;color:#e5a00d;font-weight:900;letter-spacing:1.2px;">$(HtmlEncode $bingeEyebrow)</div>
-        <div style="padding-top:5px;font-size:20px;line-height:1.25;color:#ffffff;font-weight:900;">$(HtmlEncode $bingeTimeLine)</div>
+        <div style="font-size:12px;color:#e5a00d;font-weight:900;letter-spacing:1.1px;">$(HtmlEncode $bingeEyebrow)</div>
+        <div style="padding-top:5px;font-size:27px;line-height:1.1;color:#ffffff;font-weight:800;">$(HtmlEncode $bingeTimeLine)</div>
         $bingeBreakdownHtml
       </td>
     </tr>
@@ -8700,11 +8691,10 @@ function Build-PlainText {
         $null -ne $script:GlobalTrendingStat) {
         $trendPlays = Safe-Int $script:GlobalTrendingStat.Plays
         $trendPlayWord = if ($trendPlays -eq 1) { "play" } else { "plays" }
-        $trendWatchedSuffix = Get-RecipientWatchedPlainTextSuffix -Item $script:GlobalTrendingStat -RecipientWatchedMovies $RecipientWatchedMovies
         $footerFeature += if ($trendPlays -gt 0) {
-            "`r`nTRENDING THIS WEEK: $TrendingTitle$trendWatchedSuffix — $trendPlays $trendPlayWord across the server"
+            "`r`nTRENDING THIS WEEK: $TrendingTitle — $trendPlays $trendPlayWord across the server"
         } else {
-            "`r`nTRENDING THIS WEEK: $TrendingTitle$trendWatchedSuffix"
+            "`r`nTRENDING THIS WEEK: $TrendingTitle"
         }
     }
 

--- a/platforms/windows/VERSION.txt
+++ b/platforms/windows/VERSION.txt
@@ -1,3 +1,3 @@
-TautWeekly for Plex Windows v1.10.1
+TautWeekly for Plex Windows v1.10.2
 Platform: Windows PowerShell 5.1+
 Feature: One-click Setup EXE and local Manager

--- a/scripts/test-newsletter-integration.ps1
+++ b/scripts/test-newsletter-integration.ps1
@@ -44,6 +44,36 @@ function Get-HtmlSection {
     return $Html.Substring($startIndex, $endIndex - $startIndex)
 }
 
+function Assert-FooterPresentation {
+    param([string]$Html, [string]$Context)
+    $start = $Html.IndexOf('YOUR WEEK ON PLEX', [StringComparison]::Ordinal)
+    if ($start -lt 0) { return } # Manual Welcome omits the personal footer.
+    $footer = $Html.Substring($start)
+    Assert-True (-not $footer.Contains('recipient-watched')) "$Context contains a footer watched marker."
+    $headingPattern = '<div style="([^"]+)">(YOU CLOCKED|[^<]*BINGE CHAMPION|TOP GENRE THIS WEEK|TRENDING THIS WEEK)</div>\s*(?:<img[^>]+>\s*)?<div style="([^"]+)">[^<]*</div>'
+    $summaries = [regex]::Matches($footer, $headingPattern)
+    foreach ($summary in $summaries) {
+        $heading = $summary.Groups[1].Value
+        $value = $summary.Groups[3].Value
+        foreach ($style in @('font-size:12px;', 'font-weight:900;', 'letter-spacing:1.1px;')) {
+            Assert-True ($heading.Contains($style)) "$Context footer heading lost $style"
+        }
+        foreach ($style in @('font-size:27px;', 'font-weight:800;', 'line-height:1.1;')) {
+            Assert-True ($value.Contains($style)) "$Context footer primary value lost $style"
+        }
+    }
+    foreach ($label in [regex]::Matches($footer, '<div style="([^"]+)">(MOVIES WATCHED|TV SHOWS WATCHED)</div>')) {
+        Assert-True ($label.Groups[1].Value.Contains('font-size:12px;')) "$Context recap label is not 12px."
+        if ($label.Groups[2].Value -eq 'TV SHOWS WATCHED') {
+            Assert-True ($label.Groups[1].Value.Contains('margin-bottom:-7px;')) "$Context lost deliberate TV-label spacing."
+        }
+    }
+    if ($footer.Contains('class="stats-summary-cell"')) {
+        Assert-True ($footer.Contains('class="pad" style="padding:0px 20px 0px;"')) "$Context restored unwanted bottom stats padding."
+        Assert-True ($summaries.Count -ge 2) "$Context did not validate both summary values."
+    }
+}
+
 function Get-TautulliMetadataCallCount {
     param(
         [string]$CallLogPath,
@@ -418,6 +448,7 @@ foreach ($engine in $engines) {
             $normalHtml = Get-Content $normalPath -Raw -Encoding UTF8
             $quietHtml = Get-Content (Join-Path $outputRoot 'preview-all-05-established-quiet.html') -Raw -Encoding UTF8
             $scenarioPreviewHtml = @($manualHtml, $newNoHistoryHtml, $newWithHistoryHtml, $normalHtml, $quietHtml, $warmupHtml)
+            foreach ($stateHtml in $scenarioPreviewHtml) { Assert-FooterPresentation -Html $stateHtml -Context "$($engine.Name)/$scenario" }
             $previewThemeMarkers = @(
                 '<meta name="color-scheme" content="light dark">',
                 '<meta name="supported-color-schemes" content="light dark">',
@@ -565,7 +596,7 @@ foreach ($engine in $engines) {
                     Assert-True (([regex]::Matches($heroHtml, 'class="recipient-watched-title-icon"')).Count -eq 1) "$($engine.Name)/$scenario did not render exactly one circular hero marker."
                     Assert-True (([regex]::Matches($stateHtml, 'class="recipient-watched-desktop-badge"')).Count -eq 1) "$($engine.Name)/$scenario did not render exactly one desktop hero badge."
                     Assert-True ($heroHtml.Contains('<span style="vertical-align:middle;">Selected </span><span class="recipient-watched-title-tail" style="white-space:nowrap;"><span style="vertical-align:middle;">Movie</span><img class="recipient-watched-title-icon"')) "$($engine.Name)/$scenario did not place the circular marker immediately after the mobile hero title."
-                    Assert-True ($heroHtml.Contains('alt="Watched" title="Watched"') -and $heroHtml.Contains('vertical-align:middle;margin-left:6px;')) "$($engine.Name)/$scenario lost accessible, centered, consistently spaced hero markup."
+                    Assert-True ($heroHtml.Contains('alt="Watched" title="Watched"') -and $heroHtml.Contains('vertical-align:middle;margin-left:8px;')) "$($engine.Name)/$scenario lost accessible, centered, consistently spaced hero markup."
                     Assert-True ($heroHtml.Contains("src=`"$watchedPreviewBase/watched.png`"") -and $heroHtml.Contains("src=`"$watchedPreviewBase/watched-desktop.png`"")) "$($engine.Name)/$scenario used broken watched preview asset paths."
                     Assert-True ($heroHtml.Contains('<v:group') -and $heroHtml.Contains('coordsize="180,275"') -and $heroHtml.Contains('left:147;top:0;width:26;height:26;') -and $heroHtml.Contains('width="7" height="26"') -and $heroHtml.Contains('padding:5px 0 0;')) "$($engine.Name)/$scenario lost Outlook or standard desktop overlay placement."
                     Assert-True ($heroHtml.Contains('4 plays')) "$($engine.Name)/$scenario collapsed the grouped HOT history row to one play."
@@ -574,7 +605,7 @@ foreach ($engine in $engines) {
                     Assert-True (-not $activeReleaseHtml.Contains('Selected Movie') -and $activeReleaseHtml.Contains('Selected Show')) "$($engine.Name)/$scenario duplicated the HOT movie in New Releases or lost the TV shelf."
                     Assert-True (-not $activeReleaseHtml.Contains('recipient-watched-title-icon')) "$($engine.Name)/$scenario marked a TV release."
                     $afterActiveHeroHtml = $stateHtml.Substring($releaseStart)
-                    Assert-True ($afterActiveHeroHtml.Contains('<span style="vertical-align:middle;">Active Trending </span><span class="recipient-watched-title-tail" style="white-space:nowrap;"><span style="vertical-align:middle;">Movie</span><img class="recipient-watched-title-icon"') -and $afterActiveHeroHtml.Contains('posters/poster_active-trending-movie.jpg')) "$($engine.Name)/$scenario lost the recipient-specific compact Trending marker or poster."
+                    Assert-True ($afterActiveHeroHtml.Contains('>Active Trending Movie</div>') -and $afterActiveHeroHtml.Contains('posters/poster_active-trending-movie.jpg') -and -not $afterActiveHeroHtml.Contains('recipient-watched')) "$($engine.Name)/$scenario marked footer Trending or lost its title/poster."
                 }
                 $activeLogoPath = Join-Path (Join-Path $outputRoot 'media') 'logo_selected-movie.png'
                 Assert-True ((Test-Path -LiteralPath $activeLogoPath) -and (Get-Item -LiteralPath $activeLogoPath).Length -gt 256) "$($engine.Name)/$scenario did not persist the active clearLogo asset."
@@ -582,7 +613,7 @@ foreach ($engine in $engines) {
                 Assert-True ($activeStatsStart -ge 0) "$($engine.Name)/$scenario could not isolate active real-history stats."
                 $activeStatsHtml = $normalHtml.Substring($activeStatsStart)
                 $expectedChromePreviewSource = if ($engine.Container) { 'assets/platform-chrome.png' } else { '../assets/platform-chrome.png' }
-                Assert-True ($activeStatsHtml.Contains('MOVIES WATCHED') -and $activeStatsHtml.Contains('<span style="vertical-align:middle;">Selected </span><span class="recipient-watched-title-tail" style="white-space:nowrap;"><span style="vertical-align:middle;">Movie</span><img class="recipient-watched-title-icon"')) "$($engine.Name)/$scenario lost the recipient watched marker in the personal movie recap."
+                Assert-True ($activeStatsHtml.Contains('MOVIES WATCHED') -and $activeStatsHtml.Contains('>Selected Movie</div>') -and -not $activeStatsHtml.Contains('recipient-watched')) "$($engine.Name)/$scenario marked the footer or lost the personal movie recap."
                 Assert-True ($activeStatsHtml.Contains('Drama, Mystery') -and $activeStatsHtml.Contains('Rotten Tomatoes critic') -and $activeStatsHtml.Contains('Rotten Tomatoes audience')) "$($engine.Name)/$scenario lost watched-movie genres or critic/audience ratings."
                 Assert-True ($activeStatsHtml.Contains('81%</span>') -and $activeStatsHtml.Contains('92%</span>')) "$($engine.Name)/$scenario swapped or lost exact watched-movie critic/audience values."
                 Assert-True ($activeStatsHtml.Contains('posters/poster_selected-movie.jpg')) "$($engine.Name)/$scenario lost the watched-movie stat poster."
@@ -610,7 +641,7 @@ foreach ($engine in $engines) {
                     Assert-True (([regex]::Matches($stateHtml, 'class="recipient-watched-desktop-badge"')).Count -eq 1) "$($engine.Name)/$scenario did not render exactly one desktop hero badge."
                     Assert-True ($heroHtml.Contains('<span style="vertical-align:middle;">Quiet Trending </span><span class="recipient-watched-title-tail" style="white-space:nowrap;"><span style="vertical-align:middle;">Movie</span><img class="recipient-watched-title-icon"')) "$($engine.Name)/$scenario did not place the circular marker immediately after the mobile hero title."
                     Assert-True ($releaseHtml.Contains('<span style="vertical-align:middle;">Recent Movie </span><span class="recipient-watched-title-tail" style="white-space:nowrap;"><span style="vertical-align:middle;">One</span><img class="recipient-watched-title-icon"')) "$($engine.Name)/$scenario did not place the circular marker immediately after a watched card title."
-                    Assert-True ($stateHtml.Contains('alt="Watched" title="Watched"') -and $stateHtml.Contains('vertical-align:middle;margin-left:6px;')) "$($engine.Name)/$scenario lost accessible, centered, consistently spaced marker markup."
+                    Assert-True ($stateHtml.Contains('alt="Watched" title="Watched"') -and $stateHtml.Contains('vertical-align:middle;margin-left:8px;')) "$($engine.Name)/$scenario lost accessible, centered, consistently spaced marker markup."
                     Assert-True ($stateHtml.Contains("src=`"$watchedPreviewBase/watched.png`"") -and $heroHtml.Contains("src=`"$watchedPreviewBase/watched-desktop.png`"")) "$($engine.Name)/$scenario used broken watched preview asset paths."
                     Assert-True ($heroHtml.Contains('<v:group') -and $heroHtml.Contains('coordsize="180,275"') -and $heroHtml.Contains('left:147;top:0;width:26;height:26;') -and $heroHtml.Contains('width="7" height="26"') -and $heroHtml.Contains('padding:5px 0 0;')) "$($engine.Name)/$scenario lost Outlook or standard desktop overlay placement."
                     Assert-True ($releaseHtml.Contains('>Selected Movie</div>') -and -not $releaseHtml.Contains('<span style="vertical-align:middle;">Selected </span><span class="recipient-watched-title-tail" style="white-space:nowrap;"><span style="vertical-align:middle;">Movie</span><img class="recipient-watched-title-icon"')) "$($engine.Name)/$scenario left a gap or leaked another user's watched state into Selected Movie."
@@ -1230,7 +1261,7 @@ foreach ($engine in $engines) {
                         '--require-html', 'cid:hero_logo',
                         '--require-html', 'cid:recipient_watched',
                         '--require-html', 'cid:recipient_watched_desktop',
-                        '--require-html', 'vertical-align:middle;margin-left:6px;',
+                        '--require-html', 'vertical-align:middle;margin-left:8px;',
                         '--require-plain', 'HOT NEW RELEASE: Selected Movie - Watched',
                         '--require-html', 'Selected Show',
                         '--require-html', 'Active Trending Movie',
@@ -1275,7 +1306,7 @@ foreach ($engine in $engines) {
                         '--require-html', 'cid:hero_logo',
                         '--require-html', 'cid:recipient_watched',
                         '--require-html', 'cid:recipient_watched_desktop',
-                        '--require-html', 'vertical-align:middle;margin-left:6px;',
+                        '--require-html', 'vertical-align:middle;margin-left:8px;',
                         '--require-plain', 'TRENDING THIS WEEK: Quiet Trending Movie - Watched',
                         '--require-html', 'Recent Movie One',
                         '--require-html', 'Selected Movie',
@@ -1523,7 +1554,7 @@ foreach ($engine in $engines) {
                             '--require-html', 'cid:hero_logo',
                             '--require-html', 'cid:recipient_watched',
                             '--require-html', 'cid:recipient_watched_desktop',
-                            '--require-html', 'vertical-align:middle;margin-left:6px;',
+                            '--require-html', 'vertical-align:middle;margin-left:8px;',
                             '--require-plain', 'HOT NEW RELEASE: Selected Movie - Watched',
                             '--require-cid-sha256', 'poster_active-trending-movie=31AC758909ADD2BB42FCE41C0973435FA6705D95A0F8981C4F421A1C6E404817',
                             '--require-cid-png-dimensions', 'hero_logo=320x96'
@@ -1547,7 +1578,7 @@ foreach ($engine in $engines) {
                         '--require-html', 'cid:hero_logo',
                         '--require-html', 'cid:recipient_watched',
                         '--require-html', 'cid:recipient_watched_desktop',
-                        '--require-html', 'vertical-align:middle;margin-left:6px;',
+                        '--require-html', 'vertical-align:middle;margin-left:8px;',
                         '--require-plain', 'TRENDING THIS WEEK: Quiet Trending Movie - Watched',
                         '--require-html', 'Recent Movie One',
                         '--require-html', 'Selected Movie',
@@ -1751,7 +1782,7 @@ foreach ($engine in $engines) {
                             '--require-html', 'cid:hero_logo',
                             '--require-html', 'cid:recipient_watched',
                             '--require-html', 'cid:recipient_watched_desktop',
-                            '--require-html', 'vertical-align:middle;margin-left:6px;',
+                            '--require-html', 'vertical-align:middle;margin-left:8px;',
                             '--require-plain', 'HOT NEW RELEASE: Selected Movie - Watched',
                             '--require-cid-sha256', 'poster_active-trending-movie=31AC758909ADD2BB42FCE41C0973435FA6705D95A0F8981C4F421A1C6E404817',
                             '--require-cid-sha256', 'poster_selected-movie=31AC758909ADD2BB42FCE41C0973435FA6705D95A0F8981C4F421A1C6E404817',
@@ -1790,7 +1821,7 @@ foreach ($engine in $engines) {
                             '--require-html', 'cid:hero_logo',
                             '--require-html', 'cid:recipient_watched',
                             '--require-html', 'cid:recipient_watched_desktop',
-                            '--require-html', 'vertical-align:middle;margin-left:6px;',
+                            '--require-html', 'vertical-align:middle;margin-left:8px;',
                             '--require-plain', 'TRENDING THIS WEEK: Quiet Trending Movie - Watched',
                             '--require-cid-sha256', 'poster_quiet-trending-movie=31AC758909ADD2BB42FCE41C0973435FA6705D95A0F8981C4F421A1C6E404817',
                             '--require-cid-sha256', 'poster_quiet-recent-movie-01=31AC758909ADD2BB42FCE41C0973435FA6705D95A0F8981C4F421A1C6E404817',

--- a/scripts/test-recipient-watched-movies.ps1
+++ b/scripts/test-recipient-watched-movies.ps1
@@ -30,7 +30,8 @@ $requiredFunctions = @(
     'Test-IncludedLibraryRow', 'Get-IncludedLibraryQueryScopes',
     'Test-RecipientHasWatchedMovie', 'Get-RecipientWatchedAssetSource',
     'Get-RecipientWatchedTitleIconHtml', 'Get-RecipientWatchedTitleHtml', 'Get-RecipientWatchedDesktopHeroPosterHtml',
-    'Get-RecipientWatchedPlainTextSuffix', 'Get-ReleaseCardsHtml', 'Get-StatsMovieRowsHtml'
+    'Get-RecipientWatchedPlainTextSuffix', 'Get-ReleaseCardsHtml', 'Get-StatsMovieRowsHtml',
+    'Get-StatsMovieRatingHtml', 'Get-StatsTvShowRowsHtml', 'Get-StatsTvShowRatingHtml', 'Get-StatsEpisodeRowsHtml'
 )
 
 $sharedDefinitions = @{}
@@ -42,9 +43,9 @@ foreach ($renderer in $renderers) {
     Assert-True ($parseErrors.Count -eq 0) "Parser errors prevent watched-state testing: $($renderer.Path)"
     foreach ($name in $requiredFunctions) {
         $definition = Get-RendererFunctionDefinition -Ast $ast -Name $name -Renderer $renderer.Path
-        if ($name -like '*Recipient*Watched*') {
+        if ($name -like '*Recipient*Watched*' -or $name -like 'Get-Stats*') {
             if ($sharedDefinitions.ContainsKey($name)) {
-                Assert-True ($definition -ceq $sharedDefinitions[$name]) "Renderer drift in shared $name"
+                Assert-True ($definition.Replace('../assets/', 'assets/') -ceq $sharedDefinitions[$name].Replace('../assets/', 'assets/')) "Renderer drift in shared $name"
             } else { $sharedDefinitions[$name] = $definition }
         }
         Invoke-Expression $definition
@@ -155,8 +156,8 @@ foreach ($renderer in $renderers) {
 
     $previewIcon = Get-RecipientWatchedTitleIconHtml $watched $state Preview $renderer.PreviewBase
     Assert-True ($previewIcon.Contains("src=`"$($renderer.PreviewBase)/watched.png`"")) "$($renderer.Path) used the wrong preview path"
-    Assert-True ($previewIcon.Contains('width="20" height="20" alt="Watched" title="Watched"')) "$($renderer.Path) lost circular icon dimensions/accessibility"
-    Assert-True ($previewIcon.Contains('vertical-align:middle;margin-left:6px;')) "$($renderer.Path) lost consistent icon centering/spacing"
+    Assert-True ($previewIcon.Contains('width="16" height="16" alt="Watched" title="Watched"')) "$($renderer.Path) lost circular icon dimensions/accessibility"
+    Assert-True ($previewIcon.Contains('vertical-align:middle;margin-left:8px;')) "$($renderer.Path) lost consistent icon centering/spacing"
     $emailIcon = Get-RecipientWatchedTitleIconHtml $watched $state Email $renderer.PreviewBase
     Assert-True ($emailIcon.Contains('src="cid:recipient_watched"')) "$($renderer.Path) lost the circular CID"
     Assert-True ((Get-RecipientWatchedTitleIconHtml $unwatched $state Preview $renderer.PreviewBase) -eq '') "$($renderer.Path) left an unwatched title gap"
@@ -181,23 +182,29 @@ foreach ($renderer in $renderers) {
     Assert-True ((Get-RecipientWatchedTitleHtml 'TV Title' $tv $state Preview $renderer.PreviewBase) -ceq 'TV Title') "$($renderer.Path) changed TV title markup"
     $watchedCard = Get-ReleaseCardsHtml @($watched) @() Preview $state $renderer.PreviewBase Movie
     Assert-True ($watchedCard.Contains($previewTitle)) "$($renderer.Path) did not place the icon immediately after the card title"
-    Assert-True ($watchedCard.Contains('vertical-align:middle;margin-left:6px;')) "$($renderer.Path) card spacing differs from hero spacing"
+    Assert-True ($watchedCard.Contains('vertical-align:middle;margin-left:8px;')) "$($renderer.Path) card spacing differs from hero spacing"
     $unwatchedCard = Get-ReleaseCardsHtml @($unwatched) @() Preview $state $renderer.PreviewBase Movie
     Assert-True (-not $unwatchedCard.Contains('recipient-watched-title-icon')) "$($renderer.Path) left watched markup in an unwatched card"
     $tvCard = Get-ReleaseCardsHtml @($tv) @() Preview $state $renderer.PreviewBase TV
     Assert-True (-not $tvCard.Contains('recipient-watched-title-icon')) "$($renderer.Path) changed TV card rendering"
 
-    $statsRow = Get-StatsMovieRowsHtml @($watched) @() Preview $state $renderer.PreviewBase
-    Assert-True ($statsRow.Contains($previewTitle)) "$($renderer.Path) omitted the identical marker from the personal movie recap"
-    $unwatchedStats = Get-StatsMovieRowsHtml @($unwatched) @() Preview $state $renderer.PreviewBase
+    $statsRow = Get-StatsMovieRowsHtml @($watched) @() Preview
+    Assert-True ($statsRow.Contains('>Watched Movie</div>') -and -not $statsRow.Contains('recipient-watched')) "$($renderer.Path) marked a personal movie recap"
+    $unwatchedStats = Get-StatsMovieRowsHtml @($unwatched) @() Preview
     Assert-True (-not $unwatchedStats.Contains('recipient-watched-title-icon')) "$($renderer.Path) marked an unwatched recap item"
 
     $source = [IO.File]::ReadAllText($path)
+    $footerStart = $source.IndexOf('    $trendingBlock = ""')
+    $footerEnd = $source.IndexOf('    # Suppress empty weekly recap', $footerStart)
+    $footerDefinition = $source.Substring($footerStart, $footerEnd - $footerStart)
+    if ($sharedDefinitions.ContainsKey('Footer')) {
+        Assert-True ($footerDefinition -ceq $sharedDefinitions['Footer']) "$($renderer.Path) has footer markup drift"
+    } else { $sharedDefinitions['Footer'] = $footerDefinition }
     Assert-True ($source.Contains('$hotTitleWithStatus = Get-RecipientWatchedTitleHtml -EncodedTitle $hotTitle')) "$($renderer.Path) lost mobile hero placement"
     Assert-True ($source.Contains('$hotPosterHtml = Get-RecipientWatchedDesktopHeroPosterHtml')) "$($renderer.Path) lost desktop hero placement"
-    Assert-True ($source.Contains('$trendingTitleWithStatus = Get-RecipientWatchedTitleHtml -EncodedTitle $trendingDisplay -Item $script:GlobalTrendingStat')) "$($renderer.Path) omitted the compact Trending movie marker"
-    Assert-True ($source.Contains('$trendWatchedSuffix = Get-RecipientWatchedPlainTextSuffix -Item $script:GlobalTrendingStat')) "$($renderer.Path) omitted compact Trending plain-text status"
-    Assert-True ($source.Contains('$watchedSuffix = Get-RecipientWatchedPlainTextSuffix -Item $_')) "$($renderer.Path) omitted personal movie plain-text status"
+    Assert-True (-not $source.Contains('$trendingTitleWithStatus')) "$($renderer.Path) marked compact footer Trending"
+    Assert-True (-not $source.Contains('$trendWatchedSuffix')) "$($renderer.Path) marked compact footer Trending in plain text"
+    Assert-True ($source.Contains('$watchedSuffix = Get-RecipientWatchedPlainTextSuffix -Item $_')) "$($renderer.Path) omitted main movie-card plain-text status"
     Assert-True ($source.Contains('Cid = "recipient_watched"; MediaType = "image/png"')) "$($renderer.Path) omitted circular MIME registration"
     Assert-True ($source.Contains('Cid = "recipient_watched_desktop"; MediaType = "image/png"')) "$($renderer.Path) omitted desktop MIME registration"
     Assert-True (([regex]::Matches($source, [regex]::Escape('Get-RecipientWatchedMovies -ExpectedUserId $user.UserId'))).Count -eq 3) "$($renderer.Path) omitted a recipient-state lifecycle"

--- a/scripts/test-recipient-watched-visuals.mjs
+++ b/scripts/test-recipient-watched-visuals.mjs
@@ -1,19 +1,23 @@
 #!/usr/bin/env node
 // Local-only visual acceptance for retained synthetic integration fixtures.
-// Usage: node scripts/test-recipient-watched-visuals.mjs FIXTURE_APP OUTPUT_DIR PLAYWRIGHT_MODULE BROWSER_EXE
+// Usage: node scripts/test-recipient-watched-visuals.mjs FIXTURE_APP OUTPUT_DIR PLAYWRIGHT_MODULE BROWSER_EXE [PREVIEW_FILTER] [WIDTHS]
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const [fixtureArg, outputArg, playwrightArg, executablePath] = process.argv.slice(2);
+const [fixtureArg, outputArg, playwrightArg, executablePath, previewFilter, widthArg] = process.argv.slice(2);
+const widths = widthArg ? widthArg.split(',').map(Number) : [1280, 390, 320];
+assert(widths.length && widths.every(width => Number.isInteger(width) && width >= 320), 'Invalid viewport widths.');
 assert(fixtureArg && outputArg && playwrightArg && executablePath, 'Provide all four paths; use only synthetic integration fixtures.');
 const fixtureRoot = path.resolve(fixtureArg);
 const outputRoot = path.resolve(outputArg);
 const { chromium } = await import(pathToFileURL(path.resolve(playwrightArg)).href);
-const names = (await fs.readdir(path.join(fixtureRoot, 'output'))).filter(name => /^preview-all-.*\.html$/.test(name)).sort();
+let names = (await fs.readdir(path.join(fixtureRoot, 'output'))).filter(name => /^preview-all-.*\.html$/.test(name)).sort();
 assert.equal(names.length, 7, 'Expected the Index and all six lifecycle previews.');
+if (previewFilter) names = names.filter(name => previewFilter.split(',').some(part => name.includes(part)));
+assert(names.length > 0, 'Preview filter selected no pages.');
 await fs.mkdir(outputRoot, { recursive: true });
 const types = { '.html':'text/html', '.css':'text/css', '.js':'text/javascript', '.png':'image/png', '.gif':'image/gif', '.svg':'image/svg+xml' };
 const server = http.createServer(async (request, response) => {
@@ -51,7 +55,7 @@ const errors = [];
 page.on('pageerror', error => errors.push(error.message));
 const results = [];
 try {
-  for (const width of [1280, 390, 320]) {
+  for (const width of widths) {
     await page.setViewportSize({ width, height: 1000 });
     for (const name of names) {
       await page.goto(origin + '/output/' + encodeURIComponent(name), { waitUntil:'networkidle' });
@@ -78,14 +82,66 @@ try {
           const posterBox = rect(poster);
           return { ...box, inset:posterBox.right-box.right, raised:posterBox.top-box.top, posterWidth:posterBox.width, alt:badge.alt, tooltip:badge.title };
         });
+        const typography = element => {
+          const style = getComputedStyle(element);
+          return { text:element.textContent.trim(), size:style.fontSize, weight:style.fontWeight, lineHeight:style.lineHeight, letterSpacing:style.letterSpacing, marginBottom:style.marginBottom };
+        };
+        const footerHeading = [...document.querySelectorAll('td')].find(element => element.textContent.trim() === 'YOUR WEEK ON PLEX');
+        const inFooter = element => footerHeading && (footerHeading.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING);
+        const summaries = [...document.querySelectorAll('div')].filter(element => visible(element) && inFooter(element) && /^(YOU CLOCKED|.*BINGE CHAMPION|TOP GENRE THIS WEEK|TRENDING THIS WEEK)$/.test(element.textContent.trim())).map(heading => {
+          let value = heading.nextElementSibling;
+          if (value?.tagName === 'IMG') value = value.nextElementSibling;
+          return { heading:typography(heading), value:typography(value), support:value.nextElementSibling ? typography(value.nextElementSibling) : null };
+        });
+        const recap = [...document.querySelectorAll('.stats-title-cell div')].filter(visible).map(typography);
+        const labels = [...document.querySelectorAll('div')].filter(element => /^(MOVIES WATCHED|TV SHOWS WATCHED)$/.test(element.textContent.trim())).map(element => ({ ...typography(element), count:typography(element.previousElementSibling) }));
+        const rtIcons = [...document.querySelectorAll('.stats-title-cell img[alt^="Rotten Tomatoes"]')].filter(visible).map(rect);
+        const statsGrid = document.querySelector('.stats-summary-cell')?.closest('td.pad');
+        const statsPadding = statsGrid ? getComputedStyle(statsGrid).paddingBottom : null;
         return {
-          circles, badges,
+          circles, badges, summaries, recap, labels, rtIcons, statsPadding,
+          footerMarkers:[...document.querySelectorAll('.recipient-watched-title-icon,.recipient-watched-desktop-badge')].filter(inFooter).length,
           broken:[...document.images].filter(image => !image.naturalWidth).map(image => image.getAttribute('src')),
           overflow:document.documentElement.scrollWidth > innerWidth,
+          overflowElements:[...document.querySelectorAll('td,div,img')].filter(element => visible(element) && element.getBoundingClientRect().right > innerWidth + 1).slice(-12).map(element => ({ tag:element.tagName, text:element.textContent.trim().slice(0,70), ...rect(element) })),
         };
       });
       assert.equal(geometry.broken.length, 0, name + ': broken image reference');
+      if (geometry.overflow) {
+        await page.screenshot({ path:path.join(outputRoot, width + '-overflow.png'), fullPage:true });
+        console.error(JSON.stringify(geometry.overflowElements));
+      }
       assert.equal(geometry.overflow, false, name + ': horizontal overflow at ' + width);
+      assert.equal(geometry.footerMarkers, 0, name + ': footer watched marker');
+      for (const summary of geometry.summaries) {
+        assert.equal(summary.heading.size, '12px');
+        assert.equal(summary.heading.weight, '900');
+        assert.equal(summary.heading.letterSpacing, '1.1px');
+        assert.equal(summary.value.size, '27px');
+        assert.equal(summary.value.weight, '800');
+        assert(Math.abs(parseFloat(summary.value.lineHeight) - 29.7) < 0.01);
+        if (summary.support) {
+          assert.equal(summary.support.size, '12px');
+          assert.equal(summary.support.weight, '400');
+          assert(Math.abs(parseFloat(summary.support.lineHeight) - 16.2) < 0.01);
+        }
+      }
+      for (const text of geometry.recap) assert.equal(text.size, '12px', 'Recap/IMDb text size: ' + text.text);
+      for (const label of geometry.labels) {
+        assert.equal(label.size, '12px');
+        assert.equal(label.count.size, '18px');
+        assert.equal(label.count.weight, '800');
+        assert.equal(label.count.lineHeight, '18px');
+        if (label.text === 'TV SHOWS WATCHED') assert.equal(label.marginBottom, '-7px');
+      }
+      for (const icon of geometry.rtIcons) {
+        assert.equal(icon.width, 16);
+        assert.equal(icon.height, 16);
+      }
+      if (geometry.statsPadding !== null) {
+        assert.equal(geometry.statsPadding, '0px');
+        assert(geometry.summaries.length >= 2, 'Missing footer summary measurements.');
+      }
       for (const badge of geometry.badges) {
         assert.equal(width, 1280, 'Desktop badge leaked into mobile.');
         assert.equal(badge.width, 26);
@@ -96,16 +152,21 @@ try {
         assert.equal(badge.tooltip, 'Watched');
       }
       for (const circle of geometry.circles) {
-        assert.equal(circle.width, 20);
-        assert.equal(circle.height, 20);
-        assert.equal(circle.margin, '6px');
+        assert.equal(circle.width, 16);
+        assert.equal(circle.height, 16);
+        assert.equal(circle.margin, '8px');
         assert.equal(circle.align, 'middle');
         assert.equal(circle.alt, 'Watched');
         assert.equal(circle.tooltip, 'Watched');
-        assert(Math.abs(circle.gap-6) < 0.1, 'A wrapped title orphaned its icon or changed the 6px gap.');
+        assert(Math.abs(circle.gap-8) < 0.1, 'A wrapped title orphaned its icon or changed the 8px gap.');
         assert(Math.abs(circle.centerDelta) <= 1, 'The watched icon is not vertically centered with its title.');
       }
       results.push({ name, width, ...geometry });
+      const statsHeading = page.getByText('YOUR WEEK ON PLEX', { exact:true }).first();
+      if (await statsHeading.count()) {
+        const y = await statsHeading.evaluate(element => element.getBoundingClientRect().top + scrollY);
+        await page.screenshot({ path:path.join(outputRoot, width + '-' + name.replace('.html', '') + '-footer.png'), fullPage:true, clip:{ x:0, y, width, height:Math.min(1000, await page.evaluate(() => document.documentElement.scrollHeight) - y) } });
+      }
       if (name.includes('04-normal')) {
         await page.screenshot({ path:path.join(outputRoot, width + '-normal.png'), fullPage:true });
         await page.locator(width === 1280 ? '.design-hot-desktop' : '.design-hot-mobile').last().screenshot({ path:path.join(outputRoot, width + '-hero.png') });
@@ -116,7 +177,7 @@ try {
   }
   assert.equal(errors.length, 0, 'Browser errors: ' + errors.join('; '));
   await fs.writeFile(path.join(outputRoot, 'geometry.json'), JSON.stringify(results, null, 2));
-  console.log(JSON.stringify({ fixtures:names.length, viewports:3, pages:results.length, screenshots:outputRoot, circles:results.flatMap(result => result.circles.map(circle => ({ width:result.width, title:circle.title, gap:circle.gap, centerDelta:circle.centerDelta }))) }));
+  console.log(JSON.stringify({ fixtures:names.length, viewports:widths.length, pages:results.length, screenshots:outputRoot, circles:results.flatMap(result => result.circles.map(circle => ({ width:result.width, title:circle.title, gap:circle.gap, centerDelta:circle.centerDelta }))) }));
 } finally {
   await browser.close();
   await new Promise(resolve => server.close(resolve));

--- a/scripts/test-release-artifacts.ps1
+++ b/scripts/test-release-artifacts.ps1
@@ -130,11 +130,24 @@ function Assert-RendererContract([string]$PackageName, [string]$Renderer) {
     Assert-True ($Renderer.Contains('if ($rowUserId -ne $ExpectedUserId) { continue }')) "$PackageName does not fail closed on cross-user history rows."
     Assert-True ($Renderer.Contains('function Test-RecipientHasWatchedMovie') -and $Renderer.Contains('MetadataGuids.ContainsKey($metadataGuid)')) "$PackageName lacks exact movie key/GUID watched-state matching."
     Assert-True ($Renderer.Contains('function Get-RecipientWatchedTitleIconHtml') -and $Renderer.Contains('function Get-RecipientWatchedDesktopHeroPosterHtml')) "$PackageName lacks shared watched-marker rendering helpers."
-    Assert-True ($Renderer.Contains('width="20" height="20" alt="Watched" title="Watched"')) "$PackageName lacks accessible circular watched-icon markup."
-    Assert-True ($Renderer.Contains('vertical-align:middle;margin-left:6px;') -and $Renderer.Contains('function Get-RecipientWatchedTitleHtml') -and $Renderer.Contains('class="recipient-watched-title-tail" style="white-space:nowrap;"')) "$PackageName has inconsistent circular watched-icon centering, spacing, or wrapping."
+    Assert-True ($Renderer.Contains('width="16" height="16" alt="Watched" title="Watched"')) "$PackageName lacks accessible circular watched-icon markup."
+    Assert-True ($Renderer.Contains('vertical-align:middle;margin-left:8px;') -and $Renderer.Contains('function Get-RecipientWatchedTitleHtml') -and $Renderer.Contains('class="recipient-watched-title-tail" style="white-space:nowrap;"')) "$PackageName has inconsistent circular watched-icon centering, spacing, or wrapping."
     Assert-True ($Renderer.Contains('width="26" height="26" alt="Watched" title="Watched"') -and $Renderer.Contains('width="147" height="26"') -and $Renderer.Contains('width="7" height="26"') -and $Renderer.Contains('padding:5px 0 0;')) "$PackageName lacks the approved table-based desktop poster-badge placement."
     Assert-True ($Renderer.Contains('<v:group') -and $Renderer.Contains('coordsize="180,275"') -and $Renderer.Contains('left:147;top:0;width:26;height:26;')) "$PackageName lacks the fixed-coordinate Outlook poster-badge fallback."
     Assert-True ($Renderer.Contains('Cid = "recipient_watched"; MediaType = "image/png"') -and $Renderer.Contains('Cid = "recipient_watched_desktop"; MediaType = "image/png"')) "$PackageName does not MIME-link both watched assets."
+    Assert-True (-not $Renderer.Contains('$trendingTitleWithStatus') -and -not $Renderer.Contains('$trendWatchedSuffix')) "$PackageName marks compact footer Trending."
+    $recapSource = [regex]::Match($Renderer, '(?s)function Get-StatsMovieRowsHtml.*?(?=function Get-StatsTvShowRatingHtml)').Value
+    Assert-True ($recapSource.Length -gt 0 -and -not $recapSource.Contains('RecipientWatched')) "$PackageName marks personal footer movies."
+    foreach ($value in @('$timeText', '$(HtmlEncode $bingeTimeLine)', '$(HtmlEncode $topGenreName)', '$trendingDisplay')) {
+        $valueMatches = [regex]::Matches($Renderer, '<div style="([^"]+)">' + [regex]::Escape($value) + '</div>')
+        $expectedCount = if ($value -eq '$(HtmlEncode $bingeTimeLine)') { 2 } else { 1 }
+        Assert-True ($valueMatches.Count -eq $expectedCount) "$PackageName is missing a footer primary-value variant."
+        foreach ($valueMatch in $valueMatches) {
+            foreach ($style in @('font-size:27px;', 'font-weight:800;', 'line-height:1.1;')) {
+                Assert-True ($valueMatch.Groups[1].Value.Contains($style)) "$PackageName footer value lost $style"
+            }
+        }
+    }
     Assert-True ($Renderer.Contains('function Get-RecipientWatchedPlainTextSuffix')) "$PackageName lacks plain-text watched semantics."
 }
 

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -955,7 +955,7 @@ foreach ($relativePath in $rendererPaths) {
 
     $manyMovieRowsInput = @(1..12 | ForEach-Object {
         [PSCustomObject]@{
-            Title = "Uncapped Movie $($_.ToString('00'))"; PosterRatingKey = ''; Genres = @('Drama'); Seconds = (5400 * $_)
+            Title = "Uncapped Movie $($_.ToString('00'))"; PosterRatingKey = ''; Genres = @('Drama'); DesignGenres = @('Drama'); Seconds = (5400 * $_)
             DesignRtCritic = if ($_ -eq 1) { '91' } else { '' }
             DesignRtCriticImage = 'rottentomatoes://image.rating.ripe'
         }
@@ -975,6 +975,14 @@ foreach ($relativePath in $rendererPaths) {
     Assert-True (([regex]::Matches($manyTvRows, 'Uncapped Show \d{2}')).Count -eq 11) "$relativePath did not render every one of eleven personal TV rows"
     Assert-True ($manyTvRows.Contains('Uncapped Show 11') -and $manyTvRows.Contains('IMDb') -and $manyTvRows.Contains('8.4')) "$relativePath lost the final TV row or an eligible show rating"
     Assert-True (([regex]::Matches($manyTvRows, 'class="stats-title-cell stats-tv-title-cell stats-tv-title-(?:left|right)"')).Count -eq 11 -and ([regex]::Matches($manyTvRows, 'class="stats-title-spacer stats-tv-title-spacer"')).Count -eq 1) "$relativePath did not pair an odd TV count into two desktop/mobile columns with one safe spacer"
+
+    # Recap text uses the approved 12px sizes without changing each role's weight/leading.
+    Assert-True ($manyMovieRows.Contains('font-size:12px;line-height:1.3;color:#9b9b9b;font-weight:500;')) "$relativePath changed movie genre typography"
+    Assert-True ($manyMovieRows.Contains('font-size:12px;line-height:1.35;color:#e5a00d;font-weight:700;')) "$relativePath changed movie rating typography"
+    Assert-True ($manyTvRows.Contains('font-size:12px;line-height:1.35;color:#e5a00d;font-weight:700;">' + '<span style="display:inline-block;white-space:nowrap;"><img')) "$relativePath did not apply 12px to the TV IMDb number"
+    Assert-True ($manyTvRows.Contains('font-size:12px;line-height:1.35;color:#9b9b9b;font-weight:600;')) "$relativePath changed TV watch-duration typography"
+    Assert-True (-not ($manyMovieRows + $manyTvRows).Contains('recipient-watched')) "$relativePath marked a footer recap"
+    Assert-True (($preferredMovieStats -split 'width="16" height="16"').Count -eq 3) "$relativePath did not size both footer Rotten Tomatoes icons at 16px"
 
     $preferredShowStats = Get-StatsTvShowRatingHtml -Item $selectedProviderShow -ImageMode Preview
     Assert-True ($preferredShowStats.Contains('IMDb') -and $preferredShowStats.Contains('8.4') -and -not $preferredShowStats.Contains('%')) "$relativePath grouped TV stats did not prefer show-level IMDb over show-level RT"


### PR DESCRIPTION
## Summary

Prepare v0.21.2 from verified main/v0.21.1, preserving the v0.21.0 Quickstart feature spotlight.

- Display original watched circles at 16x16px with 8px left margin, vertical centering, accessible Watched labels, safe wrapping, and no unwatched gap. Main movie heroes/cards only; remove all footer markers. Keep original PNG hashes and 26x26 desktop shield placement.
- Match footer labels, recap titles/genres/ratings (explicitly including TV IMDb numbers), and TV duration at 12px; preserve role-specific weights/leading and 18px/800/1 counts. Footer RT icons display at 16px.
- Normalize all four primary footer values to exactly 27px/800/1.1, including Binge winner/non-winner/standalone. Headings use 12px/900/1.1px tracking; support uses 12px/400/1.35.
- Preserve deliberate stats padding 0px 20px 0px, TV label margin-bottom -7px, existing artwork/card dimensions, winner treatment, dynamic data, privacy, lifecycle behavior, and preheaders.
- Allow long compact Trending titles to wrap at 320px without shrinking the required typography or artwork.
- Add the user-approved risk-based validation policy to AGENTS.md; update focused tests, docs, release notes, and five package baselines. No CI redesign.

## Validation

Local focused watched-state/isolation, whole-footer/recap helper parity, PNG hash/type/dimension checks, renderer collection/recap tests, Binge privacy/ranking, Top Genre, and source package renderer contracts pass. Windows PowerShell 5.1 and PowerShell 7 were used where relevant. Repository/privacy, platform contracts, docs/link checks (93 files), PowerShell parse (80 files), JS syntax, and diff checks pass.

Three representative Windows integration scenarios passed: active, quiet, and optional-hero-metadata (Binge winner). These include lifecycle previews and localhost-only captured SMTP/CID/plain-text checks. After browser QA detected a 320px compact-title overflow, only the affected active scenario was regenerated; quiet/winner evidence was reused because their unchanged Trending-hero/Top-Genre path does not render that compact block.

18 browser pages pass: normal and standalone-quiet previews for active, quiet, and winner fixtures at 1280/390/320px. Computed text verifies 12px IMDb and all 27px/800/1.1 primary values; no footer markers, broken references, or horizontal overflow. Watched circles have exactly 8px gap and center error below 0.8px; desktop shields retain 26px/inset7/raised5. Synthetic screenshots were inspected. Original user references remain read-only and were never copied into public fixtures.

Required existing branch/PR/main/tag/release/container/Pages runs will be monitored, not manually duplicated. Full local baseline integration/privacy/package builds were intentionally not repeated; required CI retains those gates.

## Limitations and publication

Classic Outlook fallback is structurally checked, not natively certified. Watched state requires retained Tautulli history. Windows executables remain unsigned. No real Plex, Tautulli, SMTP endpoints, or real email were used.

Merge only at the validated head after required checks pass. Then publish the annotated tag from verified main and verify release packages/checksums, multi-architecture image tags/manifests, and Pages.
