### PR TITLE
chore: prepare v0.24.1 hotfix release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
         run: |
           ./scripts/check-links.ps1
           ./scripts/validate-docs.ps1
+          ./scripts/validate-release-history.ps1
       - name: Validate JavaScript and Manager accessibility
         run: |
           node --check docs/assets/site.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,22 +32,7 @@ jobs:
           if ($env:GITHUB_REF_NAME -notmatch '^v\d+\.\d+\.\d+$') {
               throw "Release tags must use vMAJOR.MINOR.PATCH."
           }
-          $versionFiles = @(Get-ChildItem -LiteralPath platforms -Filter VERSION.txt -Recurse)
-          if ($versionFiles.Count -eq 0) {
-              throw 'No platform VERSION.txt files were found.'
-          }
-          foreach ($file in $versionFiles) {
-              if ((Get-Content -LiteralPath $file.FullName -Raw).Trim() -ne $version) {
-                  throw "$($file.FullName) does not match $version."
-              }
-          }
-          if (-not (Test-Path -LiteralPath "docs/releases/$($env:GITHUB_REF_NAME).md" -PathType Leaf)) {
-              throw "Release notes are missing for $($env:GITHUB_REF_NAME)."
-          }
-          $changelog = Get-Content -LiteralPath CHANGELOG.md -Raw
-          if ($changelog -notmatch "(?m)^## \[$([regex]::Escape($version))\]") {
-              throw "CHANGELOG.md has no $version section."
-          }
+          ./scripts/validate-release-history.ps1 -Version $version
       - name: Require the exact tagged commit to have green CI provenance
         uses: actions/github-script@v8
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-08-31
+
 ### Fixed
 
 - Preserved privacy-safe SMTP category, protocol stage, numeric response code,

--- a/docs/gui-preview/index.html
+++ b/docs/gui-preview/index.html
@@ -93,8 +93,8 @@
     </aside>
 
     <main class="content" id="main-content" tabindex="-1">
-      <aside class="demo-banner" role="note" aria-label="GUI preview boundary" data-preview-release="v0.24.0">
-        <strong>Interactive GUI Preview · v0.24.0</strong>
+      <aside class="demo-banner" role="note" aria-label="GUI preview boundary" data-preview-release="v0.24.1">
+        <strong>Interactive GUI Preview · v0.24.1</strong>
         <span>Fictional data · temporary in-memory changes. Do not enter real credentials.</span>
         <span>No services, email, files, credentials, or schedulers are contacted</span>
         <label>Package example <select id="demo-profile"><option value="windows">Windows</option><option value="nas">NAS / Docker</option><option value="mac">macOS Docker</option><option value="linux">Native Linux</option><option value="freebsd">FreeBSD / Podman</option></select></label>
@@ -346,7 +346,7 @@
             <a class="update-docs-link" id="update-docs-link" href="../" target="_blank" rel="noopener noreferrer">Open platform update guide</a>
           </div>
           <label class="update-install-confirm" id="update-install-confirm-row" for="update-install-confirm" hidden><input id="update-install-confirm" type="checkbox"><span><strong>Install the verified stable Windows update</strong><small>Windows will request administrator approval. The existing updater verifies release URLs, archive checksums, internal manifests, rollback, and post-update health.</small></span></label>
-          <div class="update-settings-actions"><button class="button button-secondary" id="update-check-button" type="button">Check now</button><button class="button button-primary" id="update-install-button" type="button" hidden disabled>Install update</button><a id="update-release-notes" href="../releases/v0.24.0.md" target="_blank" rel="noopener noreferrer" hidden>Read stable release notes</a></div>
+          <div class="update-settings-actions"><button class="button button-secondary" id="update-check-button" type="button">Check now</button><button class="button button-primary" id="update-install-button" type="button" hidden disabled>Install update</button><a id="update-release-notes" href="../releases/v0.24.1.md" target="_blank" rel="noopener noreferrer" hidden>Read stable release notes</a></div>
           <p class="verification-message" id="update-settings-message" role="status" aria-live="polite">Normal Manager and dashboard health never depend on Internet availability.</p>
           <p class="update-security-boundary"><strong>The Manager never gains host control.</strong> Container profiles do not mount the Docker socket, add a privileged helper, run the web process as root, or mutate the host. Use the reported full-semver reference or its manifest digest; minor, latest, and edge tags are mutable. Native Unix packages keep installation in their existing host wrappers.</p>
         </section>

--- a/docs/gui-preview/mock-api.js
+++ b/docs/gui-preview/mock-api.js
@@ -2,8 +2,8 @@
 
 (() => {
   const now = () => new Date().toISOString();
-  const DEMO_VERSION = "0.24.0";
-  const PREVIOUS_VERSION = "0.23.3";
+  const DEMO_VERSION = "0.24.1";
+  const PREVIOUS_VERSION = "0.24.0";
   const PROFILES = {
     windows: { runtimeMode: "windows", runtimeProfile: "native-windows", packageKind: "windows-installer", label: "Windows" },
     nas: { runtimeMode: "nas", runtimeProfile: "server", packageKind: "container-compose", label: "NAS / Docker" },

--- a/docs/releases/v0.24.1.md
+++ b/docs/releases/v0.24.1.md
@@ -1,0 +1,33 @@
+# TautWeekly for Plex v0.24.1
+
+Released: 2026-08-31
+
+## SMTP failure diagnostics hotfix
+
+Failed TestEmail, single-test, and Manual Welcome operations now preserve the
+SMTP transport's existing privacy-safe failure evidence through the renderer
+and Manager boundaries. Instead of reducing every failure to the same generic
+handoff message, Manager can show the fixed failure category, protocol stage,
+numeric SMTP response code, batch-fatal state, acceptance state, and failed
+attempt count.
+
+This changes diagnosis only; it does not change SMTP delivery behavior or add a
+provider-specific setup path. Existing provider-neutral STARTTLS,
+authentication, sender-identity, credential, and verification guidance remains
+the setup contract.
+
+## Privacy boundary
+
+Credentials, email addresses, provider response text, message content, private
+hostnames and addresses, and generated newsletters are still excluded. The
+support code remains a local operation identifier and does not encode a mail
+provider's response.
+
+If a send still fails after updating, report only Manager's sanitized failure
+category, protocol stage, numeric response code, batch-fatal and acceptance
+states, failed-attempt count, and support code.
+
+## Compatibility
+
+No configuration or data migration is required. Existing schedules, recipient
+state, cache data, credentials, and platform update paths remain compatible.

--- a/scripts/ci_classifier.py
+++ b/scripts/ci_classifier.py
@@ -37,6 +37,7 @@ FAST_ONLY_SCRIPTS = {
     "scripts/test-manager-update-indicator.mjs",
     "scripts/validate-branding.ps1",
     "scripts/validate-docs.ps1",
+    "scripts/validate-release-history.ps1",
     "scripts/validate-repository.ps1",
     "scripts/validate-shell.sh",
     "scripts/validate-unraid-template.ps1",

--- a/scripts/test_ci_classifier.py
+++ b/scripts/test_ci_classifier.py
@@ -72,6 +72,9 @@ class ClassifierTests(unittest.TestCase):
     def test_ci_workflow_change_fails_closed_to_every_gate(self):
         self.assert_gates([".github/workflows/ci.yml"], set(GATES))
 
+    def test_release_history_validator_stays_in_the_fast_layer(self):
+        self.assert_gates(["scripts/validate-release-history.ps1"], set())
+
     def test_unknown_executable_input_fails_closed(self):
         self.assert_gates(["tools/new-build-helper.py"], set(GATES) - {"pages"})
 
@@ -164,6 +167,14 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("      - 'v*.*.*'", on_block)
         self.assertIn("Release history, version, and CI provenance", self.release)
         self.assertIn("check_name: 'required'", self.release)
+        self.assertIn(
+            "./scripts/validate-release-history.ps1 -Version $version", self.release
+        )
+        self.assertNotIn(
+            "(Get-Content -LiteralPath $file.FullName -Raw).Trim() -ne $version",
+            self.release,
+        )
+        self.assertIn("./scripts/validate-release-history.ps1", self.ci)
         self.assertEqual(self.release.count("./scripts/build-releases.ps1"), 1)
         self.assertNotIn("./scripts/validate-repository.ps1", self.release)
 

--- a/scripts/validate-release-history.ps1
+++ b/scripts/validate-release-history.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param(
+    [string]$Root = '',
+    [string]$Version = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([string]::IsNullOrWhiteSpace($Root)) { $Root = Split-Path -Parent $PSScriptRoot }
+$Root = [IO.Path]::GetFullPath($Root)
+
+$changelogPath = Join-Path $Root 'CHANGELOG.md'
+$changelog = [IO.File]::ReadAllText($changelogPath)
+$releaseMatches = [regex]::Matches(
+    $changelog,
+    '(?m)^## \[(?<version>\d+\.\d+\.\d+)\] - (?<date>\d{4}-\d{2}-\d{2})\s*$'
+)
+if ($releaseMatches.Count -eq 0) {
+    throw 'CHANGELOG.md has no dated semantic-version release section.'
+}
+
+$latestVersion = $releaseMatches[0].Groups['version'].Value
+$latestDate = $releaseMatches[0].Groups['date'].Value
+if ([string]::IsNullOrWhiteSpace($Version)) { $Version = $latestVersion }
+if ($Version -notmatch '^\d+\.\d+\.\d+$') {
+    throw "Release version must use MAJOR.MINOR.PATCH: $Version"
+}
+if ($Version -ne $latestVersion) {
+    throw "Latest CHANGELOG.md release is $latestVersion, not $Version."
+}
+
+$unreleasedIndex = $changelog.IndexOf('## [Unreleased]', [StringComparison]::Ordinal)
+$releaseIndex = $changelog.IndexOf("## [$Version]", [StringComparison]::Ordinal)
+if ($unreleasedIndex -lt 0 -or $releaseIndex -lt 0 -or $unreleasedIndex -gt $releaseIndex) {
+    throw 'CHANGELOG.md must keep [Unreleased] before the latest dated release.'
+}
+
+$notesRelative = "docs/releases/v$Version.md"
+$notesPath = Join-Path $Root $notesRelative
+if (-not [IO.File]::Exists($notesPath)) {
+    throw "Release notes are missing: $notesRelative"
+}
+$notes = [IO.File]::ReadAllText($notesPath)
+if ($notes -notmatch "(?m)^# TautWeekly for Plex v$([regex]::Escape($Version))\s*$") {
+    throw "$notesRelative does not identify TautWeekly for Plex v$Version."
+}
+$releasedMatch = [regex]::Match($notes, '(?m)^Released:\s*(?<date>\d{4}-\d{2}-\d{2})\s*$')
+if (-not $releasedMatch.Success -or $releasedMatch.Groups['date'].Value -ne $latestDate) {
+    throw "$notesRelative does not use the CHANGELOG.md release date $latestDate."
+}
+
+$versionFiles = @(Get-ChildItem -LiteralPath (Join-Path $Root 'platforms') -Filter VERSION.txt -Recurse)
+if ($versionFiles.Count -eq 0) {
+    throw 'No platform VERSION.txt source-baseline files were found.'
+}
+foreach ($file in $versionFiles) {
+    $firstLine = [IO.File]::ReadLines($file.FullName) | Select-Object -First 1
+    if ([string]::IsNullOrWhiteSpace($firstLine) -or $firstLine -notmatch '\bv\d+\.\d+\.\d+\b') {
+        throw "$($file.FullName) does not identify its independent platform source baseline."
+    }
+}
+
+Write-Host "[PASS] Release history identifies v$Version on $latestDate with matching notes and $($versionFiles.Count) valid platform source baselines."

--- a/scripts/validate-repository.ps1
+++ b/scripts/validate-repository.ps1
@@ -108,6 +108,7 @@ $required = @(
     'scripts/test-recipient-watched-movies.ps1',
     'scripts/test-recipient-watched-visuals.mjs',
     'scripts/test-release-reproducibility.ps1',
+    'scripts/validate-release-history.ps1',
     'scripts/test-windows-installer.ps1',
     'scripts/test-scheduler-timezone.ps1',
     'scripts/test-manager-accessibility.py',


### PR DESCRIPTION
## Summary

- prepare v0.24.1 as the SMTP diagnostics hotfix release with dated changelog history, provider-neutral release notes, and a synchronized stable-version GUI preview
- keep the main Quickstart feature spotlight on v0.23.0
- replace the post-v0.24.0 release preflight's invalid repository-version/platform-baseline equality check with one shared release-history validator used by PR and tag workflows
- require matching latest changelog version/date, release-note identity/date, and valid independent platform source baselines

References #172.

## Validation

- `scripts/validate-release-history.ps1 -Version 0.24.1`
- stale version `0.24.0` is rejected
- `scripts/test_ci_classifier.py` — 20 tests
- `scripts/sync-gui-preview.mjs --check`
- `scripts/validate-docs.ps1`
- `scripts/check-links.ps1`
- `scripts/validate-repository.ps1`
- `scripts/validate-platforms.ps1`
- `scripts/validate-powershell.ps1` — 85 files
- `git diff --check`