### PR TITLE
fix: run verified main publications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,7 +511,7 @@ jobs:
   publish-edge-container:
     name: Publish verified edge container
     needs: [provenance, classify, required]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.classify.outputs.container == 'true'
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.required.result == 'success' && needs.classify.outputs.container == 'true'
     uses: ./.github/workflows/container.yml
     with:
       publish_mode: edge
@@ -527,7 +527,7 @@ jobs:
   deploy-pages:
     name: Deploy verified Pages
     needs: [provenance, classify, required]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.classify.outputs.pages == 'true'
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.required.result == 'success' && needs.classify.outputs.pages == 'true'
     uses: ./.github/workflows/pages.yml
     with:
       validate: false

--- a/scripts/test_ci_classifier.py
+++ b/scripts/test_ci_classifier.py
@@ -146,6 +146,19 @@ class WorkflowContractTests(unittest.TestCase):
             self.assertRegex(on_block, r"(?m)^  workflow_call:")
         self.assertNotIn("\n    permissions:", self.container)
 
+    def test_main_publications_run_after_successful_aggregate_with_skipped_gates(self):
+        publish = self.ci.split("\n  publish-edge-container:", 1)[1].split(
+            "\n  deploy-pages:", 1
+        )[0]
+        pages = self.ci.split("\n  deploy-pages:", 1)[1]
+        for block, selected in ((publish, "container"), (pages, "pages")):
+            self.assertIn("if: always() &&", block)
+            self.assertIn("needs.required.result == 'success'", block)
+            self.assertIn(
+                f"needs.classify.outputs.{selected} == 'true'",
+                block,
+            )
+
     def test_release_is_tag_only_and_requires_green_exact_commit(self):
         on_block = self.release.split("\npermissions:", 1)[0]
         self.assertIn("      - 'v*.*.*'", on_block)


### PR DESCRIPTION
## Summary
- let selected Pages and edge-container publication jobs evaluate after trusted-merge validation gates are intentionally skipped
- require the stable aggregate job to succeed before either publication can start
- add a workflow contract regression for the skipped-transitive-gate case

## Diagnosis
Main run 33228426047 trusted PR #168's exact base/head provenance and correctly emitted `container=true` and `pages=true`. Both publication jobs were nevertheless skipped because their job conditions inherited GitHub Actions' implicit success requirement across the aggregate's skipped validation dependencies.

## Validation
- 19 classifier/workflow contract tests
- `git diff --check`
- checksum-verified actionlint v1.7.12 across all four workflows