### PR TITLE
fix: neutralize Funnel dashboard status color

### DIFF
--- a/docs/gui-preview/app.js
+++ b/docs/gui-preview/app.js
@@ -688,7 +688,7 @@ function renderIntegrationStatus() {
   setText("funnel-state", funnel.label);
   setText("funnel-detail", funnel.detail);
   const funnelValue = byId("funnel-integration-value");
-  funnelValue.className = `integration-value ${funnel.tone}`;
+    funnelValue.className = "integration-value neutral";
   funnelValue.setAttribute("aria-label", `Tailscale Funnel status: ${funnel.label}; ${funnel.detail}`);
   const funnelLink = byId("funnel-settings-link");
   const settingsAvailable = state.tailscale?.supported === true;

--- a/manager/internal/manager/web/app.js
+++ b/manager/internal/manager/web/app.js
@@ -687,7 +687,7 @@ function renderIntegrationStatus() {
   setText("funnel-state", funnel.label);
   setText("funnel-detail", funnel.detail);
   const funnelValue = byId("funnel-integration-value");
-  funnelValue.className = `integration-value ${funnel.tone}`;
+    funnelValue.className = "integration-value neutral";
   funnelValue.setAttribute("aria-label", `Tailscale Funnel status: ${funnel.label}; ${funnel.detail}`);
   const funnelLink = byId("funnel-settings-link");
   const settingsAvailable = state.tailscale?.supported === true;


### PR DESCRIPTION
## Summary
- keep the Dashboard Tailscale Funnel status text visually neutral across all states
- keep the Manager and published GUI preview synchronized

## Validation
- no local checks were run for this two-line presentation-only refinement, per request
- repository-required GitHub checks remain authoritative