### PR TITLE
fix: keep SMTP guidance provider-neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Changed
-
-- Added Zoho-specific SMTP setup guidance for the account/data-center server,
-  STARTTLS port 587, full-address authentication, allowed sender identity, and
-  whitespace-free application passwords.
-
 ### Fixed
 
 - Preserved privacy-safe SMTP category, protocol stage, numeric response code,

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,33 +35,19 @@ and it does not display or copy private configuration, logs, or output.
 
 ## SMTP authentication or TLS fails
 
-- Use the provider's STARTTLS hostname and port, normally 587.
+- Use the exact SMTP submission hostname from the provider's account settings.
+- Use a supported STARTTLS submission port, normally 587. TautWeekly does not
+  support implicit-TLS port 465.
 - Confirm whether authentication is required and whether the username is a full
   email address.
+- Keep `FromEmail` equal to the authenticated account or a sender identity or
+  alias that the account is permitted to use.
 - Use an application password when the provider requires one.
 - Preserve password whitespace unless the provider displays grouped characters
   and `SmtpStripPasswordSpaces` is intentionally enabled.
 - `verify` proves that the SMTP host is reachable; it does not authenticate or
   submit mail. Use a numeric ID from `list-users` with `send-test` for the
   authoritative delivery check. Listing users does not save a default.
-
-For Zoho Mail, use the exact outgoing server shown for the account and data
-center. TautWeekly requires its TLS/STARTTLS port 587 rather than implicit-SSL
-port 465. Enable authentication, use the full Zoho email address as the
-username, and keep `FromEmail` equal to that account or one of its permitted
-aliases. When Zoho MFA requires an application-specific password, enter it
-without spaces or deliberately enable `SmtpStripPasswordSpaces`. See
-[Zoho's SMTP configuration](https://www.zoho.com/mail/help/zoho-smtp.html) and
-[application-password guidance](https://help.zoho.com/portal/en/kb/accounts/manage-your-zoho-account/articles/mfa-application-specific-passwords).
-
-For Proton SMTP submission, use `smtp.protonmail.ch`, port 587, STARTTLS,
-authentication enabled, and `SmtpAuthenticationMethod` set to `Auto` or
-`Login`. The username and `FromEmail` must be the exact address paired with the
-generated SMTP token; the password must be that token, not a Proton account,
-mailbox, or Bridge password. See [Proton's SMTP submission instructions](https://proton.me/support/smtp-submission).
-If Proton reports `Sender address rejected: not logged in`, update to a build
-containing the explicit SMTP authentication transport, then regenerate or
-re-enter the token if the error remains.
 
 ## SMTP provider temporarily locks or limits the account
 

--- a/manager/internal/manager/config_editor.go
+++ b/manager/internal/manager/config_editor.go
@@ -154,7 +154,7 @@ func configDefinitions() []configDefinition {
 		{Name: "SmtpUseAuthentication", Label: "Use SMTP authentication", Group: "SMTP", Type: "boolean", Default: true},
 		{Name: "SmtpUsername", Label: "SMTP username", Group: "SMTP", Type: "text", Default: ""},
 		{Name: "SmtpPassword", Label: "SMTP password", Group: "SMTP", Type: "secret", Help: "Leave blank to preserve the stored password. Revealing it requires your Manager password and clears automatically."},
-		{Name: "SmtpStripPasswordSpaces", Label: "Strip password spaces", Group: "SMTP", Type: "boolean", Default: false, Help: "Enable only when the provider displays a grouped app password; all whitespace is removed before authentication."},
+		{Name: "SmtpStripPasswordSpaces", Label: "Strip password spaces", Group: "SMTP", Type: "boolean", Default: false},
 		{Name: "SmtpAuthenticationMethod", Label: "Authentication method", Group: "SMTP", Type: "select", Required: true, Default: "Auto", Options: []string{"Auto"}},
 		{Name: "SmtpTimeoutSeconds", Label: "SMTP timeout (seconds)", Group: "SMTP", Type: "integer", Required: true, Default: int64(30), Min: portMin, Max: shortMax},
 		{Name: "ScheduleDay", Label: "Weekly send day", Group: "Schedule", Type: "select", Required: true, Default: "Friday", Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}},
@@ -669,7 +669,7 @@ func parseAndValidateConfigValue(raw json.RawMessage, definition configDefinitio
 			}
 		}
 		if definition.Name == "SmtpHost" && text != "" && !validSMTPHost(text) {
-			return nil, "Enter a hostname only, such as smtp.gmail.com; do not include smtp:// or a port."
+			return nil, "Enter a hostname only, such as smtp.example.com; do not include smtp:// or a port."
 		}
 		if definition.Type == "time" && text != "" {
 			if _, err := time.Parse("15:04", text); err != nil || len(text) != 5 {

--- a/manager/internal/manager/config_editor_test.go
+++ b/manager/internal/manager/config_editor_test.go
@@ -280,7 +280,7 @@ func TestSaveConfigValidationAndRevisionConflict(t *testing.T) {
 
 func TestSaveConfigRejectsSMTPURLInsteadOfReportingUnsafeDNS(t *testing.T) {
 	definition := configDefinition{Name: "SmtpHost", Type: "text", Required: true}
-	_, message := parseAndValidateConfigValue(json.RawMessage(`"smtp://smtp.gmail.com:587"`), definition)
+	_, message := parseAndValidateConfigValue(json.RawMessage(`"smtp://smtp.example.com:587"`), definition)
 	if !strings.Contains(message, "hostname only") {
 		t.Fatalf("SMTP URL validation message: %q", message)
 	}

--- a/manager/internal/manager/integration_test.go
+++ b/manager/internal/manager/integration_test.go
@@ -107,16 +107,16 @@ func TestSMTPDestinationFailuresDistinguishSyntaxFromUnsafeResolution(t *testing
 		},
 		tlsConfig: func(string) *tls.Config { return &tls.Config{} },
 	}
-	invalid := smtpProbeConfig{Host: "smtp://smtp.gmail.com", Port: 587, Timeout: time.Second}
+	invalid := smtpProbeConfig{Host: "smtp://smtp.example.com", Port: 587, Timeout: time.Second}
 	if err := probeSMTPNetwork(context.Background(), invalid, dependencies); !errors.Is(err, errSMTPHost) {
 		t.Fatalf("invalid SMTP syntax classification: got %v", err)
 	}
-	unsafe := smtpProbeConfig{Host: "smtp.gmail.com", Port: 587, Timeout: time.Second}
+	unsafe := smtpProbeConfig{Host: "smtp.example.com", Port: 587, Timeout: time.Second}
 	if err := probeSMTPNetwork(context.Background(), unsafe, dependencies); !errors.Is(err, errSMTPUnsafeAddress) {
 		t.Fatalf("unsafe SMTP resolution classification: got %v", err)
 	}
-	if !validSMTPHost("smtp.gmail.com") || !allowedSMTPIP(net.ParseIP("192.178.231.109")) || !allowedSMTPIP(net.ParseIP("2607:f8b0:4023:200d::6d")) {
-		t.Fatal("valid Gmail host or public unicast address was rejected")
+	if !validSMTPHost("smtp.example.com") || !allowedSMTPIP(net.ParseIP("192.0.2.10")) || !allowedSMTPIP(net.ParseIP("2001:db8::10")) {
+		t.Fatal("valid SMTP host or public unicast address was rejected")
 	}
 }
 

--- a/manager/internal/manager/smtp_check.go
+++ b/manager/internal/manager/smtp_check.go
@@ -288,7 +288,7 @@ func smtpAdvertisesSTARTTLS(lines []string) bool {
 func smtpFailureSummary(err error) string {
 	switch {
 	case errors.Is(err, errSMTPHost):
-		return "The saved SMTP host or port is invalid. Enter a hostname only, such as smtp.gmail.com, and a STARTTLS port such as 587. No credentials were sent."
+		return "The saved SMTP host or port is invalid. Enter a hostname only, such as smtp.example.com, and a STARTTLS port such as 587. No credentials were sent."
 	case errors.Is(err, errSMTPUnsafeAddress):
 		return "The saved SMTP hostname resolved to an unsafe or non-unicast address. Review local DNS or filtering before retrying. No credentials were sent."
 	case errors.Is(err, errSMTPTLS):

--- a/scripts/validate-docs.ps1
+++ b/scripts/validate-docs.ps1
@@ -818,8 +818,26 @@ $troubleshooting = [IO.File]::ReadAllText((Join-Path $docs 'TROUBLESHOOTING.md')
 if ($configuration -notmatch 'SmtpAuthenticationMethod' -or $configuration -notmatch 'successful `235` response') {
     throw 'SMTP authentication transport is not documented in CONFIGURATION.md.'
 }
-if ($troubleshooting -notmatch 'smtp\.protonmail\.ch' -or $troubleshooting -notmatch 'Sender address rejected: not logged in') {
-    throw 'Proton SMTP troubleshooting guidance is missing.'
+$smtpTroubleshooting = [regex]::Match($troubleshooting, '(?ms)^## SMTP authentication or TLS fails\s*(?<content>.*?)(?=^##\s)')
+if (-not $smtpTroubleshooting.Success) {
+    throw 'Provider-neutral SMTP authentication troubleshooting guidance is missing.'
+}
+$smtpTroubleshootingContent = $smtpTroubleshooting.Groups['content'].Value
+foreach ($pattern in @(
+    'exact SMTP submission hostname',
+    'STARTTLS submission port',
+    'does not\s+support implicit-TLS port 465',
+    'FromEmail',
+    'application password',
+    'SmtpStripPasswordSpaces',
+    'does not authenticate or\s+submit mail'
+)) {
+    if ($smtpTroubleshootingContent -notmatch $pattern) {
+        throw "Provider-neutral SMTP troubleshooting guidance is missing: $pattern"
+    }
+}
+if ($smtpTroubleshootingContent -match '(?i)\b(Proton|Zoho|Gmail|Outlook|Office 365|Microsoft 365|Yahoo|iCloud|Fastmail|Mailgun|SendGrid|SMTP2GO|Amazon SES|Postmark)\b') {
+    throw 'SMTP troubleshooting guidance must remain provider-neutral.'
 }
 foreach ($pattern in @(
     'Manager \*\*Config\*\* is the setup source on Windows, NAS/Docker, macOS Docker\s+Desktop, native Linux, and FreeBSD Podman',


### PR DESCRIPTION
## Summary

- remove provider-specific SMTP setup guidance from current docs, changelog, and Manager field help
- keep troubleshooting focused on provider-neutral STARTTLS, authentication, sender-identity, credential, and verification requirements
- use reserved example hostnames in user-facing validation and enforce the neutral guidance contract

This is an immediate hotfix refinement of #173 for issue #172. It adds no user-facing capability and is not a feature release.

## Validation

- `scripts/validate-docs.ps1`
- `scripts/check-links.ps1`
- `scripts/validate-powershell.ps1`
- `scripts/validate-repository.ps1`
- `scripts/test-manager-accessibility.py`
- provider-name scan across current docs and Manager source
- `git diff --check`