### PR TITLE
fix: match main TV IMDb numbers at 12px (v0.21.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.21.3] - 2026-08-25
+
+### Fixed
+
+- Completed the 12px IMDb-number refinement in main TV cards: exact episode
+  scores and show-level fallback scores now match the 12px footer rating text.
+  Preserved weight 700, existing spacing, icon dimensions, rating selection,
+  and all other main-card typography. v0.21.2 had only updated footer recaps.
+- Extended existing renderer, visual, and package assertions to cover main TV
+  IMDb numbers as well as footer ratings.
+- Advanced source baselines to Windows 1.10.3, NAS/Docker 1.5.3, macOS 1.4.3,
+  native Linux 1.3.3, and FreeBSD/Podman 1.2.3. All v0.21.2 footer values,
+  marker placement, privacy, lifecycle behavior, and validation policy remain.
+
 ## [0.21.2] - 2026-08-25
 
 ### Fixed

--- a/docs/releases/v0.21.3.md
+++ b/docs/releases/v0.21.3.md
@@ -1,0 +1,28 @@
+# TautWeekly for Plex v0.21.3
+
+This immediate follow-up completes the IMDb-number refinement from v0.21.2.
+The earlier patch set footer TV recap ratings to 12px but left main TV card
+ratings at 11px.
+
+Main TV cards now display both exact episode IMDb scores and show-level IMDb
+fallback scores at **12px**, retaining weight 700, existing spacing and line
+height, and the original 28x14px IMDb icon. Other main-card typography and
+rating-selection behavior are unchanged.
+
+All v0.21.2 refinements remain: 16px watched circles with 8px spacing in main
+movie content only; unchanged 26px desktop shields; no footer watched markers;
+12px footer text; and all four primary footer values at 27px/800/1.1. The
+v0.21.0 Quickstart feature spotlight and risk-based validation policy remain.
+
+Focused existing tests cover both main TV IMDb paths across all maintained
+renderers. The visual check now measures every visible IMDb number in main
+content and footer recaps. Representative synthetic desktop/mobile QA and
+required CI/release gates are used; no duplicate full local baseline suite.
+
+Source baselines: Windows 1.10.3, NAS/Docker 1.5.3, macOS 1.4.3, native Linux
+1.3.3, and FreeBSD/Podman 1.2.3. No configuration migration is required.
+
+Classic Outlook remains structurally tested, not natively certified. Watched
+state requires retained Tautulli history. Windows executables are unsigned;
+verify downloaded packages against SHA256SUMS.txt. No real services or email
+delivery are used for validation.

--- a/platforms/freebsd-podman/CHANGELOG.txt
+++ b/platforms/freebsd-podman/CHANGELOG.txt
@@ -1,5 +1,9 @@
 TautWeekly for Plex FreeBSD Podman platform changelog
 
+v1.2.3
+- displays main TV episode IMDb numbers and show-level fallback IMDb numbers at 12px, matching footer rating text
+- preserves the existing score weight, icon dimensions, spacing, and all v0.21.2 footer/watched-marker refinements
+
 v1.2.2
 - refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values
 - displays unchanged watched circles at 16x16 with 8px spacing only in main movie content; preserves the 26x26 desktop shield

--- a/platforms/freebsd-podman/VERSION.txt
+++ b/platforms/freebsd-podman/VERSION.txt
@@ -1,2 +1,2 @@
-TautWeekly for Plex FreeBSD Podman platform source v1.2.2
+TautWeekly for Plex FreeBSD Podman platform source v1.2.3
 Repository releases use the repository-level semantic version and preserve this platform baseline in release metadata.

--- a/platforms/linux/CHANGELOG.txt
+++ b/platforms/linux/CHANGELOG.txt
@@ -1,5 +1,9 @@
 TautWeekly for Plex native Linux platform changelog
 
+v1.3.3
+- displays main TV episode IMDb numbers and show-level fallback IMDb numbers at 12px, matching footer rating text
+- preserves the existing score weight, icon dimensions, spacing, and all v0.21.2 footer/watched-marker refinements
+
 v1.3.2
 - refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values
 - displays unchanged watched circles at 16x16 with 8px spacing only in main movie content; preserves the 26x26 desktop shield

--- a/platforms/linux/VERSION.txt
+++ b/platforms/linux/VERSION.txt
@@ -1,2 +1,2 @@
-TautWeekly for Plex native Linux platform source v1.3.2
+TautWeekly for Plex native Linux platform source v1.3.3
 Repository releases use the repository-level semantic version and preserve this platform baseline in release metadata.

--- a/platforms/mac-docker/CHANGELOG.txt
+++ b/platforms/mac-docker/CHANGELOG.txt
@@ -1,6 +1,11 @@
 TAUTWEEKLY FOR PLEX MAC PORTABLE CHANGELOG
 ================================
 
+v1.4.3 Portable
+---------------
+- displays main TV episode IMDb numbers and show-level fallback IMDb numbers at 12px, matching footer rating text
+- preserves the existing score weight, icon dimensions, spacing, and all v0.21.2 footer/watched-marker refinements
+
 v1.4.2 Portable
 ---------------
 - refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values

--- a/platforms/mac-docker/VERSION.txt
+++ b/platforms/mac-docker/VERSION.txt
@@ -1,3 +1,3 @@
-TautWeekly for Plex Mac Portable v1.4.2
+TautWeekly for Plex Mac Portable v1.4.3
 Platform: macOS with Docker Desktop
 Feature: Authenticated macOS Manager

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -7469,7 +7469,7 @@ function Get-TvEpisodeLinesHtml {
         $ratingHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($imdb)) {
             $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "assets/imdb.png" }
-            $ratingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:11px;font-weight:700;white-space:nowrap;">' +
+            $ratingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:12px;font-weight:700;white-space:nowrap;">' +
             '<img src="' + $imdbSrc + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
             (HtmlEncode $imdb) +
             '</span>'
@@ -7619,7 +7619,7 @@ $genreHtml
                     $showImdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
                     if (-not [string]::IsNullOrWhiteSpace($showImdb)) {
                         $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
-                        $showRatingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:11px;font-weight:700;white-space:nowrap;">' +
+                        $showRatingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:12px;font-weight:700;white-space:nowrap;">' +
                             '<img src="' + $imdbSrc + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
                             (HtmlEncode $showImdb) +
                             '</span>'

--- a/platforms/nas-docker/CHANGELOG.txt
+++ b/platforms/nas-docker/CHANGELOG.txt
@@ -1,6 +1,11 @@
 TAUTWEEKLY FOR PLEX NAS PORTABLE CHANGELOG
 =================================
 
+v1.5.3 Portable
+---------------
+- displays main TV episode IMDb numbers and show-level fallback IMDb numbers at 12px, matching footer rating text
+- preserves the existing score weight, icon dimensions, spacing, and all v0.21.2 footer/watched-marker refinements
+
 v1.5.2 Portable
 ---------------
 - refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values

--- a/platforms/nas-docker/VERSION.txt
+++ b/platforms/nas-docker/VERSION.txt
@@ -1,3 +1,3 @@
-TautWeekly for Plex NAS Portable v1.5.2
+TautWeekly for Plex NAS Portable v1.5.3
 Platforms: QNAP, Unraid, Docker Desktop, generic Linux Docker
 Distribution: GHCR image, Unraid Community Apps template, and Docker Compose source

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -7470,7 +7470,7 @@ function Get-TvEpisodeLinesHtml {
         $ratingHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($imdb)) {
             $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "assets/imdb.png" }
-            $ratingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:11px;font-weight:700;white-space:nowrap;">' +
+            $ratingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:12px;font-weight:700;white-space:nowrap;">' +
             '<img src="' + $imdbSrc + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
             (HtmlEncode $imdb) +
             '</span>'
@@ -7620,7 +7620,7 @@ $genreHtml
                     $showImdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
                     if (-not [string]::IsNullOrWhiteSpace($showImdb)) {
                         $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
-                        $showRatingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:11px;font-weight:700;white-space:nowrap;">' +
+                        $showRatingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:12px;font-weight:700;white-space:nowrap;">' +
                             '<img src="' + $imdbSrc + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
                             (HtmlEncode $showImdb) +
                             '</span>'

--- a/platforms/windows/CHANGELOG.txt
+++ b/platforms/windows/CHANGELOG.txt
@@ -1,6 +1,11 @@
 TAUTWEEKLY FOR PLEX PORTABLE CHANGELOG
 ===============================
 
+v1.10.3 Windows
+---------------
+- displays main TV episode IMDb numbers and show-level fallback IMDb numbers at 12px, matching footer rating text
+- preserves the existing score weight, icon dimensions, spacing, and all v0.21.2 footer/watched-marker refinements
+
 v1.10.2 Windows
 ---------------
 - refines footer typography, including 12px IMDb scores and 27px/800/1.1 primary summary values

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -7421,7 +7421,7 @@ function Get-TvEpisodeLinesHtml {
         $ratingHtml = ""
         if (-not [string]::IsNullOrWhiteSpace($imdb)) {
             $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
-            $ratingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:11px;font-weight:700;white-space:nowrap;">' +
+            $ratingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:12px;font-weight:700;white-space:nowrap;">' +
             '<img src="' + $imdbSrc + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
             (HtmlEncode $imdb) +
             '</span>'
@@ -7571,7 +7571,7 @@ $genreHtml
                     $showImdb = Get-OptionalStringProperty -InputObject $item -Name "DesignImdbRating"
                     if (-not [string]::IsNullOrWhiteSpace($showImdb)) {
                         $imdbSrc = if ($ImageMode -eq "Email") { "cid:icon_imdb" } else { "../assets/imdb.png" }
-                        $showRatingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:11px;font-weight:700;white-space:nowrap;">' +
+                        $showRatingHtml = '<span style="display:inline-block;margin-left:8px;color:#e5a00d;font-size:12px;font-weight:700;white-space:nowrap;">' +
                             '<img src="' + $imdbSrc + '" alt="IMDb" width="28" height="14" style="display:inline-block;width:28px;height:14px;object-fit:contain;border:0;vertical-align:-3px;margin-right:5px;">' +
                             (HtmlEncode $showImdb) +
                             '</span>'

--- a/platforms/windows/VERSION.txt
+++ b/platforms/windows/VERSION.txt
@@ -1,3 +1,3 @@
-TautWeekly for Plex Windows v1.10.2
+TautWeekly for Plex Windows v1.10.3
 Platform: Windows PowerShell 5.1+
 Feature: One-click Setup EXE and local Manager

--- a/scripts/test-recipient-watched-movies.ps1
+++ b/scripts/test-recipient-watched-movies.ps1
@@ -185,8 +185,10 @@ foreach ($renderer in $renderers) {
     Assert-True ($watchedCard.Contains('vertical-align:middle;margin-left:8px;')) "$($renderer.Path) card spacing differs from hero spacing"
     $unwatchedCard = Get-ReleaseCardsHtml @($unwatched) @() Preview $state $renderer.PreviewBase Movie
     Assert-True (-not $unwatchedCard.Contains('recipient-watched-title-icon')) "$($renderer.Path) left watched markup in an unwatched card"
+    $tv | Add-Member -NotePropertyName DesignImdbRating -NotePropertyValue '8.4'
     $tvCard = Get-ReleaseCardsHtml @($tv) @() Preview $state $renderer.PreviewBase TV
     Assert-True (-not $tvCard.Contains('recipient-watched-title-icon')) "$($renderer.Path) changed TV card rendering"
+    Assert-True ($tvCard.Contains('alt="IMDb"') -and $tvCard.Contains('8.4') -and $tvCard.Contains('font-size:12px;font-weight:700;white-space:nowrap;')) "$($renderer.Path) main TV show-level IMDb fallback is not 12px"
 
     $statsRow = Get-StatsMovieRowsHtml @($watched) @() Preview
     Assert-True ($statsRow.Contains('>Watched Movie</div>') -and -not $statsRow.Contains('recipient-watched')) "$($renderer.Path) marked a personal movie recap"

--- a/scripts/test-recipient-watched-visuals.mjs
+++ b/scripts/test-recipient-watched-visuals.mjs
@@ -94,12 +94,13 @@ try {
           return { heading:typography(heading), value:typography(value), support:value.nextElementSibling ? typography(value.nextElementSibling) : null };
         });
         const recap = [...document.querySelectorAll('.stats-title-cell div')].filter(visible).map(typography);
+        const imdbRatings = [...document.querySelectorAll('img[alt="IMDb"]')].filter(visible).map(icon => typography(icon.parentElement));
         const labels = [...document.querySelectorAll('div')].filter(element => /^(MOVIES WATCHED|TV SHOWS WATCHED)$/.test(element.textContent.trim())).map(element => ({ ...typography(element), count:typography(element.previousElementSibling) }));
         const rtIcons = [...document.querySelectorAll('.stats-title-cell img[alt^="Rotten Tomatoes"]')].filter(visible).map(rect);
         const statsGrid = document.querySelector('.stats-summary-cell')?.closest('td.pad');
         const statsPadding = statsGrid ? getComputedStyle(statsGrid).paddingBottom : null;
         return {
-          circles, badges, summaries, recap, labels, rtIcons, statsPadding,
+          circles, badges, summaries, recap, imdbRatings, labels, rtIcons, statsPadding,
           footerMarkers:[...document.querySelectorAll('.recipient-watched-title-icon,.recipient-watched-desktop-badge')].filter(inFooter).length,
           broken:[...document.images].filter(image => !image.naturalWidth).map(image => image.getAttribute('src')),
           overflow:document.documentElement.scrollWidth > innerWidth,
@@ -127,6 +128,10 @@ try {
         }
       }
       for (const text of geometry.recap) assert.equal(text.size, '12px', 'Recap/IMDb text size: ' + text.text);
+      for (const rating of geometry.imdbRatings) {
+        assert.equal(rating.size, '12px', 'Main/footer IMDb number: ' + rating.text);
+        assert.equal(rating.weight, '700');
+      }
       for (const label of geometry.labels) {
         assert.equal(label.size, '12px');
         assert.equal(label.count.size, '18px');

--- a/scripts/test-release-artifacts.ps1
+++ b/scripts/test-release-artifacts.ps1
@@ -148,6 +148,7 @@ function Assert-RendererContract([string]$PackageName, [string]$Renderer) {
             }
         }
     }
+    Assert-True (([regex]::Matches($Renderer, 'margin-left:8px;color:#e5a00d;font-size:12px;font-weight:700;white-space:nowrap;')).Count -eq 2) "$PackageName does not size both main TV IMDb paths at 12px."
     Assert-True ($Renderer.Contains('function Get-RecipientWatchedPlainTextSuffix')) "$PackageName lacks plain-text watched semantics."
 }
 

--- a/scripts/test-renderer-collections.ps1
+++ b/scripts/test-renderer-collections.ps1
@@ -1102,6 +1102,7 @@ foreach ($relativePath in $rendererPaths) {
     Enrich-TvEpisodeMetadata -ReleaseData ([PSCustomObject]@{ TV = @($episodeShow) })
     Assert-True ($selectedProviderEpisode.ImdbRating -eq '8.6') "$relativePath let a selected TMDB score prevent exact-episode IMDb recovery"
     $episodeHtml = Get-TvEpisodeLinesHtml -Item $episodeShow -ImageMode Preview
+    Assert-True ($episodeHtml.Contains('font-size:12px;font-weight:700;white-space:nowrap;')) "$relativePath main TV episode IMDb number is not 12px"
     Assert-True ($episodeHtml.Contains('IMDb') -and $episodeHtml.Contains('8.6') -and -not $episodeHtml.Contains('Rotten Tomatoes') -and -not $episodeHtml.Contains('83%') -and -not $episodeHtml.Contains('TMDB') -and -not $episodeHtml.Contains('7.4')) "$relativePath did not keep exact-episode IMDb ahead of RT and generic providers"
 
     $sparseSeededEpisode = [PSCustomObject]@{


### PR DESCRIPTION
## Summary
Immediate completion of the v0.21.2 UI refinement: the main TV card IMDb number was still 11px. Set both exact-episode and show-level fallback numbers to 12px in all three renderers. Keep weight 700, 8px spacing, 28x14 IMDb artwork, rating selection, and other card typography unchanged.

Prepare v0.21.3 with platform patch baselines and release notes. Preserve the v0.21.0 feature spotlight, all v0.21.2 footer and watched-marker changes, and the risk-based AGENTS policy. Extend existing assertions for the two IMDb paths.

## Proportionate verification
- Extracted only the relevant production helpers; both paths pass in Preview and Email modes across Windows, NAS, and macOS, with normalized output parity.
- One synthetic preview at 1280px and 390px: both scores compute to 12px/700, margin 8px, icons 28x14, loaded artwork, no horizontal overflow. Inspected the mobile screenshot.
- Relative links (95 files), diff whitespace, and visual-script syntax pass.
- No full local baseline, integration regeneration, or duplicate manual CI run. Existing CI and release gates remain required and will be monitored.
- Synthetic data only; no real endpoints or email. Classic Outlook remains structurally tested, not natively certified; Windows binaries remain unsigned.

v0.21.2 is already published; this correction uses a new patch tag, without rewriting published history.