### PR TITLE
ci: optimize risk-based workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,144 +1,281 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: Validation scope for this diagnostic run.
+        required: true
+        default: auto
+        type: choice
+        options: [auto, fast, full]
 
 permissions:
+  actions: read
+  checks: read
   contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  repository-validation:
-    name: Repository, shell, JSON, and Compose
+  provenance:
+    name: Event and merge provenance
     runs-on: ubuntu-latest
+    outputs:
+      full_validation: ${{ steps.provenance.outputs.full_validation }}
+      trusted_merge: ${{ steps.provenance.outputs.trusted_merge }}
+    steps:
+      - name: Identify validation authority
+        id: provenance
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (context.eventName !== 'push' || context.ref !== 'refs/heads/main') {
+              core.setOutput('trusted_merge', 'false');
+              core.setOutput('full_validation', 'true');
+              await core.summary.addHeading('CI event provenance')
+                .addRaw(`${context.eventName} runs validate their selected change classes directly.`).write();
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+            const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: sha,
+            });
+            const pull = associated.data.find(candidate =>
+              candidate.merged_at &&
+              candidate.base.ref === context.payload.repository.default_branch &&
+              candidate.merge_commit_sha === sha
+            );
+            let trusted = false;
+            let reason = 'no merged pull request owns this exact main commit';
+            if (pull) {
+              const commit = await github.rest.repos.getCommit({ owner, repo, ref: sha });
+              const firstParent = commit.data.parents[0]?.sha;
+              const runs = await github.rest.actions.listWorkflowRunsForRepo({
+                owner, repo, event: 'pull_request', head_sha: pull.head.sha,
+                status: 'completed', per_page: 50,
+              });
+              const artifactName =
+                `ci-provenance-pr-${pull.number}-base-${firstParent}-head-${pull.head.sha}`;
+              let matchingRun;
+              if (pull.base.sha === firstParent) {
+                const candidates = runs.data.workflow_runs.filter(run =>
+                  run.name === 'CI' &&
+                  run.conclusion === 'success' &&
+                  run.head_branch === pull.head.ref &&
+                  run.head_sha === pull.head.sha &&
+                  run.head_repository?.full_name === pull.head.repo.full_name
+                );
+                for (const run of candidates) {
+                  const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                    owner, repo, run_id: run.id, per_page: 100,
+                  });
+                  if (artifacts.data.artifacts.some(artifact =>
+                    artifact.name === artifactName && !artifact.expired
+                  )) {
+                    matchingRun = run;
+                    break;
+                  }
+                }
+              }
+              if (!matchingRun) {
+                reason = pull.base.sha === firstParent
+                  ? 'no successful PR run has exact base/head provenance for this merge'
+                  : 'the merged pull-request base does not match the merge first parent';
+              } else {
+                const checks = await github.rest.checks.listForRef({
+                  owner, repo, ref: pull.head.sha, check_name: 'required',
+                  filter: 'latest', per_page: 100,
+                });
+                trusted = checks.data.check_runs.some(check =>
+                  check.conclusion === 'success' &&
+                  check.details_url?.includes(`/actions/runs/${matchingRun.id}/`)
+                );
+                reason = trusted
+                  ? `PR #${pull.number} has a successful CI / required check for the tested merge tree`
+                  : `PR #${pull.number} lacks a successful CI / required check on the matching run`;
+              }
+            }
+            core.setOutput('trusted_merge', trusted ? 'true' : 'false');
+            core.setOutput('full_validation', trusted ? 'false' : 'true');
+            await core.summary.addHeading('CI event provenance')
+              .addRaw(`${trusted ? 'Trusted merge' : 'Fail-closed main validation'}: ${reason}.`).write();
+
+  classify:
+    name: Change classifier
+    runs-on: ubuntu-latest
+    needs: provenance
+    outputs:
+      powershell: ${{ steps.changes.outputs.powershell }}
+      renderer: ${{ steps.changes.outputs.renderer }}
+      manager: ${{ steps.changes.outputs.manager }}
+      package: ${{ steps.changes.outputs.package }}
+      installer: ${{ steps.changes.outputs.installer }}
+      compose: ${{ steps.changes.outputs.compose }}
+      container: ${{ steps.changes.outputs.container }}
+      container_arm64: ${{ steps.changes.outputs.container_arm64 }}
+      pages: ${{ steps.changes.outputs.pages }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
         with:
-          go-version-file: manager/go.mod
-          cache-dependency-path: manager/go.mod
-      - name: Validate repository hygiene and JSON
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || github.sha }}
+          HEAD_SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_SCOPE: ${{ inputs.scope || 'auto' }}
+        run: |
+          base_sha="$BASE_SHA"
+          if test "$EVENT_NAME" = workflow_dispatch && test "$REQUESTED_SCOPE" = auto; then
+            base_sha="$(git rev-parse "${HEAD_SHA}^")"
+          fi
+          python3 scripts/ci_classifier.py \
+            --base "$base_sha" --head "$HEAD_SHA" --scope "$REQUESTED_SCOPE"
+
+  fast:
+    name: Fast repository contracts
+    runs-on: ubuntu-latest
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate repository hygiene, synchronization, and JSON
         shell: pwsh
         run: |
           ./scripts/validate-repository.ps1
           ./scripts/validate-branding.ps1
           ./scripts/validate-unraid-template.ps1
           ./scripts/validate-platforms.ps1
-      - name: Validate relative links
+      - name: Validate documentation and relative links
         shell: pwsh
-        run: ./scripts/check-links.ps1
-      - name: Validate documentation features and JavaScript
         run: |
-          pwsh ./scripts/validate-docs.ps1
+          ./scripts/check-links.ps1
+          ./scripts/validate-docs.ps1
+      - name: Validate JavaScript and Manager accessibility
+        run: |
           node --check docs/assets/site.js
           node --check docs/gui-preview/mock-api.js
           node --check docs/gui-preview/rich-preview.js
           node --check docs/gui-preview/update-ui.js
           node --check docs/gui-preview/app.js
+          node --check manager/internal/manager/web/update-ui.js
+          node --check manager/internal/manager/web/app.js
           node --check scripts/test-recipient-watched-visuals.mjs
           node scripts/test-gui-preview-personal-stats.mjs
           node scripts/test-manager-update-indicator.mjs
           node scripts/test-manager-header-refresh.mjs
           node scripts/test-manager-preview-refresh.mjs
           node scripts/test-manager-cache-verification.mjs
-      - name: Validate shell scripts
-        run: ./scripts/validate-shell.sh
-      - name: Test container health behavior
-        run: ./scripts/test-container-health.sh
-      - name: Test unified container profile selection
-        run: ./scripts/test-container-profiles.sh
-      - name: Test cross-platform command routing
-        run: ./scripts/test-platform-command-routing.sh
-      - name: Test bundled email assets and persistent refresh
+          python3 scripts/test-manager-accessibility.py
+      - name: Validate shell, PowerShell 7, and workflow syntax
         run: |
+          ./scripts/validate-shell.sh
+          pwsh ./scripts/validate-powershell.ps1
+          ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].each { |file| YAML.parse_file(file) }"
+      - name: Test fast runtime contracts and CI classifier fixtures
+        run: |
+          ./scripts/test-container-health.sh
+          ./scripts/test-container-profiles.sh
+          ./scripts/test-platform-command-routing.sh
+          ./scripts/test-update-management.sh
           python3 -B scripts/optimize-email-gifs.py --check
           python3 -B scripts/test-asset-refresh.py
-      - name: Test update detection and application guards
-        run: |
-          ./scripts/test-update-management.sh
-          pwsh ./scripts/test-update-checks.ps1
-      - name: Test scheduler timezone behavior
-        shell: pwsh
-        run: ./scripts/test-scheduler-timezone.ps1
-      - name: Test renderer collection and poster-probe behavior on Unix
-        shell: pwsh
-        run: ./scripts/test-renderer-collections.ps1
-      - name: Test recipient-specific movie watched markers on PowerShell 7
-        shell: pwsh
-        run: ./scripts/test-recipient-watched-movies.ps1
-      - name: Test bounded deleted-item cache on PowerShell 7
-        shell: pwsh
-        run: |
-          ./scripts/test-deleted-item-cache.ps1
-          ./scripts/test-cache-diagnostics.ps1
-      - name: Test rolling configuration-backup retention on PowerShell 7
-        shell: pwsh
-        run: ./scripts/test-config-backup-retention.ps1
-      - name: Test production recipient policy on PowerShell 7
-        shell: pwsh
-        run: ./scripts/test-sendall-recipient-policy.ps1 -PythonPath python3
-      - name: Test SMTP authentication protocol on PowerShell 7
-        run: python3 scripts/test-smtp-transport.py --helper platforms/nas-docker/app/Smtp-Transport.ps1
-      - name: Validate NAS Compose configuration
-        run: |
-          docker compose -f platforms/nas-docker/compose.yaml config --quiet
-          docker compose -f platforms/nas-docker/compose.qnap.yaml config --quiet
-      - name: Validate macOS Compose configuration
-        run: |
-          docker compose -f platforms/mac-docker/compose.yaml config --quiet
-          docker compose -f platforms/mac-docker/compose.registry.yaml config --quiet
-      - name: Build and boot-test the macOS Docker image
-        run: ./scripts/test-container-image.sh tautweekly-mac-ci platforms/mac-docker mac
+          python3 -B scripts/test_ci_classifier.py
 
-  powershell-syntax:
-    name: PowerShell syntax
+  fast-windows-powershell:
+    name: Fast Windows PowerShell syntax
     runs-on: windows-latest
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true'
     steps:
       - uses: actions/checkout@v6
-      - name: Parse all PowerShell source
+      - name: Parse all PowerShell source with Windows PowerShell
         shell: powershell
         run: .\scripts\validate-powershell.ps1
-      - name: Test adaptive renderer collection edges
-        shell: powershell
-        run: .\scripts\test-renderer-collections.ps1
-      - name: Test recipient-specific movie watched markers on Windows PowerShell
-        shell: powershell
-        run: .\scripts\test-recipient-watched-movies.ps1
-      - name: Test bounded deleted-item cache on Windows PowerShell
+
+  powershell-runtime-unix:
+    name: PowerShell runtime (PowerShell 7)
+    runs-on: ubuntu-latest
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.powershell == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test configuration, scheduling, and update runtime behavior
+        shell: pwsh
+        run: |
+          ./scripts/test-config-backup-retention.ps1
+          ./scripts/test-scheduler-timezone.ps1
+          ./scripts/test-update-checks.ps1
+
+  powershell-runtime-windows:
+    name: PowerShell runtime (Windows PowerShell)
+    runs-on: windows-latest
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.powershell == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test configuration, scheduling, and update runtime behavior
         shell: powershell
         run: |
+          .\scripts\test-config-backup-retention.ps1
+          .\scripts\test-scheduler-timezone.ps1
+          .\scripts\test-update-checks.ps1
+
+  renderer-unix:
+    name: Renderer privacy and portability (PowerShell 7)
+    runs-on: ubuntu-latest
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.renderer == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test cross-platform renderer, cache, recipient, and SMTP contracts
+        shell: pwsh
+        run: |
+          ./scripts/test-renderer-collections.ps1
+          ./scripts/test-recipient-watched-movies.ps1
+          ./scripts/test-deleted-item-cache.ps1
+          ./scripts/test-cache-diagnostics.ps1
+          ./scripts/test-sendall-recipient-policy.ps1 -PythonPath python3
+      - name: Test SMTP authentication protocol on PowerShell 7
+        run: python3 scripts/test-smtp-transport.py --helper platforms/nas-docker/app/Smtp-Transport.ps1
+
+  renderer-windows:
+    name: Full active/quiet renderer and privacy matrix
+    runs-on: windows-latest
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.renderer == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test renderer behavior and recipient isolation
+        shell: powershell
+        run: |
+          .\scripts\test-renderer-collections.ps1
+          .\scripts\test-recipient-watched-movies.ps1
           .\scripts\test-deleted-item-cache.ps1
           .\scripts\test-cache-diagnostics.ps1
-      - name: Test rolling configuration-backup retention on Windows PowerShell
-        shell: powershell
-        run: .\scripts\test-config-backup-retention.ps1
-      - name: Test user-exclusion selection
-        shell: powershell
-        run: .\scripts\test-user-exclusions.ps1
-      - name: Test Binge Champion privacy and ranking
-        shell: powershell
-        run: .\scripts\test-binge-champion.ps1
-      - name: Test Top Movie Genre aggregation, assets, and footer matrix
-        shell: powershell
-        run: .\scripts\test-top-movie-genre.ps1
-      - name: Test global library selection and renderer scope
-        shell: powershell
-        run: .\scripts\test-library-selection.ps1
-      - name: Test Windows stable update process and rollback behavior
-        shell: powershell
-        run: .\scripts\test-update-checks.ps1
-      - name: Test full active-week and quiet-week rendering
-        shell: powershell
-        run: .\scripts\test-newsletter-integration.ps1
-      - name: Test production recipient policy and zero-delivery evidence
-        shell: powershell
-        run: .\scripts\test-sendall-recipient-policy.ps1
+          .\scripts\test-user-exclusions.ps1
+          .\scripts\test-binge-champion.ps1
+          .\scripts\test-top-movie-genre.ps1
+          .\scripts\test-library-selection.ps1
+          .\scripts\test-newsletter-integration.ps1
+          .\scripts\test-sendall-recipient-policy.ps1
       - name: Test SMTP authentication protocol on Windows PowerShell
         run: python scripts/test-smtp-transport.py --helper platforms/windows/Smtp-Transport.ps1
 
-  manager-tests:
-    name: Local Manager (${{ matrix.os }})
+  manager:
+    name: Manager (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.manager == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -148,35 +285,22 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: manager/go.mod
-          cache-dependency-path: |
-            manager/go.mod
-            installer/go.mod
+          cache-dependency-path: manager/go.mod
       - name: Test and vet the Manager
         working-directory: manager
         run: |
           go test ./...
           go vet ./...
-      - name: Test and vet the Windows installer
-        working-directory: installer
-        run: |
-          go test ./...
-          go test -tags uninstaller ./...
-          go vet ./...
-          go vet -tags uninstaller ./...
-      - name: Cross-build the Manager for maintained targets
+      - name: Cross-build maintained Manager targets once
+        if: matrix.os == 'ubuntu-latest'
         shell: pwsh
         run: ./scripts/test-manager-cross-builds.ps1
-      - name: Validate embedded Manager JavaScript
-        run: |
-          node --check manager/internal/manager/web/update-ui.js
-          node --check manager/internal/manager/web/app.js
-      - name: Validate Manager accessibility structure
-        run: python scripts/test-manager-accessibility.py
 
-  release-archives:
-    name: Reproducible release archives
+  package:
+    name: Release package, checksums, and reproducibility
     runs-on: ubuntu-latest
-    needs: [repository-validation, powershell-syntax, manager-tests]
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.package == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -188,7 +312,7 @@ jobs:
       - name: Build archives and SHA-256 checksums
         shell: pwsh
         run: ./scripts/build-releases.ps1 -Version ci
-      - name: Test packaged runtime contracts and checksums
+      - name: Test package contracts and checksums
         shell: pwsh
         run: ./scripts/test-release-artifacts.ps1
       - name: Boot-test the packaged native Linux Manager
@@ -196,12 +320,10 @@ jobs:
       - name: Verify release archive reproducibility
         shell: pwsh
         run: ./scripts/test-release-reproducibility.ps1 -Version ci
-      - name: Test ZIP archives
-        run: for file in dist/*.zip; do unzip -t "$file"; done
-      - name: Test TAR.GZ archives
-        run: for file in dist/*.tar.gz; do tar -tzf "$file" >/dev/null; done
-      - name: Test launcher permissions
+      - name: Test archive integrity and launcher modes
         run: |
+          for file in dist/*.zip; do unzip -t "$file"; done
+          for file in dist/*.tar.gz; do tar -tzf "$file" >/dev/null; done
           test -x platforms/nas-docker/tautweekly.sh
           test -x platforms/nas-docker/app/bin/run-as-user.sh
           test -x platforms/nas-docker/app/bin/runtime-profile.sh
@@ -242,7 +364,7 @@ jobs:
           tar -tvzf dist/TautWeekly-freebsd-podman.tar.gz TautWeekly-freebsd-podman/app/bin/run-as-user.sh | grep -q '^-rwx'
           tar -tvzf dist/TautWeekly-freebsd-podman.tar.gz TautWeekly-freebsd-podman/app/bin/runtime-profile.sh | grep -q '^-rwx'
           tar -tvzf dist/TautWeekly-freebsd-podman.tar.gz TautWeekly-freebsd-podman/app/bin/run-script.sh | grep -q '^-rwx'
-      - name: Upload release candidates
+      - name: Upload release candidates for the installer gate
         uses: actions/upload-artifact@v4
         with:
           name: tautweekly-release-candidates
@@ -250,16 +372,166 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  windows-installer:
-    name: Windows one-click installer lifecycle
+  installer:
+    name: Windows installer lifecycle
     runs-on: windows-latest
-    needs: release-archives
+    needs: [provenance, classify, package]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.installer == 'true'
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: installer/go.mod
+          cache-dependency-path: installer/go.mod
+      - name: Test and vet installer sources
+        working-directory: installer
+        run: |
+          go test ./...
+          go test -tags uninstaller ./...
+          go vet ./...
+          go vet -tags uninstaller ./...
       - uses: actions/download-artifact@v4
         with:
           name: tautweekly-release-candidates
           path: dist
-      - name: Test isolated install, upgrade, icon, and uninstall lifecycle
+      - name: Test isolated install, upgrade, icon, rollback, and uninstall
         shell: powershell
         run: .\scripts\test-windows-installer.ps1
+
+  compose:
+    name: Compose and runtime-profile configuration
+    runs-on: ubuntu-latest
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.compose == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate Compose variants and profile refusal behavior
+        run: |
+          docker compose -f platforms/nas-docker/compose.yaml config --quiet
+          docker compose -f platforms/nas-docker/compose.qnap.yaml config --quiet
+          docker compose -f platforms/mac-docker/compose.yaml config --quiet
+          docker compose -f platforms/mac-docker/compose.registry.yaml config --quiet
+          ./scripts/test-container-profiles.sh
+
+  container-validation:
+    name: Container image validation
+    needs: [provenance, classify]
+    if: needs.provenance.outputs.full_validation == 'true' && needs.classify.outputs.container == 'true'
+    uses: ./.github/workflows/container.yml
+    with:
+      publish_mode: none
+      smoke_test: true
+      test_arm64: ${{ needs.classify.outputs.container_arm64 == 'true' }}
+    permissions:
+      contents: read
+
+  required:
+    name: required
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - provenance
+      - classify
+      - fast
+      - fast-windows-powershell
+      - powershell-runtime-unix
+      - powershell-runtime-windows
+      - renderer-unix
+      - renderer-windows
+      - manager
+      - package
+      - installer
+      - compose
+      - container-validation
+    steps:
+      - name: Require every selected gate
+        env:
+          FULL_VALIDATION: ${{ needs.provenance.outputs.full_validation }}
+          PROVENANCE_RESULT: ${{ needs.provenance.result }}
+          CLASSIFY_RESULT: ${{ needs.classify.result }}
+          FAST_RESULT: ${{ needs.fast.result }}
+          FAST_WINDOWS_RESULT: ${{ needs.fast-windows-powershell.result }}
+          POWERSHELL_SELECTED: ${{ needs.classify.outputs.powershell }}
+          POWERSHELL_UNIX_RESULT: ${{ needs.powershell-runtime-unix.result }}
+          POWERSHELL_WINDOWS_RESULT: ${{ needs.powershell-runtime-windows.result }}
+          RENDERER_SELECTED: ${{ needs.classify.outputs.renderer }}
+          RENDERER_UNIX_RESULT: ${{ needs.renderer-unix.result }}
+          RENDERER_WINDOWS_RESULT: ${{ needs.renderer-windows.result }}
+          MANAGER_SELECTED: ${{ needs.classify.outputs.manager }}
+          MANAGER_RESULT: ${{ needs.manager.result }}
+          PACKAGE_SELECTED: ${{ needs.classify.outputs.package }}
+          PACKAGE_RESULT: ${{ needs.package.result }}
+          INSTALLER_SELECTED: ${{ needs.classify.outputs.installer }}
+          INSTALLER_RESULT: ${{ needs.installer.result }}
+          COMPOSE_SELECTED: ${{ needs.classify.outputs.compose }}
+          COMPOSE_RESULT: ${{ needs.compose.result }}
+          CONTAINER_SELECTED: ${{ needs.classify.outputs.container }}
+          CONTAINER_RESULT: ${{ needs.container-validation.result }}
+        run: |
+          test "$PROVENANCE_RESULT" = success
+          test "$CLASSIFY_RESULT" = success
+          if test "$FULL_VALIDATION" = true; then
+            test "$FAST_RESULT" = success
+            test "$FAST_WINDOWS_RESULT" = success
+          fi
+          require_selected() {
+            selected="$1"; result="$2"; gate="$3"
+            if test "$FULL_VALIDATION" = true && test "$selected" = true && test "$result" != success; then
+              echo "Selected gate failed or did not run: $gate ($result)" >&2
+              exit 1
+            fi
+          }
+          require_selected "$POWERSHELL_SELECTED" "$POWERSHELL_UNIX_RESULT" powershell-unix
+          require_selected "$POWERSHELL_SELECTED" "$POWERSHELL_WINDOWS_RESULT" powershell-windows
+          require_selected "$RENDERER_SELECTED" "$RENDERER_UNIX_RESULT" renderer-unix
+          require_selected "$RENDERER_SELECTED" "$RENDERER_WINDOWS_RESULT" renderer-windows
+          require_selected "$MANAGER_SELECTED" "$MANAGER_RESULT" manager
+          require_selected "$PACKAGE_SELECTED" "$PACKAGE_RESULT" package
+          require_selected "$INSTALLER_SELECTED" "$INSTALLER_RESULT" installer
+          require_selected "$COMPOSE_SELECTED" "$COMPOSE_RESULT" compose
+          require_selected "$CONTAINER_SELECTED" "$CONTAINER_RESULT" container
+      - name: Materialize exact PR base/head provenance
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          printf 'pull_request=%s\nbase_sha=%s\nhead_sha=%s\n' \
+            "$PR_NUMBER" "$BASE_SHA" "$HEAD_SHA" > ci-provenance.txt
+      - name: Record exact PR base/head provenance
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-provenance-pr-${{ github.event.pull_request.number }}-base-${{ github.event.pull_request.base.sha }}-head-${{ github.event.pull_request.head.sha }}
+          path: ci-provenance.txt
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-edge-container:
+    name: Publish verified edge container
+    needs: [provenance, classify, required]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.classify.outputs.container == 'true'
+    uses: ./.github/workflows/container.yml
+    with:
+      publish_mode: edge
+      smoke_test: false
+      test_arm64: false
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+  deploy-pages:
+    name: Deploy verified Pages
+    needs: [provenance, classify, required]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.classify.outputs.pages == 'true'
+    uses: ./.github/workflows/pages.yml
+    with:
+      validate: false
+    permissions:
+      contents: read
+      pages: write
+      id-token: write

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,54 +1,57 @@
 name: Container
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'platforms/nas-docker/**'
-      - 'platforms/mac-docker/**'
-      - 'manager/**'
-      - 'templates/**'
-      - 'ca_profile.xml'
-      - 'scripts/test-container-image.sh'
-      - 'scripts/test-container-profiles.sh'
-      - '.github/workflows/container.yml'
-  pull_request:
-    paths:
-      - 'platforms/nas-docker/**'
-      - 'platforms/mac-docker/**'
-      - 'manager/**'
-      - 'templates/**'
-      - 'ca_profile.xml'
-      - 'scripts/test-container-image.sh'
-      - 'scripts/test-container-profiles.sh'
-      - '.github/workflows/container.yml'
-      - '.github/workflows/release.yml'
   workflow_call:
     inputs:
       release_tag:
-        description: Full release tag whose unified image must publish before the release.
-        required: true
+        description: Full release tag for a release publication.
+        required: false
+        default: ''
         type: string
+      publish_mode:
+        description: Publication target (none, edge, or release).
+        required: false
+        default: none
+        type: string
+      smoke_test:
+        description: Build and boot-test the amd64 image and all runtime profiles.
+        required: false
+        default: true
+        type: boolean
+      test_arm64:
+        description: Build and boot-test arm64 through QEMU.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
+    inputs:
+      smoke_test:
+        description: Build and boot-test the amd64 image and all runtime profiles.
+        required: true
+        default: true
+        type: boolean
+      test_arm64:
+        description: Build and boot-test arm64 through QEMU.
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   unified:
-    name: Unified image (amd64 and arm64)
+    name: Unified image validation and publication
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Set up QEMU
+        if: inputs.test_arm64 || inputs.publish_mode == 'edge' || inputs.publish_mode == 'release'
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Validate runtime profile selection and refusal
+        if: inputs.smoke_test
         run: ./scripts/test-container-profiles.sh
       - name: Build amd64 smoke image
+        if: inputs.smoke_test
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -59,11 +62,13 @@ jobs:
           build-args: BUILD_VERSION=ci
           cache-from: type=gha,scope=unified
       - name: Boot-test every unified profile on amd64
+        if: inputs.smoke_test
         run: |
           ./scripts/test-container-image.sh tautweekly-unified-ci:amd64 '' server
           ./scripts/test-container-image.sh tautweekly-unified-ci:amd64 '' desktop
           ./scripts/test-container-image.sh tautweekly-unified-ci:amd64 '' unraid
       - name: Build arm64 smoke image through QEMU
+        if: inputs.smoke_test && inputs.test_arm64
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -74,32 +79,35 @@ jobs:
           build-args: BUILD_VERSION=ci
           cache-from: type=gha,scope=unified
       - name: Boot-test the unified arm64 runtime through QEMU
+        if: inputs.smoke_test && inputs.test_arm64
         run: ./scripts/test-container-image.sh tautweekly-unified-ci:arm64 '' server
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request' && (inputs.release_tag != '' || github.ref == 'refs/heads/main')
+        if: inputs.publish_mode == 'edge' || inputs.publish_mode == 'release'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate unified image metadata
+        if: inputs.publish_mode == 'edge' || inputs.publish_mode == 'release'
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/sparkmoxie/tautweekly
           flavor: latest=false
           tags: |
-            type=raw,value=edge,enable=${{ inputs.release_tag == '' && github.ref == 'refs/heads/main' }}
-            type=semver,pattern={{version}},value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
-            type=raw,value=latest,enable=${{ inputs.release_tag != '' }}
+            type=raw,value=edge,enable=${{ inputs.publish_mode == 'edge' }}
+            type=semver,pattern={{version}},value=${{ inputs.release_tag }},enable=${{ inputs.publish_mode == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release_tag }},enable=${{ inputs.publish_mode == 'release' }}
+            type=raw,value=latest,enable=${{ inputs.publish_mode == 'release' }}
       - name: Build and publish the unified image
+        if: inputs.publish_mode == 'edge' || inputs.publish_mode == 'release'
         uses: docker/build-push-action@v7
         with:
           context: .
           file: platforms/nas-docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' && (inputs.release_tag != '' || github.ref == 'refs/heads/main') }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: BUILD_VERSION=${{ steps.meta.outputs.version }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,13 +1,13 @@
 name: Pages
 
 on:
-  push:
-    branches:
-      - main
-      - public-launch
-    paths:
-      - 'docs/**'
-      - '.github/workflows/pages.yml'
+  workflow_call:
+    inputs:
+      validate:
+        description: Re-run documentation validation before deployment.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
 
 permissions:
@@ -21,14 +21,14 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.ref_name == github.event.repository.default_branch
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Validate documentation links
+      - name: Validate documentation links for a manual deployment
+        if: github.event_name == 'workflow_dispatch' || inputs.validate
         shell: pwsh
         run: |
           ./scripts/validate-branding.ps1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,28 +6,71 @@ on:
       - 'v*.*.*'
 
 permissions:
+  actions: read
+  checks: read
   contents: write
   packages: write
   attestations: write
   id-token: write
 
 jobs:
-  container-images:
-    name: Publish unified release container image
-    needs: [build, windows-installer]
-    uses: ./.github/workflows/container.yml
-    with:
-      release_tag: ${{ github.ref_name }}
-    secrets: inherit
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
+  preflight:
+    name: Release history, version, and CI provenance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Require the release tag on current main history
+        run: |
+          git fetch origin main --no-tags
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - name: Require matching versions and release notes
+        shell: pwsh
+        run: |
+          $version = $env:GITHUB_REF_NAME -replace '^v', ''
+          if ($env:GITHUB_REF_NAME -notmatch '^v\d+\.\d+\.\d+$') {
+              throw "Release tags must use vMAJOR.MINOR.PATCH."
+          }
+          $versionFiles = @(Get-ChildItem -LiteralPath platforms -Filter VERSION.txt -Recurse)
+          if ($versionFiles.Count -eq 0) {
+              throw 'No platform VERSION.txt files were found.'
+          }
+          foreach ($file in $versionFiles) {
+              if ((Get-Content -LiteralPath $file.FullName -Raw).Trim() -ne $version) {
+                  throw "$($file.FullName) does not match $version."
+              }
+          }
+          if (-not (Test-Path -LiteralPath "docs/releases/$($env:GITHUB_REF_NAME).md" -PathType Leaf)) {
+              throw "Release notes are missing for $($env:GITHUB_REF_NAME)."
+          }
+          $changelog = Get-Content -LiteralPath CHANGELOG.md -Raw
+          if ($changelog -notmatch "(?m)^## \[$([regex]::Escape($version))\]") {
+              throw "CHANGELOG.md has no $version section."
+          }
+      - name: Require the exact tagged commit to have green CI provenance
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const checks = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref: context.sha,
+              check_name: 'required',
+              filter: 'latest',
+              per_page: 100,
+            });
+            const green = checks.data.check_runs.some(check =>
+              check.conclusion === 'success' &&
+              check.details_url?.includes('/actions/runs/')
+            );
+            if (!green) {
+              core.setFailed(`The tagged commit ${context.sha} has no successful CI / required check.`);
+            }
 
   build:
     name: Build and validate release candidates
     runs-on: ubuntu-latest
+    needs: preflight
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -36,69 +79,7 @@ jobs:
           cache-dependency-path: |
             manager/go.mod
             installer/go.mod
-      - name: Test and vet the Manager
-        working-directory: manager
-        run: |
-          go test ./...
-          go vet ./...
-      - name: Test and vet the Windows installer
-        working-directory: installer
-        run: |
-          go test ./...
-          go test -tags uninstaller ./...
-          go vet ./...
-          go vet -tags uninstaller ./...
-      - name: Cross-build the Manager for maintained targets
-        shell: pwsh
-        run: ./scripts/test-manager-cross-builds.ps1
-      - name: Validate embedded Manager JavaScript
-        run: |
-          node --check manager/internal/manager/web/app.js
-          node --check scripts/test-recipient-watched-visuals.mjs
-          node scripts/test-manager-header-refresh.mjs
-          node scripts/test-manager-preview-refresh.mjs
-          node scripts/test-manager-cache-verification.mjs
-      - name: Validate Manager accessibility structure
-        run: python scripts/test-manager-accessibility.py
-      - name: Test synthetic GUI preview personal statistics
-        run: node scripts/test-gui-preview-personal-stats.mjs
-      - name: Validate repository
-        shell: pwsh
-        run: |
-          ./scripts/validate-repository.ps1
-          ./scripts/validate-branding.ps1
-          ./scripts/validate-unraid-template.ps1
-          ./scripts/validate-platforms.ps1
-          ./scripts/check-links.ps1
-          ./scripts/validate-docs.ps1
-          ./scripts/validate-powershell.ps1
-          ./scripts/test-deleted-item-cache.ps1
-          ./scripts/test-cache-diagnostics.ps1
-          ./scripts/test-config-backup-retention.ps1
-          ./scripts/test-renderer-collections.ps1
-          ./scripts/test-recipient-watched-movies.ps1
-          ./scripts/test-sendall-recipient-policy.ps1
-      - name: Validate shell scripts
-        run: ./scripts/validate-shell.sh
-      - name: Test scheduler timezone behavior
-        shell: pwsh
-        run: ./scripts/test-scheduler-timezone.ps1
-      - name: Test bundled email assets and persistent refresh
-        run: |
-          python3 -B scripts/optimize-email-gifs.py --check
-          python3 -B scripts/test-asset-refresh.py
-      - name: Test update detection and application guards
-        run: |
-          ./scripts/test-container-profiles.sh
-          ./scripts/test-update-management.sh
-          pwsh ./scripts/test-update-checks.ps1
-      - name: Validate Compose files
-        run: |
-          docker compose -f platforms/nas-docker/compose.yaml config --quiet
-          docker compose -f platforms/nas-docker/compose.qnap.yaml config --quiet
-          docker compose -f platforms/mac-docker/compose.yaml config --quiet
-          docker compose -f platforms/mac-docker/compose.registry.yaml config --quiet
-      - name: Build release archives and checksums
+      - name: Build release archives and checksums once
         shell: pwsh
         run: ./scripts/build-releases.ps1
       - name: Test packaged runtime contracts and checksums
@@ -109,8 +90,10 @@ jobs:
       - name: Verify release archive reproducibility
         shell: pwsh
         run: ./scripts/test-release-reproducibility.ps1 -Version ($env:GITHUB_REF_NAME -replace '^v','')
-      - name: Test launcher permissions
+      - name: Test archive integrity and launcher permissions
         run: |
+          for file in dist/*.zip; do unzip -t "$file"; done
+          for file in dist/*.tar.gz; do tar -tzf "$file" >/dev/null; done
           tar -tvzf dist/TautWeekly-nas-docker.tar.gz TautWeekly-nas-docker/tautweekly.sh | grep -q '^-rwx'
           tar -tvzf dist/TautWeekly-nas-docker.tar.gz TautWeekly-nas-docker/app/bin/run-as-user.sh | grep -q '^-rwx'
           tar -tvzf dist/TautWeekly-nas-docker.tar.gz TautWeekly-nas-docker/app/bin/runtime-profile.sh | grep -q '^-rwx'
@@ -156,6 +139,22 @@ jobs:
         shell: powershell
         run: .\scripts\test-windows-installer.ps1
 
+  container-images:
+    name: Publish unified release container image
+    needs: [build, windows-installer]
+    uses: ./.github/workflows/container.yml
+    with:
+      release_tag: ${{ github.ref_name }}
+      publish_mode: release
+      smoke_test: true
+      test_arm64: true
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
   publish:
     name: Publish verified release
     runs-on: ubuntu-latest
@@ -171,8 +170,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           notes_file="docs/releases/${GITHUB_REF_NAME}.md"
-          if test -f "$notes_file"; then
-            gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --notes-file "$notes_file" --title "TautWeekly for Plex $GITHUB_REF_NAME"
-          else
-            gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --generate-notes --title "TautWeekly for Plex $GITHUB_REF_NAME"
-          fi
+          gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --notes-file "$notes_file" --title "TautWeekly for Plex $GITHUB_REF_NAME"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,25 +42,35 @@ These instructions apply to the entire repository.
 
 ## Optimized CI trigger matrix
 
-This section is the target policy for a future workflow change, not a description of the workflows currently implemented in .github/workflows. Reinspect the current workflows, required checks or rulesets, and recent Actions history before implementing it. Preserve the intent of the matrix if job names or scripts have since changed.
+This section describes the implemented risk-based policy in `.github/workflows`.
+Reinspect the current workflows, required checks or rulesets, and recent Actions
+history before changing it. Keep `scripts/ci_classifier.py` and its positive and
+negative fixtures synchronized with workflow, build, packaging, and test inputs.
 
 ### Evidence and current behavior
 
 - The baseline audit was performed against v0.23.1 / 06fba2372e45ab88fe63a58736b98b82a42f1b55 on 2026-08-27. At that point ci.yml used unfiltered push and pull_request triggers, so the same feature-branch commit ran the complete CI workflow twice once a pull request existed. The workflow also ran the complete matrix again on main and on release tags.
 - PRs #161 and #162 each produced both a six-job branch-push CI run and a six-job pull-request CI run for the identical head SHA. Their full active-week and quiet-week rendering steps took 12.4 and 13.4 minutes in the PR runs; the complete duplicate runs took 16-24 minutes. Each merge then produced another approximately 20-minute full main CI run.
 - The v0.23.1 tag produced an 18.2-minute generic CI run in parallel with the 18.3-minute Release workflow. The tag CI repeated PowerShell, rendering, archive, and installer checks even though Release built and validated the artifacts, tested the installer, built and boot-tested both container architectures, and published only after those jobs passed.
+- The final v0.24.0 maintenance PR repeated its exact head SHA in a 19.2-minute
+  branch-push CI run and a 21.4-minute pull-request CI run. The latter spent
+  14 minutes 27 seconds in the full active-week and quiet-week render step.
+  Merging then launched another 20.7-minute generic main CI run, and tagging the
+  same merge commit launched a 21-minute generic CI run beside the 19.3-minute
+  Release workflow. The optimized triggers eliminate the feature-branch and tag
+  copies and make a verified merge run provenance-only.
 - At the audit point GitHub reported no classic branch protection on main and no repository rulesets. Do not infer that this remains true. Before changing check names or triggers, query both protection mechanisms and inventory any required status contexts.
 - test-newsletter-integration.ps1 copies and exercises the Windows, NAS/Linux/FreeBSD, and Mac renderer payloads across active, quiet, and additional edge scenarios. build-releases.ps1 packages the complete platform trees and platform guides, builds Manager and installer binaries, normalizes archives, and emits checksums. These direct dependencies are the basis for the path classes below; keep the classifier synchronized when either script changes.
 
-### Target event policy
+### Implemented event policy
 
 | Event | Always present | Conditional work | Work intentionally omitted |
 | --- | --- | --- | --- |
-| Feature-branch push | No automatic full validation. Developers may use a manual diagnostic dispatch before opening a PR. | None by default. Once a PR exists, pull_request is the authoritative validation event. | Do not run a second full branch-push matrix for the same SHA. |
+| Feature-branch push | No automatic CI workflow. Developers may use a manual `auto`, `fast`, or `full` diagnostic dispatch before opening a PR. | None by default. Once a PR exists, `pull_request` is the authoritative validation event. | Do not run a second full branch-push matrix for the same SHA. |
 | Pull request | Run an unfiltered change-classifier job, the fast PR layer, and one stable aggregate check named CI / required. | Run the path-classified PowerShell/runtime, render, Manager, package, installer, Compose, and container-image gates below. | Do not publish Pages, containers, archives, or releases. |
-| Push to main after a green PR | Run a short merge-integrity/provenance check and the stable aggregate. Require PRs to be current with main so the tested PR merge tree is the tree that lands. | Deploy Pages for documentation inputs and publish the edge container for container-image inputs. Perform only deployment-specific verification not already proven by the PR SHA/tree. | Do not blindly replay the full PR matrix, full render matrix, release archives, or installer lifecycle. |
+| Push to main after a green PR | Verify the exact merge commit, PR head, tested first parent, short-lived exact base/head provenance artifact, and successful `CI / required` run, then run the stable aggregate. Require PRs to be current with main so the tested PR merge tree is the tree that lands. | Deploy Pages for documentation inputs and publish the edge container for container-image inputs, after the aggregate. Perform only deployment-specific work not already proven by the PR tree. | Do not blindly replay the full PR matrix, full render matrix, release archives, or installer lifecycle. |
 | Direct or otherwise unverified push to main | Detect the lack of a green associated PR and fail closed. | Run the same path-classified gates that a PR would have required before any deployment or publication. | Do not treat an unprotected direct push as if it inherited PR evidence. |
-| Release tag v*.*.* | Run a release preflight that proves the tag is on the intended main history, version/release notes agree, and the underlying tree has green CI provenance. | Build the final archives once; validate checksums, payload contracts, launcher modes, native Linux package, and reproducibility; test the generated Windows installer; build and boot-test the release container architectures; publish attestations, containers, artifacts, and the GitHub Release only after all gates pass. | Do not trigger generic CI or the source-render matrix merely because a tag was pushed. Do not build the same release candidates in both CI and Release. |
+| Release tag `v*.*.*` | Run a release preflight that proves the tag is on main history, every platform version and the release notes agree, and the exact tagged commit has green `CI / required` provenance. | Build the final archives once; validate checksums, payload contracts, launcher modes, native Linux startup, and reproducibility; test the generated Windows installer; build and boot-test both release container architectures; publish attestations, containers, artifacts, and the GitHub Release only after all gates pass. | Generic CI does not trigger for tags, and Release does not repeat the source-render or generic repository matrix. |
 | Manual dispatch | Always identify the selected commit and report which classifier outputs and gates were requested. | Permit focused diagnostics or an explicit full audit. | A manual run does not replace a required PR result unless it tests the exact required commit/tree and repository policy explicitly accepts its stable aggregate context. |
 
 Keep the required PR workflow itself free of workflow-level paths filters. The classifier, fast layer, and aggregate must start for every PR; apply path conditions to jobs or reusable calls. Otherwise an intentionally unmatched workflow may never create its required check and can leave branch protection pending.
@@ -73,7 +83,7 @@ The path notation below is descriptive shorthand; expand it explicitly in the cl
 | --- | --- | --- |
 | Fast PR layer | Every PR, including Markdown- and AGENTS.md-only changes. | Repository privacy/hygiene and JSON checks; branding, platform-copy, Unraid, and GUI synchronization contracts; docs validation and relative links; shell, JavaScript, Python, JSON/YAML, and PowerShell syntax; Manager accessibility; plus cheap unit checks applicable to the changed files. This layer must remain fast and must not build release archives, installers, or container images. |
 | PowerShell/runtime | Maintained platforms/**/*.ps1 runtime or setup code; PowerShell validators/tests and their fixtures; templates or configuration contracts consumed by that code. | Parse under the maintained Windows PowerShell and PowerShell 7 engines and run the relevant cross-platform runtime/unit suites. Exclude the full newsletter render gate unless the render class also matches. |
-| Full renderer | Any maintained TautWeekly.ps1; renderer-loaded SMTP, operation-lock, deleted-item-cache, or cache-diagnostic runtime; newsletter templates or local email assets; renderer fixture/assertion helpers; render, recipient-isolation, library/user-selection, cache, MIME/SMTP, or presentation tests; or packaging logic that can change which renderer/runtime/template/asset bytes enter an artifact. | Run the complete active-week and quiet-week render matrix on the maintained Windows and container engines, together with the privacy/isolation assertions. A guide, license, or other package-only text input does not select this gate merely because it is included in an archive. |
+| Full renderer | Any maintained `TautWeekly.ps1`; renderer-loaded SMTP, operation-lock, deleted-item-cache, or cache-diagnostic runtime; newsletter templates or local email assets; renderer fixture/assertion helpers; render, recipient-isolation, library/user-selection, cache, MIME/SMTP, or presentation tests; or packaging logic that can change which renderer/runtime/template/asset bytes enter an artifact. | Run the complete active-week and quiet-week matrix once under Windows PowerShell across the maintained Windows and container payloads, plus the PowerShell 7 portability, cache, SMTP, and recipient-isolation assertions. A guide, license, or other package-only text input does not select this gate merely because it is included in an archive. |
 | Manager | manager/**, mirrored Manager or GUI-preview web assets, Manager Go tests, GUI synchronization, accessibility, update-indicator/header/preview tests, or Manager cross-build logic. | Run Go test/vet, embedded JavaScript checks, GUI parity/accessibility tests, and maintained-target cross-builds. Avoid repeating the same cross-build on both runner operating systems unless the OS itself is under test. |
 | Release package | platforms/** files copied into a release; manager/**; installer/**; the five packaged platform README files; LICENSE; THIRD_PARTY_NOTICES.md; release builder, artifact-contract, reproducibility, native-Linux-package, archive-mode, or checksum logic. | Build candidates once, then test exact manifests/payload contracts, archive integrity and executable modes, checksums, native Linux startup, and reproducibility. Upload a short-lived candidate only when a downstream selected gate needs it. |
 | Windows installer | installer/**; any Windows release-payload input; Manager Windows binary/resource inputs; installer build/test logic. | Consume the selected package candidate and test isolated install, upgrade, icon/identity, rollback where applicable, and uninstall. Do not run for packages that cannot change the Windows payload or installer. |
@@ -89,6 +99,18 @@ Keep path classification conservative around shared inputs. In particular, the c
 - Run the aggregate with if: always() and make it depend on the classifier, fast layer, and every conditional gate. It must succeed only when the classifier and fast layer succeeded and every selected gate succeeded. A conditional gate may be skipped only when the classifier explicitly marked it unnecessary; cancellation, failure, or a missing selected result fails the aggregate.
 - Keep job/check names stable or migrate repository protection atomically with a workflow rename. Validate the skipped-job cases on a docs-only PR and the selected-job cases on representative PowerShell, renderer, package, installer, and container changes before making the aggregate required.
 - Use concurrency cancellation keyed to the PR number for superseded PR runs, but never let a cancelled latest run satisfy the aggregate. Reuse successful outputs and artifacts within the same SHA/tree instead of rebuilding them in downstream jobs.
+
+### Workflow implementation map
+
+| Responsibility | Implementation |
+| --- | --- |
+| Event authority and merge provenance | `.github/workflows/ci.yml` jobs `provenance` and `classify` |
+| Conservative path classification | `scripts/ci_classifier.py`; unknown executable, build, workflow, or test inputs fail closed |
+| Classifier regression coverage | `scripts/test_ci_classifier.py` positive and negative fixtures |
+| Stable protection context | `CI / required`, produced by the `required` job with `if: always()` |
+| PR container validation and main edge publication | Reusable `.github/workflows/container.yml`, called in validation-only or publication-only mode |
+| Pages publication | Reusable `.github/workflows/pages.yml`, called only after `CI / required` succeeds on main |
+| Tagged publication | `.github/workflows/release.yml` preflight, single candidate build, installer lifecycle, multiarch container publication, and final release job |
 
 ## Local asset optimization before deployment
 

--- a/scripts/ci_classifier.py
+++ b/scripts/ci_classifier.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Conservatively map changed repository paths to CI risk gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+
+GATES = (
+    "powershell",
+    "renderer",
+    "manager",
+    "package",
+    "installer",
+    "compose",
+    "container",
+    "container_arm64",
+    "pages",
+)
+
+ALL_VALIDATION_GATES = GATES[:-1]
+
+FAST_ONLY_SCRIPTS = {
+    "scripts/check-links.ps1",
+    "scripts/optimize-email-gifs.py",
+    "scripts/test-asset-refresh.py",
+    "scripts/test-gui-preview-personal-stats.mjs",
+    "scripts/test-manager-accessibility.py",
+    "scripts/test-manager-cache-verification.mjs",
+    "scripts/test-manager-header-refresh.mjs",
+    "scripts/test-manager-preview-refresh.mjs",
+    "scripts/test-manager-update-indicator.mjs",
+    "scripts/validate-branding.ps1",
+    "scripts/validate-docs.ps1",
+    "scripts/validate-repository.ps1",
+    "scripts/validate-shell.sh",
+    "scripts/validate-unraid-template.ps1",
+}
+
+RENDERER_TEST_MARKERS = (
+    "binge-champion",
+    "cache-diagnostics",
+    "deleted-item-cache",
+    "library-selection",
+    "newsletter-integration",
+    "recipient-watched",
+    "renderer-collection",
+    "sendall-recipient",
+    "smtp-transport",
+    "top-movie-genre",
+    "user-exclusion",
+)
+
+RENDERER_RUNTIME_NAMES = {
+    "cache-diagnostics.ps1",
+    "deleteditemcache.ps1",
+    "operation-lock.ps1",
+    "smtp-transport.ps1",
+    "tautweekly.ps1",
+}
+
+PACKAGED_GUIDES = {
+    "docs/freebsd/readme.md",
+    "docs/linux/readme.md",
+    "docs/mac/readme.md",
+    "docs/nas-docker/readme.md",
+    "docs/windows/readme.md",
+}
+
+EXECUTABLE_SUFFIXES = {
+    ".go",
+    ".js",
+    ".mjs",
+    ".ps1",
+    ".py",
+    ".sh",
+    ".yaml",
+    ".yml",
+}
+
+
+def empty_result() -> dict[str, bool]:
+    return {gate: False for gate in GATES}
+
+
+def enable(result: dict[str, bool], *gates: str) -> None:
+    for gate in gates:
+        result[gate] = True
+
+
+def enable_all_validation(result: dict[str, bool]) -> None:
+    enable(result, *ALL_VALIDATION_GATES)
+
+
+def classify_path(raw_path: str) -> dict[str, bool]:
+    """Classify one path. Unknown executable inputs fail closed."""
+
+    path = raw_path.replace("\\", "/").removeprefix("./").lower()
+    result = empty_result()
+    name = PurePosixPath(path).name
+    suffix = PurePosixPath(path).suffix
+
+    if path in {"scripts/ci_classifier.py", "scripts/test_ci_classifier.py"}:
+        enable_all_validation(result)
+        enable(result, "pages")
+        return result
+
+    if path == ".github/workflows/ci.yml":
+        enable_all_validation(result)
+        enable(result, "pages")
+        return result
+    if path == ".github/workflows/container.yml":
+        enable(result, "container", "container_arm64")
+        return result
+    if path == ".github/workflows/release.yml":
+        enable(result, "manager", "package", "installer", "container", "container_arm64")
+        return result
+    if path == ".github/workflows/pages.yml":
+        enable(result, "pages")
+        return result
+    if path.startswith(".github/workflows/") or path.startswith(".github/actions/"):
+        enable_all_validation(result)
+        enable(result, "pages")
+        return result
+
+    if path.startswith("docs/"):
+        enable(result, "pages")
+        if path in PACKAGED_GUIDES:
+            enable(result, "package")
+        return result
+
+    if path in {"license", "third_party_notices.md"}:
+        enable(result, "package")
+        return result
+
+    if path == "ca_profile.xml" or path.startswith("templates/"):
+        enable(result, "renderer", "package", "container")
+        return result
+
+    if path.startswith("manager/"):
+        enable(result, "manager", "package", "installer", "container", "container_arm64")
+        return result
+
+    if path.startswith("installer/"):
+        enable(result, "package", "installer")
+        return result
+
+    if path.startswith("platforms/"):
+        enable(result, "package")
+
+        if suffix == ".ps1":
+            enable(result, "powershell")
+        if name in RENDERER_RUNTIME_NAMES or "/assets-default/" in path:
+            enable(result, "renderer")
+
+        if (
+            "/compose" in path
+            or path.endswith("/my-tautulli.xml")
+            or path.endswith("/tautweekly.env.example")
+            or path.endswith("/runtime-profile.sh")
+        ):
+            enable(result, "compose")
+
+        if path.startswith("platforms/nas-docker/app/") or path.startswith(
+            "platforms/mac-docker/app/"
+        ):
+            enable(result, "container")
+
+        if "dockerfile" in name or name in {
+            ".dockerignore",
+            "entrypoint.sh",
+            "healthcheck.sh",
+            "runtime-profile.sh",
+            "run-as-user.sh",
+            "run-mode.sh",
+            "run-script.sh",
+            "run-service.sh",
+        }:
+            enable(result, "container", "container_arm64")
+
+        if path.startswith("platforms/nas-docker/") and (
+            "dockerfile" in name or "/app/" in path
+        ):
+            enable(result, "container")
+        return result
+
+    if path.startswith("scripts/"):
+        if path in FAST_ONLY_SCRIPTS:
+            return result
+
+        if path == "scripts/validate-platforms.ps1":
+            enable_all_validation(result)
+            return result
+
+        if suffix == ".ps1":
+            enable(result, "powershell")
+
+        if any(marker in path for marker in RENDERER_TEST_MARKERS):
+            enable(result, "powershell", "renderer")
+
+        if any(
+            marker in path
+            for marker in (
+                "build-releases",
+                "linux-manager-package",
+                "release-artifact",
+                "release-reproducibility",
+            )
+        ):
+            enable(result, "package")
+
+        if "manager" in path:
+            enable(result, "manager")
+        if "windows-installer" in path:
+            enable(result, "package", "installer")
+        if "container" in path:
+            enable(result, "compose", "container")
+        if "container-image" in path or "manager-cross-build" in path:
+            enable(result, "container_arm64")
+
+        if not any(result.values()) and suffix in EXECUTABLE_SUFFIXES:
+            enable_all_validation(result)
+        return result
+
+    if path.startswith(".github/issue_template/") or path in {
+        ".github/pull_request_template.md",
+        "agents.md",
+        "changelog.md",
+        "contributing.md",
+        "readme.md",
+    }:
+        return result
+
+    if suffix in EXECUTABLE_SUFFIXES:
+        enable_all_validation(result)
+    return result
+
+
+def classify_paths(paths: list[str], scope: str = "auto") -> dict[str, bool]:
+    result = empty_result()
+    if scope == "full":
+        enable(result, *GATES)
+        return result
+    if scope == "fast":
+        return result
+
+    for path in paths:
+        path_result = classify_path(path)
+        for gate, selected in path_result.items():
+            result[gate] = result[gate] or selected
+    return result
+
+
+def changed_paths(base: str, head: str) -> list[str]:
+    if base and set(base) == {"0"}:
+        command = ["git", "ls-tree", "-r", "--name-only", head]
+    else:
+        command = ["git", "diff", "--name-only", "--diff-filter=ACMRD", base, head]
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
+
+def write_github_output(path: str, result: dict[str, bool], files: list[str]) -> None:
+    with open(path, "a", encoding="utf-8") as output:
+        for gate in GATES:
+            output.write(f"{gate}={'true' if result[gate] else 'false'}\n")
+        output.write(f"files_json={json.dumps(files, separators=(',', ':'))}\n")
+
+
+def write_summary(path: str, result: dict[str, bool], files: list[str], scope: str) -> None:
+    selected = [gate for gate in GATES if result[gate]] or ["fast layer only"]
+    with open(path, "a", encoding="utf-8") as summary:
+        summary.write("## CI change classification\n\n")
+        summary.write(f"Scope: `{scope}`  \n")
+        summary.write(f"Changed paths: `{len(files)}`  \n")
+        summary.write(f"Selected gates: {', '.join(f'`{gate}`' for gate in selected)}\n\n")
+        if files:
+            summary.write("<details><summary>Changed paths</summary>\n\n")
+            summary.write("\n".join(f"- `{item}`" for item in files))
+            summary.write("\n\n</details>\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--scope", choices=("auto", "fast", "full"), default="auto")
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
+    parser.add_argument("--summary", default=os.environ.get("GITHUB_STEP_SUMMARY"))
+    args = parser.parse_args()
+
+    files = changed_paths(args.base, args.head)
+    result = classify_paths(files, args.scope)
+    if args.github_output:
+        write_github_output(args.github_output, result, files)
+    if args.summary:
+        write_summary(args.summary, result, files, args.scope)
+    json.dump({"files": files, "gates": result}, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_ci_classifier.py
+++ b/scripts/test_ci_classifier.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Positive and negative fixtures for the conservative CI path classifier."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from ci_classifier import GATES, classify_paths
+
+
+class ClassifierTests(unittest.TestCase):
+    def assert_gates(self, paths: list[str], selected: set[str], absent: set[str] | None = None):
+        result = classify_paths(paths)
+        self.assertEqual({gate for gate in GATES if result[gate]}, selected)
+        for gate in absent or set():
+            self.assertFalse(result[gate], f"{gate} unexpectedly selected for {paths}")
+
+    def test_docs_only_selects_pages_without_expensive_validation(self):
+        self.assert_gates(
+            ["docs/TROUBLESHOOTING.md"],
+            {"pages"},
+            {"renderer", "package", "installer", "container"},
+        )
+
+    def test_agents_only_uses_fast_layer(self):
+        self.assert_gates(["AGENTS.md"], set())
+
+    def test_packaged_platform_guide_selects_package_and_pages(self):
+        self.assert_gates(["docs/windows/README.md"], {"package", "pages"})
+
+    def test_renderer_runtime_selects_platform_package_and_image_gates(self):
+        self.assert_gates(
+            ["platforms/nas-docker/app/TautWeekly.ps1"],
+            {"powershell", "renderer", "package", "container"},
+            {"container_arm64"},
+        )
+
+    def test_scheduler_does_not_select_full_renderer(self):
+        self.assert_gates(
+            ["platforms/nas-docker/app/Scheduler.ps1"],
+            {"powershell", "package", "container"},
+            {"renderer"},
+        )
+
+    def test_manager_selects_all_consumers_and_multiarch(self):
+        self.assert_gates(
+            ["manager/internal/manager/server.go"],
+            {"manager", "package", "installer", "container", "container_arm64"},
+        )
+
+    def test_installer_does_not_select_renderer_or_container(self):
+        self.assert_gates(
+            ["installer/cmd/tautweekly-setup/main.go"],
+            {"package", "installer"},
+            {"renderer", "container"},
+        )
+
+    def test_compose_only_does_not_select_image_build(self):
+        self.assert_gates(
+            ["platforms/nas-docker/compose.yaml"],
+            {"package", "compose"},
+            {"renderer", "container"},
+        )
+
+    def test_dockerfile_selects_multiarch_image(self):
+        self.assert_gates(
+            ["platforms/nas-docker/Dockerfile"],
+            {"package", "container", "container_arm64"},
+        )
+
+    def test_ci_workflow_change_fails_closed_to_every_gate(self):
+        self.assert_gates([".github/workflows/ci.yml"], set(GATES))
+
+    def test_unknown_executable_input_fails_closed(self):
+        self.assert_gates(["tools/new-build-helper.py"], set(GATES) - {"pages"})
+
+    def test_manual_scopes_are_explicit(self):
+        self.assertFalse(any(classify_paths(["manager/go.mod"], "fast").values()))
+        self.assertTrue(all(classify_paths(["AGENTS.md"], "full").values()))
+
+
+class WorkflowContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ci = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        cls.container = Path(".github/workflows/container.yml").read_text(encoding="utf-8")
+        cls.pages = Path(".github/workflows/pages.yml").read_text(encoding="utf-8")
+        cls.release = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    def test_ci_events_are_pr_main_and_manual_only(self):
+        on_block = self.ci.split("\npermissions:", 1)[0]
+        self.assertRegex(on_block, r"(?m)^  pull_request:\s*$")
+        self.assertRegex(on_block, r"(?m)^  push:\n    branches: \[main\]$")
+        self.assertRegex(on_block, r"(?m)^  workflow_dispatch:\s*$")
+        self.assertNotIn("tags:", on_block)
+        self.assertNotIn("paths:", on_block)
+
+    def test_required_aggregate_is_stable_and_fail_closed(self):
+        required = self.ci.split("\n  required:", 1)[1].split(
+            "\n  publish-edge-container:", 1
+        )[0]
+        self.assertIn("\n    name: required\n", required)
+        self.assertIn("\n    if: always()\n", required)
+        for dependency in (
+            "provenance",
+            "classify",
+            "fast",
+            "fast-windows-powershell",
+            "powershell-runtime-unix",
+            "powershell-runtime-windows",
+            "renderer-unix",
+            "renderer-windows",
+            "manager",
+            "package",
+            "installer",
+            "compose",
+            "container-validation",
+        ):
+            self.assertIn(f"      - {dependency}\n", required)
+        self.assertIn(
+            "ci-provenance-pr-${{ github.event.pull_request.number }}"
+            "-base-${{ github.event.pull_request.base.sha }}"
+            "-head-${{ github.event.pull_request.head.sha }}",
+            required,
+        )
+        self.assertIn("> ci-provenance.txt", required)
+        self.assertIn("path: ci-provenance.txt", required)
+
+    def test_expensive_renderer_runs_once_and_only_in_selected_gate(self):
+        self.assertEqual(self.ci.count("test-newsletter-integration.ps1"), 1)
+        self.assertRegex(
+            self.ci,
+            r"renderer-windows:[\s\S]+needs\.classify\.outputs\.renderer == 'true'"
+            r"[\s\S]+test-newsletter-integration\.ps1",
+        )
+        self.assertNotIn("test-newsletter-integration.ps1", self.release)
+
+    def test_publication_workflows_have_no_direct_push_or_pr_trigger(self):
+        for workflow in (self.container, self.pages):
+            on_block = workflow.split("\npermissions:", 1)[0]
+            if "\njobs:" in on_block:
+                on_block = on_block.split("\njobs:", 1)[0]
+            self.assertNotRegex(on_block, r"(?m)^  push:")
+            self.assertNotRegex(on_block, r"(?m)^  pull_request:")
+            self.assertRegex(on_block, r"(?m)^  workflow_call:")
+        self.assertNotIn("\n    permissions:", self.container)
+
+    def test_release_is_tag_only_and_requires_green_exact_commit(self):
+        on_block = self.release.split("\npermissions:", 1)[0]
+        self.assertIn("      - 'v*.*.*'", on_block)
+        self.assertIn("Release history, version, and CI provenance", self.release)
+        self.assertIn("check_name: 'required'", self.release)
+        self.assertEqual(self.release.count("./scripts/build-releases.ps1"), 1)
+        self.assertNotIn("./scripts/validate-repository.ps1", self.release)
+
+    def test_generated_mac_runtime_profile_is_checked_in_the_package_only(self):
+        self.assertNotIn(
+            "test -x platforms/mac-docker/app/bin/runtime-profile.sh", self.ci
+        )
+        self.assertIn(
+            "tar -tvzf dist/TautWeekly-mac-docker.tar.gz "
+            "TautWeekly-mac-docker/app/bin/runtime-profile.sh | grep -q '^-rwx'",
+            self.ci,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace unfiltered push/PR CI with an unfiltered PR fast layer, conservative path classifier, and stable `CI / required` aggregate
- reuse exact PR evidence for trusted main merges, fail closed for unverified main pushes, and gate Pages/edge publication behind validation
- remove generic tag CI duplication while adding release history/version/exact-commit provenance preflight and preserving package, checksum, reproducibility, installer, multiarch, attestation, and publication gates
- document the implemented trigger matrix and measured v0.24.0 duplication in `AGENTS.md`

## Measured baseline

The v0.24.0 maintenance head ran CI twice (19.2-minute branch push and 21.4-minute PR run), including the same 14m27s active/quiet renderer step. Its merge ran another 20.7-minute generic CI, and its tag ran 21 minutes of generic CI beside the 19.3-minute Release workflow.

## Validation

- checksummed actionlint v1.7.12
- 17 classifier and workflow contract fixtures
- repository privacy/hygiene and JSON validation
- branding, Unraid, platform parity, docs, and relative-link validation
- PowerShell source parsing
- staged whitespace validation

Workflow changes intentionally select every conditional gate on this PR. No maintenance release is proposed for this internal CI/docs-only delivery. Issue #160 is untouched.