### PR TITLE
fix: recover Windows Manager after update stop errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ the structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.25.5] - 2026-09-01
+
+### Fixed
+
+- Prevent a Manager-driven Windows update from leaving the local Dashboard offline when process teardown succeeds but Windows reports a post-stop verification failure. The updater now records relaunch responsibility before termination and recovers either the exact healthy Manager or a new verified instance without changing retained Tailscale Funnel state.
+- Extend the Windows installer lifecycle test with the post-stop failure window that escaped v0.25.4 validation, proving both failure recovery and the subsequent normal update path restore the fixed loopback listener.
+
 ## [0.25.4] - 2026-09-01
 
 ### Changed

--- a/docs/gui-preview/index.html
+++ b/docs/gui-preview/index.html
@@ -94,8 +94,8 @@
     </aside>
 
     <main class="content" id="main-content" tabindex="-1">
-      <aside class="demo-banner" role="note" aria-label="GUI preview boundary" data-preview-release="v0.25.4">
-        <strong>Interactive GUI Preview · v0.25.4</strong>
+      <aside class="demo-banner" role="note" aria-label="GUI preview boundary" data-preview-release="v0.25.5">
+        <strong>Interactive GUI Preview · v0.25.5</strong>
         <span>Fictional data · temporary in-memory changes. Do not enter real credentials.</span>
         <span>No services, email, files, credentials, or schedulers are contacted</span>
         <label>Package example <select id="demo-profile"><option value="windows">Windows</option><option value="nas">NAS / Docker</option><option value="mac">macOS Docker</option><option value="linux">Native Linux</option><option value="freebsd">FreeBSD / Podman</option></select></label>
@@ -343,7 +343,7 @@
             <a class="update-docs-link" id="update-docs-link" href="../" target="_blank" rel="noopener noreferrer">Open platform update guide</a>
           </div>
           <label class="update-install-confirm" id="update-install-confirm-row" for="update-install-confirm" hidden><input id="update-install-confirm" type="checkbox"><span><strong>Install the verified stable Windows update</strong><small>Windows will request administrator approval. The existing updater verifies release URLs, archive checksums, internal manifests, rollback, and post-update health.</small></span></label>
-          <div class="update-settings-actions"><button class="button button-secondary" id="update-check-button" type="button">Check now</button><button class="button button-primary" id="update-install-button" type="button" hidden disabled>Install update</button><a id="update-release-notes" href="../releases/v0.25.4.md" target="_blank" rel="noopener noreferrer" hidden>Read stable release notes</a></div>
+          <div class="update-settings-actions"><button class="button button-secondary" id="update-check-button" type="button">Check now</button><button class="button button-primary" id="update-install-button" type="button" hidden disabled>Install update</button><a id="update-release-notes" href="../releases/v0.25.5.md" target="_blank" rel="noopener noreferrer" hidden>Read stable release notes</a></div>
           <p class="verification-message" id="update-settings-message" role="status" aria-live="polite">Normal Manager and dashboard health never depend on Internet availability.</p>
           <p class="update-security-boundary"><strong>The Manager never gains host control.</strong> Container profiles do not mount the Docker socket, add a privileged helper, run the web process as root, or mutate the host. Use the reported full-semver reference or its manifest digest; minor, latest, and edge tags are mutable. Native Unix packages keep installation in their existing host wrappers.</p>
         </section>

--- a/docs/gui-preview/mock-api.js
+++ b/docs/gui-preview/mock-api.js
@@ -2,8 +2,8 @@
 
 (() => {
   const now = () => new Date().toISOString();
-  const DEMO_VERSION = "0.25.4";
-  const PREVIOUS_VERSION = "0.25.3";
+  const DEMO_VERSION = "0.25.5";
+  const PREVIOUS_VERSION = "0.25.4";
   const PROFILES = {
     windows: { runtimeMode: "windows", runtimeProfile: "native-windows", packageKind: "windows-installer", label: "Windows" },
     nas: { runtimeMode: "nas", runtimeProfile: "server", packageKind: "container-compose", label: "NAS / Docker" },

--- a/docs/releases/v0.25.5.md
+++ b/docs/releases/v0.25.5.md
@@ -1,0 +1,31 @@
+# TautWeekly for Plex v0.25.5
+
+Released: 2026-09-01
+
+## Windows Manager update recovery
+
+This corrective release closes a Windows updater failure window introduced in
+v0.25.4. The update helper could terminate the exact installed Manager and then
+receive a late process-verification error before assigning its internal
+“Manager was running” result. Its rollback path consequently believed there
+was no Manager to restore, leaving the browser on the reconnect screen with
+the fixed loopback address refusing connections.
+
+The updater now records relaunch responsibility before it begins termination.
+If any later stop or pre-mutation step fails, recovery first accepts an exact
+installed Manager that is already healthy; otherwise it launches and verifies
+the packaged Manager on `127.0.0.1:8788`. This also avoids creating a duplicate
+when Windows reports a stop error while the original process is still healthy.
+
+## Funnel and package scope
+
+The v0.25.4 Tailscale Funnel retention behavior is unchanged. Update-internal
+restart still preserves the retained preference, verified hostname,
+publication proof, and fixed route; explicit stop, access reset, recovery,
+uninstall, and user-requested shutdown continue to turn the owned Funnel off
+deliberately.
+
+The v0.25.4 shared Manager UI corrections remain present in every maintained
+package. This patch changes only the native Windows updater lifecycle and its
+focused installer regression coverage. The v0.25.0 Quickstart spotlight stays
+current because v0.25.5 is a maintenance release.

--- a/platforms/windows/Windows-Update.ps1
+++ b/platforms/windows/Windows-Update.ps1
@@ -16,6 +16,8 @@ param(
 
     [switch]$SimulatePostInstallFailure,
 
+    [switch]$SimulateManagerStopFailure,
+
     [switch]$InstallerTestMode
 )
 
@@ -297,8 +299,10 @@ function Get-InstalledManagerProcesses {
 }
 
 function Stop-InstalledManager {
-    $managerProcesses = @(Get-InstalledManagerProcesses)
-    if ($managerProcesses.Count -eq 0) { return $false }
+    param([Parameter(Mandatory = $true)][Collections.IEnumerable]$ManagerProcesses)
+
+    $managerProcesses = @($ManagerProcesses)
+    if ($managerProcesses.Count -eq 0) { return }
     # The ordinary shutdown command deliberately disables and verifies Funnel.
     # An update-internal restart must preserve the retained preference and fixed route.
     foreach ($managerProcess in $managerProcesses) {
@@ -314,7 +318,9 @@ function Stop-InstalledManager {
     if (@(Get-InstalledManagerProcesses).Count -ne 0) {
         throw 'The exact packaged Manager process is still running after the update stop.'
     }
-    return $true
+    if ($SimulateManagerStopFailure) {
+        throw 'Simulated post-stop failure for Manager recovery validation.'
+    }
 }
 
 function Resolve-ManagerDataRoot {
@@ -379,6 +385,24 @@ function Start-InstalledManager {
     throw 'The packaged Manager did not become ready after the update.'
 }
 
+function Ensure-InstalledManagerRunning {
+    $deadline = (Get-Date).AddSeconds(10)
+    do {
+        $managerProcesses = @(Get-InstalledManagerProcesses)
+        if ($managerProcesses.Count -eq 0) { break }
+        $healthyOwners = @(Get-HealthyManagerListenerProcessIds)
+        if (@($managerProcesses | Where-Object { $healthyOwners -contains $_.Id }).Count -gt 0) {
+            return
+        }
+        Start-Sleep -Milliseconds 200
+    } while ((Get-Date) -lt $deadline)
+
+    if (@(Get-InstalledManagerProcesses).Count -ne 0) {
+        throw 'The exact packaged Manager process is still running but did not become healthy during update recovery.'
+    }
+    Start-InstalledManager
+}
+
 function Remove-OwnedFiles {
     param(
         [Parameter(Mandatory = $true)][Collections.IEnumerable]$RelativePaths,
@@ -431,6 +455,9 @@ if ($InstallerTestMode) {
         throw 'Installer test mode is restricted to an isolated TautWeekly installer test directory.'
     }
 }
+elseif ($SimulateManagerStopFailure) {
+    throw 'Manager stop-failure simulation is available only in isolated installer test mode.'
+}
 
 $candidateManifest = Read-ReleaseManifest -Root $CandidateRoot
 $requiredFiles = @(
@@ -464,7 +491,13 @@ $managerRestarted = $false
 try {
     $operationLock = Enter-TautWeeklyOperationLock -Root $InstallRoot -Purpose "update to $TargetVersion"
 
-    $managerWasRunning = Stop-InstalledManager
+    # Capture this before termination. If Windows reports a post-stop error,
+    # recovery must still know that it owns the responsibility to relaunch.
+    $managerProcesses = @(Get-InstalledManagerProcesses)
+    $managerWasRunning = $managerProcesses.Count -gt 0
+    if ($managerWasRunning) {
+        Stop-InstalledManager -ManagerProcesses $managerProcesses
+    }
 
     $task = if ($InstallerTestMode) { $null } else { Get-ScheduledNewsletterTask }
     if ($null -ne $task) {
@@ -568,7 +601,7 @@ catch {
 
     if ($managerWasRunning -and -not $managerRestarted) {
         try {
-            Start-InstalledManager
+            Ensure-InstalledManagerRunning
             $managerRestarted = $true
         }
         catch {

--- a/scripts/test-update-checks.ps1
+++ b/scripts/test-update-checks.ps1
@@ -79,6 +79,8 @@ try {
     Assert-True ($updaterSource -match '\$dataRoot = Resolve-ManagerDataRoot') 'Windows updater automatic relaunch does not use the resolved Manager private-data directory.'
     Assert-True ($updaterSource -notmatch '&\s+\$managerPath\s+shutdown') 'Windows updater invokes the user-lifecycle shutdown path, which disables retained Funnel publication.'
     Assert-True ($updaterSource -match 'Stop-Process -Id \$managerProcess\.Id -Force') 'Windows updater does not stop only the exact installed Manager process for its internal restart.'
+    Assert-True ($updaterSource -match '(?s)\$managerProcesses\s*=\s*@\(Get-InstalledManagerProcesses\).*?\$managerWasRunning\s*=\s*\$managerProcesses\.Count\s+-gt\s+0.*?Stop-InstalledManager -ManagerProcesses \$managerProcesses') 'Windows updater does not record restart ownership before stopping the Manager.'
+    Assert-True ($updaterSource -match 'function Ensure-InstalledManagerRunning') 'Windows updater cannot recover a healthy or stopped Manager after a post-stop failure.'
     foreach ($privateName in @('last-run.json', 'scheduler-heartbeat.json', 'service-heartbeat.json', 'config.backup.*.json')) {
         Assert-True ($updaterSource.Contains($privateName)) "Windows updater private-path guard is missing $privateName."
     }

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -236,6 +236,50 @@ try {
         } while (-not $restartHealthy -and (Get-Date) -lt $restartDeadline)
         Assert-True $restartHealthy 'Upgraded Manager was not healthy before automatic update recovery.'
 
+        # Reproduce the v0.25.4 stranding window: the exact Manager has exited,
+        # but post-stop verification fails before package mutation begins. The
+        # updater must remember that it owns relaunch responsibility.
+        $stopFailureResultPath = Join-Path $dataRoot 'post-stop-recovery-result.json'
+        $stopFailureArguments = @{
+            InstallRoot = $installRoot
+            CandidateRoot = $relaunchCandidateRoot
+            TargetVersion = $candidateVersion
+            ResultPath = $stopFailureResultPath
+            InstallerTestMode = $true
+            SimulateManagerStopFailure = $true
+        }
+        $stopFailureObserved = $false
+        try {
+            & (Join-Path $relaunchCandidateRoot 'Windows-Update.ps1') @stopFailureArguments
+        }
+        catch {
+            $stopFailureObserved = $_.Exception.Message -match 'Simulated post-stop failure'
+        }
+        Assert-True $stopFailureObserved 'Post-stop recovery fixture did not report the simulated updater failure.'
+        Assert-True ($runningManager.WaitForExit(20000)) 'Post-stop recovery fixture did not stop the original Manager process.'
+        $stopFailureResult = Get-Content -LiteralPath $stopFailureResultPath -Raw | ConvertFrom-Json
+        Assert-True ([string]$stopFailureResult.Status -eq 'failed') 'Post-stop recovery fixture did not retain the expected failed update result.'
+
+        $restartDeadline = (Get-Date).AddSeconds(10)
+        $restartHealthy = $false
+        $stopRecoveryOwners = @()
+        do {
+            Start-Sleep -Milliseconds 200
+            try {
+                $restartHealthy = [string](Invoke-RestMethod -UseBasicParsing -Uri 'http://127.0.0.1:8788/health/live' -TimeoutSec 2).status -eq 'alive'
+                if ($restartHealthy) {
+                    $stopRecoveryOwners = @(Get-NetTCPConnection -State Listen -LocalPort 8788 -ErrorAction Stop |
+                        Where-Object { [string]$_.LocalAddress -in @('127.0.0.1', '::1') } |
+                        Select-Object -ExpandProperty OwningProcess -Unique)
+                }
+            }
+            catch { }
+        } while ((-not $restartHealthy -or $stopRecoveryOwners.Count -ne 1) -and (Get-Date) -lt $restartDeadline)
+        Assert-True ($restartHealthy -and $stopRecoveryOwners.Count -eq 1) 'Post-stop updater failure stranded the Manager listener.'
+        Assert-True ([int]$stopRecoveryOwners[0] -ne $runningManager.Id) 'Post-stop updater failure did not replace the terminated Manager process.'
+        $runningManager.Dispose()
+        $runningManager = Get-Process -Id ([int]$stopRecoveryOwners[0]) -ErrorAction Stop
+
         # Match the in-Manager update path: the staged helper receives no
         # ManagerDataRoot and must recover the recorded private directory.
         $updateArguments = @{

--- a/scripts/validate-platforms.ps1
+++ b/scripts/validate-platforms.ps1
@@ -789,6 +789,8 @@ Require-Text 'platforms/windows/Windows-Update.ps1' @(
     'Assert-PowerShellSyntax',
     'Get-InstalledManagerProcesses',
     'Start-InstalledManager',
+    'Ensure-InstalledManagerRunning',
+    '\$managerWasRunning\s*=\s*\$managerProcesses\.Count\s+-gt\s+0',
     'Resolve-ManagerDataRoot',
     'INSTALL-METADATA\.txt',
     'Get-HealthyManagerListenerProcessIds',


### PR DESCRIPTION
## Summary
- record Windows Manager relaunch responsibility before process termination
- recover an already-healthy exact Manager or start and verify the packaged replacement after a stop/pre-mutation failure
- add the v0.25.4 post-stop stranding regression to the Windows installer lifecycle test
- prepare corrective release v0.25.5 without changing Funnel retention or shared Manager UI behavior

## Focused validation
- Windows PowerShell: scripts/test-update-checks.ps1
- Windows PowerShell: scripts/validate-platforms.ps1
- Node: scripts/test-gui-preview-personal-stats.mjs
- PowerShell 7: scripts/validate-docs.ps1
- PowerShell 7: scripts/check-links.ps1

The complete package/installer lifecycle test is left to the mandatory classified PR gate so the release candidate is built and exercised once.