### PR TITLE
fix: surface TestEmail SMTP diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Added Zoho-specific SMTP setup guidance for the account/data-center server,
+  STARTTLS port 587, full-address authentication, allowed sender identity, and
+  whitespace-free application passwords.
+
+### Fixed
+
+- Preserved privacy-safe SMTP category, protocol stage, numeric response code,
+  batch-fatal status, acceptance state, and failed-attempt count when TestEmail,
+  single-test, or Manual Welcome delivery fails. Manager now validates and
+  displays that evidence instead of collapsing every such failure to the
+  generic SMTP handoff message.
+
 ## [0.24.0] - 2026-08-28
 
 ### Changed

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -45,6 +45,15 @@ and it does not display or copy private configuration, logs, or output.
   submit mail. Use a numeric ID from `list-users` with `send-test` for the
   authoritative delivery check. Listing users does not save a default.
 
+For Zoho Mail, use the exact outgoing server shown for the account and data
+center. TautWeekly requires its TLS/STARTTLS port 587 rather than implicit-SSL
+port 465. Enable authentication, use the full Zoho email address as the
+username, and keep `FromEmail` equal to that account or one of its permitted
+aliases. When Zoho MFA requires an application-specific password, enter it
+without spaces or deliberately enable `SmtpStripPasswordSpaces`. See
+[Zoho's SMTP configuration](https://www.zoho.com/mail/help/zoho-smtp.html) and
+[application-password guidance](https://help.zoho.com/portal/en/kb/accounts/manage-your-zoho-account/articles/mfa-application-specific-passwords).
+
 For Proton SMTP submission, use `smtp.protonmail.ch`, port 587, STARTTLS,
 authentication enabled, and `SmtpAuthenticationMethod` set to `Auto` or
 `Login`. The username and `FromEmail` must be the exact address paired with the

--- a/docs/gui-preview/app.js
+++ b/docs/gui-preview/app.js
@@ -2926,7 +2926,7 @@ function operationSummary(operation) {
     case "queued": return { heading: "Manual Welcome queued", copy: "One selected-user welcome newsletter is waiting to start." };
     case "running": return { heading: "Sending one Manual Welcome", copy: "One selected Plex user is being processed. Cancellation is disabled once delivery begins." };
     case "succeeded": return { heading: "Manual Welcome accepted by SMTP", copy: "One welcome message was accepted by SMTP. The selected user's welcome state was updated; inbox delivery is not asserted." };
-    case "failed": return { heading: "Manual Welcome delivery failed", copy: rendererFailureCopy(operation.errorCategory, operation.supportCode) };
+    case "failed": return { heading: "Manual Welcome delivery failed", copy: `${rendererFailureCopy(operation.errorCategory, operation.supportCode)}${smtpFailureEvidenceCopy(operation.smtpFailure)}` };
     default: return { heading: "Manual Welcome delivery recorded", copy: "Review aggregate SMTP acceptance without exposing the selected recipient." };
     }
   }
@@ -2951,7 +2951,7 @@ function operationSummary(operation) {
     case "queued": return { heading: "Test delivery queued", copy: "The fixed six-message TestEmail operation is waiting to start." };
     case "running": return { heading: "Sending six test messages", copy: "Messages go only to the configured TestEmail; cancellation is disabled once sending begins." };
     case "succeeded": return { heading: "Test delivery accepted by SMTP", copy: `${operation.smtpAcceptedCount || 0} test messages were accepted by SMTP. Inbox delivery is not asserted.` };
-    case "failed": return { heading: "Test delivery failed", copy: `${operation.smtpAcceptedCount || 0} test message${operation.smtpAcceptedCount === 1 ? " was" : "s were"} accepted before failure. ${rendererFailureCopy(operation.errorCategory, operation.supportCode)}` };
+    case "failed": return { heading: "Test delivery failed", copy: `${operation.smtpAcceptedCount || 0} test message${operation.smtpAcceptedCount === 1 ? " was" : "s were"} accepted before failure. ${rendererFailureCopy(operation.errorCategory, operation.supportCode)}${smtpFailureEvidenceCopy(operation.smtpFailure)}` };
     default: return { heading: "Test delivery recorded", copy: "Review aggregate SMTP acceptance and failure counts." };
     }
   }

--- a/manager/README.md
+++ b/manager/README.md
@@ -244,8 +244,11 @@ and a support code when needed. Categories distinguish package-lock,
 configuration, Tautulli, Direct Plex, asset, HTML-render, preview-output, SMTP,
 and generic renderer stages; they never contain an exception message, path,
 address, media title, or identity. The
-local history uses count-only FIFO retention of the newest 20 completed
-operations, all available to the authenticated UI.
+test, Manual Welcome, and production delivery modes also retain only fixed SMTP
+protocol stage, numeric response code, batch-fatal status, and acceptance state
+when the shared transport supplies that evidence. Provider response text is
+never retained. The local history uses count-only FIFO retention of the newest
+20 completed operations, all available to the authenticated UI.
 
 Service-package Manager operations make one non-blocking attempt at the shared
 newsletter lock and report `operation-busy` immediately when a scheduled,

--- a/manager/internal/manager/config_editor.go
+++ b/manager/internal/manager/config_editor.go
@@ -154,7 +154,7 @@ func configDefinitions() []configDefinition {
 		{Name: "SmtpUseAuthentication", Label: "Use SMTP authentication", Group: "SMTP", Type: "boolean", Default: true},
 		{Name: "SmtpUsername", Label: "SMTP username", Group: "SMTP", Type: "text", Default: ""},
 		{Name: "SmtpPassword", Label: "SMTP password", Group: "SMTP", Type: "secret", Help: "Leave blank to preserve the stored password. Revealing it requires your Manager password and clears automatically."},
-		{Name: "SmtpStripPasswordSpaces", Label: "Strip password spaces", Group: "SMTP", Type: "boolean", Default: false},
+		{Name: "SmtpStripPasswordSpaces", Label: "Strip password spaces", Group: "SMTP", Type: "boolean", Default: false, Help: "Enable only when the provider displays a grouped app password; all whitespace is removed before authentication."},
 		{Name: "SmtpAuthenticationMethod", Label: "Authentication method", Group: "SMTP", Type: "select", Required: true, Default: "Auto", Options: []string{"Auto"}},
 		{Name: "SmtpTimeoutSeconds", Label: "SMTP timeout (seconds)", Group: "SMTP", Type: "integer", Required: true, Default: int64(30), Min: portMin, Max: shortMax},
 		{Name: "ScheduleDay", Label: "Weekly send day", Group: "Schedule", Type: "select", Required: true, Default: "Friday", Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}},

--- a/manager/internal/manager/operation_test.go
+++ b/manager/internal/manager/operation_test.go
@@ -23,6 +23,7 @@ type fixturePreviewRunner struct {
 	runs                 int
 	sendAllPartial       bool
 	sendAllNoEligible    bool
+	sendTestAllFailure   bool
 	previewExitCode      int
 	previewErrorCategory string
 	cacheExitCode        int
@@ -188,15 +189,39 @@ func (r *fixturePreviewRunner) RunSendTestAll(ctx context.Context, _, configPath
 		}
 	}
 	started := time.Now().UTC().Add(-time.Second)
+	schemaVersion := 1
+	outcome := "succeeded"
+	accepted := 6
+	failed := 0
+	exitCode := 0
+	var runErr error
+	var smtpFailure *SMTPFailureEvidence
+	var skipReasons *DeliverySkipReasonCounts
+	errorCategory := ""
+	if r.sendTestAllFailure {
+		schemaVersion = 3
+		outcome = "failed"
+		accepted = 0
+		failed = 1
+		exitCode = 1
+		runErr = errors.New("renderer returned exit status 1")
+		smtpFailure = &SMTPFailureEvidence{Category: "smtp-auth-failed", Stage: "auth", ResponseCode: 535, ResponseClass: 5, BatchFatal: true, Acceptance: "not-attempted"}
+		skipReasons = &DeliverySkipReasonCounts{}
+		errorCategory = smtpFailure.Category
+	}
 	result := rendererResult{
-		SchemaVersion:         1,
+		SchemaVersion:         schemaVersion,
 		Mode:                  "SendTestAll",
-		Outcome:               "succeeded",
+		Outcome:               outcome,
+		ErrorCategory:         errorCategory,
 		DeliveryScope:         "test",
 		StartedAtUTC:          started.Format(time.RFC3339Nano),
 		FinishedAtUTC:         started.Add(time.Second).Format(time.RFC3339Nano),
 		DurationMS:            1000,
-		SMTPAcceptedCount:     6,
+		SMTPAcceptedCount:     accepted,
+		FailedCount:           failed,
+		SMTPFailure:           smtpFailure,
+		SkipReasonCounts:      skipReasons,
 		GeneratedPreviewFiles: []string{},
 	}
 	encoded, err := json.Marshal(result)
@@ -206,7 +231,7 @@ func (r *fixturePreviewRunner) RunSendTestAll(ctx context.Context, _, configPath
 	if err := os.WriteFile(resultPath, encoded, 0o600); err != nil {
 		return 33, err
 	}
-	return 0, nil
+	return exitCode, runErr
 }
 
 func (r *fixturePreviewRunner) RunSendWelcome(ctx context.Context, _, configPath, resultPath, userID string) (int, error) {
@@ -503,6 +528,23 @@ func TestSendTestAllOperationRecordsAggregateSMTPAcceptanceAndCannotCancel(t *te
 		if _, err := coordinator.Start(request); err == nil {
 			t.Fatalf("unsafe test-send request was accepted: %+v", request)
 		}
+	}
+}
+
+func TestSendTestAllOperationRetainsSanitizedSMTPFailureEvidence(t *testing.T) {
+	root := integrationConfigRoot(t, "http://127.0.0.1:8181", "fictional-api-key", "", "")
+	runner := &fixturePreviewRunner{sendTestAllFailure: true}
+	coordinator, err := newOperationCoordinator(Options{DataDir: t.TempDir(), TautWeeklyRoot: root, Now: time.Now, operationRunner: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := ReadConfigEditor(root)
+	if _, err := coordinator.Start(CreateOperationRequest{Type: "send-test-all", ExpectedRevision: view.Revision, UserID: "42", ConfirmTestSend: true}); err != nil {
+		t.Fatal(err)
+	}
+	finished := waitForOperationState(t, coordinator, "failed")
+	if finished.DeliveryScope != "test" || finished.SMTPAcceptedCount != 0 || finished.FailedCount != 1 || finished.ErrorCategory != "smtp-auth-failed" || finished.SMTPFailure == nil || finished.SMTPFailure.Stage != "auth" || finished.SMTPFailure.ResponseCode != 535 || finished.SupportCode == "" {
+		t.Fatalf("unexpected sanitized test-send failure: %+v", finished)
 	}
 }
 

--- a/manager/internal/manager/renderer_result.go
+++ b/manager/internal/manager/renderer_result.go
@@ -84,7 +84,7 @@ func validRendererResult(result rendererResult, expectedMode string) bool {
 		if (result.ErrorCategory == "no-eligible-recipients" || result.ErrorCategory == "user-roster-refresh-failed") && result.Mode != "SendAll" {
 			return false
 		}
-		if structuredSMTPFailureCategory(result.ErrorCategory) && result.Mode != "SendAll" {
+		if structuredSMTPFailureCategory(result.ErrorCategory) && !smtpDeliveryMode(result.Mode) {
 			return false
 		}
 	}
@@ -93,7 +93,7 @@ func validRendererResult(result rendererResult, expectedMode string) bool {
 			return false
 		}
 	} else if result.SMTPFailure != nil {
-		if result.Mode != "SendAll" || (result.Outcome != "failed" && result.Outcome != "partial") || result.ErrorCategory != result.SMTPFailure.Category || !validSMTPFailureEvidence(*result.SMTPFailure) {
+		if !smtpDeliveryMode(result.Mode) || (result.Outcome != "failed" && !(result.Mode == "SendAll" && result.Outcome == "partial")) || result.ErrorCategory != result.SMTPFailure.Category || !validSMTPFailureEvidence(*result.SMTPFailure) {
 			return false
 		}
 	} else if structuredSMTPFailureCategory(result.ErrorCategory) {
@@ -159,15 +159,15 @@ func validRendererResult(result rendererResult, expectedMode string) bool {
 			return false
 		}
 	case "SendTest":
-		if len(seen) != 0 || result.SkippedCount != 0 || (result.Outcome == "succeeded" && (result.SMTPAcceptedCount != 1 || result.FailedCount != 0)) {
+		if len(seen) != 0 || result.SkippedCount != 0 || (result.Outcome == "succeeded" && (result.SMTPAcceptedCount != 1 || result.FailedCount != 0)) || (result.SMTPFailure != nil && (result.SMTPAcceptedCount != 0 || result.FailedCount != 1)) {
 			return false
 		}
 	case "SendTestAll":
-		if len(seen) != 0 || result.SkippedCount != 0 || (result.Outcome == "succeeded" && (result.SMTPAcceptedCount != 6 || result.FailedCount != 0)) {
+		if len(seen) != 0 || result.SkippedCount != 0 || (result.Outcome == "succeeded" && (result.SMTPAcceptedCount != 6 || result.FailedCount != 0)) || (result.SMTPFailure != nil && (result.SMTPAcceptedCount >= 6 || result.FailedCount != 1)) {
 			return false
 		}
 	case "SendWelcome":
-		if len(seen) != 0 || result.SkippedCount != 0 || (result.Outcome == "succeeded" && (result.SMTPAcceptedCount != 1 || result.FailedCount != 0)) {
+		if len(seen) != 0 || result.SkippedCount != 0 || (result.Outcome == "succeeded" && (result.SMTPAcceptedCount != 1 || result.FailedCount != 0)) || (result.SMTPFailure != nil && (result.SMTPAcceptedCount != 0 || result.FailedCount != 1)) {
 			return false
 		}
 	case "SendAll":
@@ -216,6 +216,15 @@ func validRendererErrorCategory(category string) bool {
 func structuredSMTPFailureCategory(category string) bool {
 	switch category {
 	case "smtp-auth-failed", "smtp-rate-limited", "smtp-recipient-rejected", "smtp-provider-rejected", "smtp-transport-failed", "smtp-acceptance-unknown":
+		return true
+	default:
+		return false
+	}
+}
+
+func smtpDeliveryMode(mode string) bool {
+	switch mode {
+	case "SendTest", "SendTestAll", "SendWelcome", "SendAll":
 		return true
 	default:
 		return false

--- a/manager/internal/manager/renderer_result_test.go
+++ b/manager/internal/manager/renderer_result_test.go
@@ -216,6 +216,36 @@ func TestRendererResultV3ValidatesSanitizedSMTPFailureEvidence(t *testing.T) {
 		t.Fatalf("valid ambiguous-acceptance evidence was rejected: %+v", ambiguous)
 	}
 
+	for _, delivery := range []struct {
+		mode          string
+		deliveryScope string
+		accepted      int
+	}{
+		{mode: "SendTest", deliveryScope: "test", accepted: 0},
+		{mode: "SendTestAll", deliveryScope: "test", accepted: 2},
+		{mode: "SendWelcome", deliveryScope: "welcome", accepted: 0},
+	} {
+		result := valid
+		result.Mode = delivery.mode
+		result.DeliveryScope = delivery.deliveryScope
+		result.SMTPAcceptedCount = delivery.accepted
+		result.SkippedCount = 0
+		result.SkipReasonCounts = &DeliverySkipReasonCounts{}
+		if !validRendererResult(result, delivery.mode) {
+			t.Fatalf("valid %s SMTP failure evidence was rejected: %+v", delivery.mode, result)
+		}
+	}
+
+	invalidTestAll := valid
+	invalidTestAll.Mode = "SendTestAll"
+	invalidTestAll.DeliveryScope = "test"
+	invalidTestAll.SMTPAcceptedCount = 6
+	invalidTestAll.SkippedCount = 0
+	invalidTestAll.SkipReasonCounts = &DeliverySkipReasonCounts{}
+	if validRendererResult(invalidTestAll, "SendTestAll") {
+		t.Fatalf("SendTestAll accepted SMTP failure evidence after all six messages: %+v", invalidTestAll)
+	}
+
 	cases := []struct {
 		name   string
 		mutate func(*rendererResult)

--- a/manager/internal/manager/web/app.js
+++ b/manager/internal/manager/web/app.js
@@ -2925,7 +2925,7 @@ function operationSummary(operation) {
     case "queued": return { heading: "Manual Welcome queued", copy: "One selected-user welcome newsletter is waiting to start." };
     case "running": return { heading: "Sending one Manual Welcome", copy: "One selected Plex user is being processed. Cancellation is disabled once delivery begins." };
     case "succeeded": return { heading: "Manual Welcome accepted by SMTP", copy: "One welcome message was accepted by SMTP. The selected user's welcome state was updated; inbox delivery is not asserted." };
-    case "failed": return { heading: "Manual Welcome delivery failed", copy: rendererFailureCopy(operation.errorCategory, operation.supportCode) };
+    case "failed": return { heading: "Manual Welcome delivery failed", copy: `${rendererFailureCopy(operation.errorCategory, operation.supportCode)}${smtpFailureEvidenceCopy(operation.smtpFailure)}` };
     default: return { heading: "Manual Welcome delivery recorded", copy: "Review aggregate SMTP acceptance without exposing the selected recipient." };
     }
   }
@@ -2950,7 +2950,7 @@ function operationSummary(operation) {
     case "queued": return { heading: "Test delivery queued", copy: "The fixed six-message TestEmail operation is waiting to start." };
     case "running": return { heading: "Sending six test messages", copy: "Messages go only to the configured TestEmail; cancellation is disabled once sending begins." };
     case "succeeded": return { heading: "Test delivery accepted by SMTP", copy: `${operation.smtpAcceptedCount || 0} test messages were accepted by SMTP. Inbox delivery is not asserted.` };
-    case "failed": return { heading: "Test delivery failed", copy: `${operation.smtpAcceptedCount || 0} test message${operation.smtpAcceptedCount === 1 ? " was" : "s were"} accepted before failure. ${rendererFailureCopy(operation.errorCategory, operation.supportCode)}` };
+    case "failed": return { heading: "Test delivery failed", copy: `${operation.smtpAcceptedCount || 0} test message${operation.smtpAcceptedCount === 1 ? " was" : "s were"} accepted before failure. ${rendererFailureCopy(operation.errorCategory, operation.supportCode)}${smtpFailureEvidenceCopy(operation.smtpFailure)}` };
     default: return { heading: "Test delivery recorded", copy: "Review aggregate SMTP acceptance and failure counts." };
     }
   }

--- a/platforms/mac-docker/app/TautWeekly.ps1
+++ b/platforms/mac-docker/app/TautWeekly.ps1
@@ -136,6 +136,12 @@ function Get-TautWeeklySmtpFailureEvidence {
 }
 
 trap {
+    $smtpFailure = Get-TautWeeklySmtpFailureEvidence -Exception $_.Exception
+    if ($null -ne $smtpFailure) {
+        $script:TautWeeklyResultSmtpFailure = $smtpFailure
+        $script:TautWeeklyResultErrorCategory = [string]$smtpFailure.category
+        $script:TautWeeklyResultFailedCount = [Math]::Max(1, [int]$script:TautWeeklyResultFailedCount)
+    }
     Write-TautWeeklyStructuredResult -Outcome "failed"
     exit 1
 }

--- a/platforms/nas-docker/app/TautWeekly.ps1
+++ b/platforms/nas-docker/app/TautWeekly.ps1
@@ -136,6 +136,12 @@ function Get-TautWeeklySmtpFailureEvidence {
 }
 
 trap {
+    $smtpFailure = Get-TautWeeklySmtpFailureEvidence -Exception $_.Exception
+    if ($null -ne $smtpFailure) {
+        $script:TautWeeklyResultSmtpFailure = $smtpFailure
+        $script:TautWeeklyResultErrorCategory = [string]$smtpFailure.category
+        $script:TautWeeklyResultFailedCount = [Math]::Max(1, [int]$script:TautWeeklyResultFailedCount)
+    }
     Write-TautWeeklyStructuredResult -Outcome "failed"
     exit 1
 }

--- a/platforms/windows/TautWeekly.ps1
+++ b/platforms/windows/TautWeekly.ps1
@@ -138,6 +138,12 @@ function Get-TautWeeklySmtpFailureEvidence {
 }
 
 trap {
+    $smtpFailure = Get-TautWeeklySmtpFailureEvidence -Exception $_.Exception
+    if ($null -ne $smtpFailure) {
+        $script:TautWeeklyResultSmtpFailure = $smtpFailure
+        $script:TautWeeklyResultErrorCategory = [string]$smtpFailure.category
+        $script:TautWeeklyResultFailedCount = [Math]::Max(1, [int]$script:TautWeeklyResultFailedCount)
+    }
     Write-TautWeeklyStructuredResult -Outcome "failed"
     exit 1
 }

--- a/scripts/test-manager-accessibility.py
+++ b/scripts/test-manager-accessibility.py
@@ -539,6 +539,8 @@ def main() -> int:
         failures.append("manual production delivery does not expose both all-recipient and Manual Welcome scopes")
     if 'type === "send-welcome"' not in javascript or "confirmProductionSend: true" not in javascript:
         failures.append("manual production delivery does not use the fixed confirmed operation contracts")
+    if javascript.count("smtpFailureEvidenceCopy(operation.smtpFailure)") < 4:
+        failures.append("test, welcome, partial, and failed delivery summaries do not all expose sanitized SMTP evidence")
     if 'id="manual-send-user-id"' not in combined or 'state.history.find((candidate) => manualTypes.has(candidate.type))' not in javascript:
         failures.append("Manual Welcome lacks selected-user input or shared sanitized status")
     if 'id="direct-plex-notice"' not in combined or "legacyFieldsMissing" not in javascript:

--- a/scripts/test-sendall-recipient-policy.ps1
+++ b/scripts/test-sendall-recipient-policy.ps1
@@ -533,6 +533,51 @@ foreach ($engine in $engines) {
                         Assert-True (-not $resultRaw.Contains($privateValue)) "$($engine.Name)/$($scenario.Name) exposed a recipient identity in its structured result."
                     }
                 }
+                if ($scenario.Name -eq 'auth-failure-stops-batch') {
+                    $testAllResultPath = Join-Path $tempRoot ("result-test-all-auth-failure-$($engine.Name).json")
+                    $testAllStdout = Join-Path $tempRoot ("renderer-test-all-auth-failure-$($engine.Name).stdout.txt")
+                    $testAllStderr = Join-Path $tempRoot ("renderer-test-all-auth-failure-$($engine.Name).stderr.txt")
+                    $oldTestAllDataRoot = $env:TAUTWEEKLY_DATA_DIR
+                    $oldTestAllConfig = $env:TAUTWEEKLY_CONFIG
+                    try {
+                        if ($engine.Container) {
+                            $env:TAUTWEEKLY_DATA_DIR = $dataRoot
+                            $env:TAUTWEEKLY_CONFIG = $configPath
+                        }
+                        $testAllProcess = Start-Process -FilePath $engine.Host -ArgumentList @(
+                            '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $headlessRunner,
+                            '-RendererPath', (Join-Path $appRoot 'TautWeekly.ps1'), '-ConfigPath', $configPath,
+                            '-UserId', '1', '-Mode', 'SendTestAll', '-ResultPath', $testAllResultPath
+                        ) -Wait -PassThru @processWindowArgs -RedirectStandardOutput $testAllStdout -RedirectStandardError $testAllStderr
+                    }
+                    finally {
+                        $env:TAUTWEEKLY_DATA_DIR = $oldTestAllDataRoot
+                        $env:TAUTWEEKLY_CONFIG = $oldTestAllConfig
+                    }
+
+                    Assert-True ($testAllProcess.ExitCode -eq 1) "$($engine.Name) TestEmail authentication failure exited $($testAllProcess.ExitCode), expected 1."
+                    Assert-True (Test-Path -LiteralPath $testAllResultPath) "$($engine.Name) TestEmail authentication failure omitted its structured result."
+                    $testAllResultRaw = Get-Content -LiteralPath $testAllResultPath -Raw -Encoding UTF8
+                    $testAllResult = $testAllResultRaw | ConvertFrom-Json
+                    Assert-True ($testAllResult.schemaVersion -eq 3 -and $testAllResult.mode -eq 'SendTestAll' -and $testAllResult.outcome -eq 'failed') "$($engine.Name) TestEmail authentication failure reported an invalid result envelope."
+                    Assert-True ([string]$testAllResult.errorCategory -eq 'smtp-auth-failed') "$($engine.Name) TestEmail authentication failure omitted its fixed error category."
+                    Assert-True ($testAllResult.smtpAcceptedCount -eq 0 -and $testAllResult.skippedCount -eq 0 -and $testAllResult.failedCount -eq 1) "$($engine.Name) TestEmail authentication failure reported inconsistent aggregates."
+                    Assert-True ($null -ne $testAllResult.smtpFailure) "$($engine.Name) TestEmail authentication failure omitted typed SMTP evidence."
+                    Assert-True ([string]$testAllResult.smtpFailure.category -eq 'smtp-auth-failed' -and [string]$testAllResult.smtpFailure.stage -eq 'auth') "$($engine.Name) TestEmail authentication failure reported the wrong sanitized category or stage."
+                    Assert-True ([int]$testAllResult.smtpFailure.responseCode -eq 535 -and [int]$testAllResult.smtpFailure.responseClass -eq 5) "$($engine.Name) TestEmail authentication failure reported the wrong sanitized response classification."
+                    Assert-True ([bool]$testAllResult.smtpFailure.batchFatal -and [string]$testAllResult.smtpFailure.acceptance -eq 'not-attempted') "$($engine.Name) TestEmail authentication failure reported the wrong batch or acceptance classification."
+                    foreach ($privateValue in @('virtual-sender@example.com', 'virtual-app-password', 'Authentication rejected')) {
+                        Assert-True (-not $testAllResultRaw.Contains($privateValue)) "$($engine.Name) TestEmail authentication failure exposed credentials or provider response text."
+                    }
+                    $testAllSmtpCalls = @(
+                        Get-Content -LiteralPath $smtpLog -ErrorAction SilentlyContinue |
+                            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                            ForEach-Object { $_ | ConvertFrom-Json }
+                    )
+                    Assert-True (@($testAllSmtpCalls | Where-Object { [string]$_.command -eq '<connection>' }).Count -eq ($connections.Count + 1)) "$($engine.Name) TestEmail authentication failure did not stop after one additional SMTP connection."
+                    Assert-True (@($testAllSmtpCalls | Where-Object { ([string]$_.command).StartsWith('MAIL FROM:', [StringComparison]::OrdinalIgnoreCase) }).Count -eq 0) "$($engine.Name) TestEmail authentication failure attempted an SMTP envelope after rejected authentication."
+                    Write-Host "[PASS] TestEmail sanitized SMTP failure evidence: $($engine.Name)"
+                }
                 $executed++
                 Write-Host "[PASS] SendAll recipient policy: $($engine.Name) / $($scenario.Name)"
             }


### PR DESCRIPTION
## Summary

- preserve privacy-safe SMTP failure category, stage, numeric response code, batch-fatal state, acceptance state, and failed-attempt count for TestEmail, single-test, and Manual Welcome delivery
- validate and display that evidence in Manager without retaining credentials or provider response text
- add renderer-level regression coverage across the maintained platform payloads

References #172.

## Validation

- `scripts/test-sendall-recipient-policy.ps1` — 33 scenarios across Windows, NAS/Linux/FreeBSD, and Mac
- `scripts/test-smtp-transport.py`
- `scripts/test-manager-accessibility.py`
- JavaScript syntax checks for both Manager UI copies
- `scripts/validate-powershell.ps1`
- `scripts/validate-platforms.ps1`
- `scripts/validate-docs.ps1`
- `scripts/check-links.ps1`
- `scripts/validate-repository.ps1`