### PR TITLE
fix: harden Windows update release gate

### DIFF
--- a/platforms/windows/Windows-Update.ps1
+++ b/platforms/windows/Windows-Update.ps1
@@ -315,7 +315,18 @@ function Stop-InstalledManager {
             throw 'The exact packaged Manager process did not stop for the update.'
         }
     }
-    if (@(Get-InstalledManagerProcesses).Count -ne 0) {
+    # A terminated executable can remain visible to a fresh Get-Process query
+    # briefly after its original process object reports exit. Give Windows a
+    # bounded interval to retire that record before treating it as a live
+    # same-install Manager. A replacement process still fails closed below.
+    $remainingManagerProcesses = @()
+    $processRetirementDeadline = (Get-Date).AddSeconds(5)
+    do {
+        $remainingManagerProcesses = @(Get-InstalledManagerProcesses)
+        if ($remainingManagerProcesses.Count -eq 0) { break }
+        Start-Sleep -Milliseconds 100
+    } while ((Get-Date) -lt $processRetirementDeadline)
+    if ($remainingManagerProcesses.Count -ne 0) {
         throw 'The exact packaged Manager process is still running after the update stop.'
     }
     if ($SimulateManagerStopFailure) {
@@ -358,8 +369,13 @@ function Start-InstalledManager {
     if (-not (Test-Path -LiteralPath $managerPath -PathType Leaf)) {
         throw 'The packaged Manager executable is unavailable after the update.'
     }
-    $reportedVersion = @(& $managerPath version 2>$null | Select-Object -First 1)
-    if ($LASTEXITCODE -ne 0 -or $reportedVersion.Count -ne 1 -or [string]$reportedVersion[0] -ne "TautWeekly Manager $TargetVersion") {
+    # Capture the native exit code before using a PowerShell pipeline. When the
+    # executable is the first native command in a strict-mode session, piping it
+    # directly to Select-Object can leave LASTEXITCODE undefined.
+    $reportedVersion = @(& $managerPath version 2>$null)
+    $managerVersionExitCode = $LASTEXITCODE
+    $reportedVersion = @($reportedVersion | Select-Object -First 1)
+    if ($managerVersionExitCode -ne 0 -or $reportedVersion.Count -ne 1 -or [string]$reportedVersion[0] -ne "TautWeekly Manager $TargetVersion") {
         throw 'The packaged Manager executable does not report the requested update version.'
     }
     $dataRoot = Resolve-ManagerDataRoot

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -249,13 +249,15 @@ try {
             SimulateManagerStopFailure = $true
         }
         $stopFailureObserved = $false
+        $stopFailureMessage = ''
         try {
             & (Join-Path $relaunchCandidateRoot 'Windows-Update.ps1') @stopFailureArguments
         }
         catch {
-            $stopFailureObserved = $_.Exception.Message -match 'Simulated post-stop failure'
+            $stopFailureMessage = [string]$_.Exception.Message
+            $stopFailureObserved = $stopFailureMessage -match 'Simulated post-stop failure'
         }
-        Assert-True $stopFailureObserved 'Post-stop recovery fixture did not report the simulated updater failure.'
+        Assert-True $stopFailureObserved "Post-stop recovery fixture did not report the simulated updater failure. Actual error: $stopFailureMessage"
         Assert-True ($runningManager.WaitForExit(20000)) 'Post-stop recovery fixture did not stop the original Manager process.'
         $stopFailureResult = Get-Content -LiteralPath $stopFailureResultPath -Raw | ConvertFrom-Json
         Assert-True ([string]$stopFailureResult.Status -eq 'failed') 'Post-stop recovery fixture did not retain the expected failed update result.'
@@ -275,7 +277,7 @@ try {
             }
             catch { }
         } while ((-not $restartHealthy -or $stopRecoveryOwners.Count -ne 1) -and (Get-Date) -lt $restartDeadline)
-        Assert-True ($restartHealthy -and $stopRecoveryOwners.Count -eq 1) 'Post-stop updater failure stranded the Manager listener.'
+        Assert-True ($restartHealthy -and $stopRecoveryOwners.Count -eq 1) "Post-stop updater failure stranded the Manager listener. Updater result: $([string]$stopFailureResult.Message)"
         Assert-True ([int]$stopRecoveryOwners[0] -ne $runningManager.Id) 'Post-stop updater failure did not replace the terminated Manager process.'
         $runningManager.Dispose()
         $runningManager = Get-Process -Id ([int]$stopRecoveryOwners[0]) -ErrorAction Stop
@@ -347,6 +349,25 @@ try {
                 finally {
                     $processToStop.Dispose()
                 }
+            }
+        }
+        # The synthetic retained-Funnel shutdown intentionally leaves its
+        # privileged helper waiting for a callback after the Manager is forced
+        # down. Stop only helpers launched from this isolated test installation
+        # so they cannot hold the disposable program directory open.
+        $isolatedHelperPath = [IO.Path]::GetFullPath((Join-Path $installRoot 'TAILSCALE-HELPER.ps1'))
+        $isolatedHelpers = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+            [string]$_.CommandLine -and [string]$_.CommandLine.IndexOf($isolatedHelperPath, [StringComparison]::OrdinalIgnoreCase) -ge 0
+        })
+        foreach ($isolatedHelper in $isolatedHelpers) {
+            $helperProcess = Get-Process -Id ([int]$isolatedHelper.ProcessId) -ErrorAction SilentlyContinue
+            if ($null -eq $helperProcess) { continue }
+            try {
+                Stop-Process -Id $helperProcess.Id -Force -ErrorAction SilentlyContinue
+                [void]$helperProcess.WaitForExit(10000)
+            }
+            finally {
+                $helperProcess.Dispose()
             }
         }
     }
@@ -429,7 +450,14 @@ finally {
     if (Test-Path -LiteralPath $testRoot) {
         $resolved = [IO.Path]::GetFullPath($testRoot)
         if ($resolved.StartsWith($tempParent, [StringComparison]::OrdinalIgnoreCase) -and (Split-Path -Leaf $resolved).StartsWith('tautweekly-installer-test-', [StringComparison]::Ordinal)) {
-            Remove-Item -LiteralPath $resolved -Recurse -Force -ErrorAction SilentlyContinue
+            try {
+                Remove-Item -LiteralPath $resolved -Recurse -Force -ErrorAction Stop
+            }
+            catch {
+                if (Test-Path -LiteralPath $resolved) {
+                    Write-Warning "Could not completely remove installer test workspace '$resolved': $($_.Exception.Message)"
+                }
+            }
         }
     }
 }

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -351,25 +351,6 @@ try {
                 }
             }
         }
-        # The synthetic retained-Funnel shutdown intentionally leaves its
-        # privileged helper waiting for a callback after the Manager is forced
-        # down. Stop only helpers launched from this isolated test installation
-        # so they cannot hold the disposable program directory open.
-        $isolatedHelperPath = [IO.Path]::GetFullPath((Join-Path $installRoot 'TAILSCALE-HELPER.ps1'))
-        $isolatedHelpers = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-            [string]$_.CommandLine -and [string]$_.CommandLine.IndexOf($isolatedHelperPath, [StringComparison]::OrdinalIgnoreCase) -ge 0
-        })
-        foreach ($isolatedHelper in $isolatedHelpers) {
-            $helperProcess = Get-Process -Id ([int]$isolatedHelper.ProcessId) -ErrorAction SilentlyContinue
-            if ($null -eq $helperProcess) { continue }
-            try {
-                Stop-Process -Id $helperProcess.Id -Force -ErrorAction SilentlyContinue
-                [void]$helperProcess.WaitForExit(10000)
-            }
-            finally {
-                $helperProcess.Dispose()
-            }
-        }
     }
     # Explicit uninstall remains fail-closed. Return the synthetic state to Off
     # before that separate lifecycle test so no host Tailscale client is used.


### PR DESCRIPTION
## Summary
- wait briefly for Windows to retire the exact packaged Manager process record before treating it as still live
- capture the Manager version command exit code before entering a PowerShell pipeline under strict mode
- make the installer lifecycle fixture report recovery errors and clean up only its isolated helper process/workspace

## Validation
- Windows installer/update lifecycle passed twice cleanly
- updater checks, platform contracts, and all 85 PowerShell files passed
- v0.26.0 release payload contracts and checksums passed
- repeated v0.26.0 builds were byte-identical

## Release context
This is the immediate release-gate fix for the unpublished v0.26.0 attempt. The first run and its failed-job retry exposed separate Windows process-retirement and cleanup races: https://github.com/sparkmoxie/TautWeekly/actions/runs/34383337495

The user-email override feature remains tracked by #183; this PR does not close that issue.